### PR TITLE
Added discord webhook functionality, accessible from LUA script

### DIFF
--- a/data/scripts/discord.lua
+++ b/data/scripts/discord.lua
@@ -1,0 +1,18 @@
+local LoginEvent = CreatureEvent("DiscordHook")
+
+--Discord webhook enums
+--MESSAGE_NORMAL
+--MESSAGE_ERROR;
+--MESSAGE_LOG;
+--MESSAGE_INFO;
+
+local webhookLink = "https://discord.com/api/webhooks/1268439526154567752/mvJ3BYooIUA5laVKdX4KNWxYSat5Cx5RpccCAonSYJY_tsXthe_GY9mK8sAsQL0QxZL9"
+
+function LoginEvent.onLogin(player)
+  Game.queueDiscordMessage(webhookLink, MESSAGE_INFO, "Player: " .. player:getName() .. " has logged in")
+  Game.sendDiscordWebhook()
+  return true
+end
+
+LoginEvent:type("login")
+LoginEvent:register()

--- a/premake5.lua
+++ b/premake5.lua
@@ -55,14 +55,14 @@ workspace "Black-Tek-Server"
          -- Paths to vcpkg installed dependencies
          libdirs { "vcpkg_installed/arm64-linux/lib" }
          includedirs { "vcpkg_installed/arm64-linux/include" }
-         links { "pugixml", "lua", "fmt", "ssl", "mariadb", "cryptopp", "crypto", "boost_iostreams", "zstd", "z" }
+         links { "pugixml", "lua", "fmt", "ssl", "mariadb", "cryptopp", "crypto", "boost_iostreams", "zstd", "z", "libcurl" }
       filter{}
 
       filter { "system:linux", "architecture:amd64" }
          -- Paths to vcpkg installed dependencies
          libdirs { "vcpkg_installed/x64-linux/lib" }
          includedirs { "vcpkg_installed/x64-linux/include" }
-         links { "pugixml", "lua", "fmt", "ssl", "mariadb", "cryptopp", "crypto", "boost_iostreams", "zstd", "z" }
+         links { "pugixml", "lua", "fmt", "ssl", "mariadb", "cryptopp", "crypto", "boost_iostreams", "zstd", "z", "libcurl" }
       filter{}
 
       filter "toolset:gcc"

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -54,10 +54,14 @@ Game::Game()
 	offlineTrainingWindow.buttons.emplace_back("Okay", offlineTrainingWindow.defaultEnterButton);
 	offlineTrainingWindow.buttons.emplace_back("Cancel", offlineTrainingWindow.defaultEscapeButton);
 	offlineTrainingWindow.priority = true;
+
+	curl_global_init(CURL_GLOBAL_ALL);
 }
 
 Game::~Game()
 {
+	curl_global_cleanup();
+
 	for (const auto& it : guilds) {
 		delete it.second;
 	}

--- a/src/game.h
+++ b/src/game.h
@@ -4,6 +4,8 @@
 #ifndef FS_GAME_H
 #define FS_GAME_H
 
+#include <curl/curl.h>
+
 #include "account.h"
 #include "combat.h"
 #include "groups.h"
@@ -45,6 +47,19 @@ enum GameState_t {
 	GAME_STATE_SHUTDOWN,
 	GAME_STATE_CLOSING,
 	GAME_STATE_MAINTAIN,
+};
+
+enum DiscordMessageType {
+	MESSAGE_NORMAL = 0,
+	MESSAGE_ERROR,
+	MESSAGE_LOG,
+	MESSAGE_INFO
+};
+
+struct DiscordHandle {
+	std::string token;
+	std::string field;
+	struct curl_slist* headers;
 };
 
 static constexpr int32_t PLAYER_NAME_LENGTH = 25;
@@ -528,6 +543,8 @@ class Game
 		void clearTilesToClean() {
 			tilesToClean.clear();
 		}
+
+		std::vector<DiscordHandle> discordHandles;
 
 	private:
 		bool playerSaySpell(Player* player, SpeakClasses type, const std::string& text);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -4980,8 +4980,7 @@ int LuaScriptInterface::luaGameSendDiscordWebhook(lua_State* L)
 	if (g_game.discordHandles.size() == 0)
 		return 1;
 	std::thread t{ [&] {
-		for (auto data : g_game.discordHandles)
-		{
+		for (auto data : g_game.discordHandles) {
 			CURL* curl = curl_easy_init();
 			curl_easy_setopt(curl, CURLOPT_URL, data.token.data());
 			curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data.field.data());
@@ -4990,13 +4989,13 @@ int LuaScriptInterface::luaGameSendDiscordWebhook(lua_State* L)
 			auto response = curl_easy_perform(curl);
 
 			if (response != CURLE_OK)
-				std::cout << "Curl failed" << curl_easy_strerror(response) << std::endl;
+				std::cout << "Curl failed - reason: " << curl_easy_strerror(response) << std::endl;
 
 			curl_easy_cleanup(curl);
 		}
 
 		g_game.discordHandles.clear();
-	} };
+	}};
 
 	t.detach();
 
@@ -5024,8 +5023,7 @@ int LuaScriptInterface::luaGameQueueDiscordMessages(lua_State* L)
 		struct curl_slist* headers = nullptr;
 		headers = curl_slist_append(headers, "Content-Type: application/json");
 
-		switch (messageType)
-		{
+		switch (messageType) {
 		case DiscordMessageType::MESSAGE_NORMAL:
 			field = R"({
 				"content": null,

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -596,6 +596,9 @@ class LuaScriptInterface
 		static int luaGameSetAccountStorageValue(lua_State* L);
 		static int luaGameSaveAccountStorageValues(lua_State* L);
 
+		static int luaGameQueueDiscordMessages(lua_State* L);
+		static int luaGameSendDiscordWebhook(lua_State* L);
+
 		// Variant
 		static int luaVariantCreate(lua_State* L);
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,7 +15,8 @@
     "libmariadb",
     "cryptopp",
     "pugixml",
-    "zlib"
+    "zlib",
+    "curl"
   ],
   "features": {
     "lua": {


### PR DESCRIPTION
Working discord webhook callable from LUA scripts

- Functions added
`Game.queueDiscordMessage(token, message_type, message)`
`Game.sendDiscordWebhook()`

Review necessary as code might be unreadable and outright unusable.