### PR TITLE
Docker compilation + ARM64 configuration for premake5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 # Personal Config File
 config.lua
 
+# CLion and other JetBrains tools
+/.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:22.04 AS build
+
+RUN apt update
+
+# install premake5
+RUN apt install -y unzip make g++ uuid-dev wget && \
+    mkdir /bts && \
+    cd /bts/ && wget https://github.com/premake/premake-core/archive/refs/heads/master.zip && \
+    cd /bts/ && unzip master.zip && rm master.zip && \
+    cd /bts/premake-core-master && make -f Bootstrap.mak linux && \
+    mv /bts/premake-core-master/bin/release/premake5 /bin/premake5 && \
+    rm -rf /bts/premake-core-master/bin/release/premake5
+
+# install vcpkg
+RUN apt install -y curl zip unzip tar git && \
+    cd /bts && git clone https://github.com/microsoft/vcpkg.git && \
+    /bts/vcpkg/bootstrap-vcpkg.sh
+
+COPY src /usr/src/bts/src/
+COPY premake5.lua vcpkg.json /usr/src/bts/
+
+WORKDIR /usr/src/bts
+
+# install C++ libraries from vcpkg
+RUN apt install -y pkg-config
+RUN cd /usr/src/bts && /bts/vcpkg/vcpkg install
+
+# compile project
+RUN premake5 gmake2 && make -j $(nproc) config=debug_64
+
+FROM ubuntu:22.04
+
+COPY --from=build /usr/src/bts/Black-Tek-Server /bin/bts
+COPY data /srv/data/
+COPY LICENSE README.md *.dist *.sql key.pem /srv/
+
+EXPOSE 7171 7172
+WORKDIR /srv
+VOLUME /srv
+ENTRYPOINT ["/bin/bts"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3.7"
+
+services:
+  server:
+    build:
+      context: .
+    restart: always
+    volumes:
+      - .:/srv
+    ports:
+      - "7171:7171"
+      - "7172:7172"

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,6 +1,6 @@
 workspace "Black-Tek-Server"
    configurations { "Debug", "Release"}
-   platforms { "64" }
+   platforms { "64", "ARM64" }
    location ""
    editorintegration "On"
 
@@ -13,9 +13,7 @@ workspace "Black-Tek-Server"
       location    ""
       files { "src/**.cpp", "src/**.h" }
       flags {"LinkTimeOptimization", "MultiProcessorCompile"}
-      vectorextensions "AVX"
       enableunitybuild "On"
-      architecture "amd64"
       intrinsics   "On"
 
       filter "configurations:Debug"
@@ -29,6 +27,12 @@ workspace "Black-Tek-Server"
          symbols "On"
          optimize "Speed"
       filter {}
+	  
+      filter "platforms:64"
+         architecture "x86_64"
+
+      filter "platforms:ARM64"
+         architecture "ARM64"
 
       filter "system:not windows"
          buildoptions { "-Wall", "-Wextra", "-pedantic", "-pipe", "-fvisibility=hidden", "-Wno-unused-local-typedefs" }
@@ -43,7 +47,18 @@ workspace "Black-Tek-Server"
          vsprops { VcpkgEnableManifest = "true" }
       filter {}
 
-      filter "system:Unix"
+      filter "architecture:amd64"
+	     vectorextensions "AVX"
+      filter{}
+
+      filter { "system:linux", "architecture:ARM64" }
+         -- Paths to vcpkg installed dependencies
+         libdirs { "vcpkg_installed/arm64-linux/lib" }
+         includedirs { "vcpkg_installed/arm64-linux/include" }
+         links { "pugixml", "lua", "fmt", "ssl", "mariadb", "cryptopp", "crypto", "boost_iostreams", "zstd", "z" }
+      filter{}
+
+      filter { "system:linux", "architecture:amd64" }
          -- Paths to vcpkg installed dependencies
          libdirs { "vcpkg_installed/x64-linux/lib" }
          includedirs { "vcpkg_installed/x64-linux/include" }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -32,7 +32,7 @@
     }
   },
   "default-features": [
-    "lua" /// Can change here your preference for lua support.
+    "lua"
   ],
   "builtin-baseline": "215a2535590f1f63788ac9bd2ed58ad15e6afdff"
 }


### PR DESCRIPTION
`Dockerfile` to run server inside container + ARM64 configuration for premake5.

`docker-compose.yaml` is configured to work with MySQL hosted outside container (ex. XAMPP on Windows) and server running inside Docker container. More information about that configuration: https://otland.net/threads/linux-running-on-windows.274039/#post-2697015

**ARM64 vcpkg problems**
1. To run on ARM64 you will have to install `cmake` and `ninja-build` before VCPKG (`apt install -y cmake ninja-build`).
2. Before running `bootstrap-vcpkg.sh` you must type:
```
export VCPKG_FORCE_SYSTEM_BINARIES=1
```
to make it use `cmake` installed by system.

**ARM64 Black Tek Server compilation**
I could not find any premake5 example of auto-detection of CPU architecture. It looks like you have to specify it manually.
Instead of `make` or `make config=release_64` [no config = `64`; `64` = `x86_64` -> `AMD64`]  you have to run:
```
make config=debug_arm64
```
or:
```
make config=release_arm64
```