### PR TITLE
Spell Groups: Adapt revscript loading to spell groups

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -150,6 +150,8 @@ enum SpellGroup_t : uint8_t {
 	SPELLGROUP_HEALING = 2,
 	SPELLGROUP_SUPPORT = 3,
 	SPELLGROUP_SPECIAL = 4,
+
+	SPELLGROUP_UNKNOWN = 255, // last, unspecified
 };
 
 enum SpellType_t : uint8_t {

--- a/src/enums.h
+++ b/src/enums.h
@@ -151,7 +151,7 @@ enum SpellGroup_t : uint8_t {
 	SPELLGROUP_SUPPORT = 3,
 	SPELLGROUP_SPECIAL = 4,
 
-	SPELLGROUP_UNKNOWN = 255, // last, unspecified
+	SPELLGROUP_UNKNOWN = 255 // when no group set in revscript
 };
 
 enum SpellType_t : uint8_t {

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -16671,7 +16671,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 				pushBoolean(L, true);
 			} else if (isString(L, 2)) {
 				group = stringToSpellGroup(getString(L, 2));
-				if (group != SPELLGROUP_NONE) {
+				if (group != SPELLGROUP_UNKNOWN) {
 					spell->setGroup(group);
 				} else {
 					std::cout << "[Warning - Spell::group] Unknown group: " << getString(L, 2) << std::endl;
@@ -16693,7 +16693,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 				pushBoolean(L, true);
 			} else if (isString(L, 2) && isString(L, 3)) {
 				primaryGroup = stringToSpellGroup(getString(L, 2));
-				if (primaryGroup != SPELLGROUP_NONE) {
+				if (primaryGroup != SPELLGROUP_UNKNOWN) {
 					spell->setGroup(primaryGroup);
 				} else {
 					std::cout << "[Warning - Spell::group] Unknown primaryGroup: " << getString(L, 2) << std::endl;
@@ -16701,7 +16701,7 @@ int LuaScriptInterface::luaSpellGroup(lua_State* L)
 					return 1;
 				}
 				secondaryGroup = stringToSpellGroup(getString(L, 3));
-				if (secondaryGroup != SPELLGROUP_NONE) {
+				if (secondaryGroup != SPELLGROUP_UNKNOWN) {
 					spell->setSecondaryGroup(secondaryGroup);
 				} else {
 					std::cout << "[Warning - Spell::group] Unknown secondaryGroup: " << getString(L, 3) << std::endl;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -762,24 +762,29 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 	return true;
 }
 
+void Spell::addCooldowns(Player* player) const
+{
+	if (cooldown > 0) {
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN, cooldown, 0, false, spellId);
+		player->addCondition(condition);
+	}
+
+	if (group != SPELLGROUP_NONE && groupCooldown > 0) {
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
+		player->addCondition(condition);
+	}
+
+	if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
+		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, secondaryGroupCooldown, 0, false, secondaryGroup);
+		player->addCondition(condition);
+	}
+}
+
 void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool payCost /*= true*/) const
 {
 	if (finishedCast) {
 		if (!player->hasFlag(PlayerFlag_HasNoExhaustion)) {
-			if (cooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN, cooldown, 0, false, spellId);
-				player->addCondition(condition);
-			}
-
-			if (group != SPELLGROUP_NONE && groupCooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
-				player->addCondition(condition);
-			}
-
-			if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
-				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, secondaryGroupCooldown, 0, false, secondaryGroup);
-				player->addCondition(condition);
-			}
+			addCooldowns(player);
 		}
 
 		if (aggressive) {
@@ -879,20 +884,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 			target = playerTarget;
 			if (!target || target->isRemoved() || target->isDead()) {
 				if (!casterTargetOrDirection) {
-					if (cooldown > 0) {
-						Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN, cooldown, 0, false, spellId);
-						player->addCondition(condition);
-					}
-
-					if (group != SPELLGROUP_NONE && groupCooldown > 0) {
-						Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
-						player->addCondition(condition);
-					}
-
-					if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
-						Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, secondaryGroupCooldown, 0, false, secondaryGroup);
-						player->addCondition(condition);
-					}
+					addCooldowns(player);
 
 					player->sendCancelMessage(ret);
 					g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -939,20 +931,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 			ReturnValue ret = g_game.getPlayerByNameWildcard(param, playerTarget);
 
 			if (ret != RETURNVALUE_NOERROR) {
-				if (cooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN, cooldown, 0, false, spellId);
-					player->addCondition(condition);
-				}
-
-				if (group != SPELLGROUP_NONE && groupCooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
-					player->addCondition(condition);
-				}
-
-				if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
-					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, secondaryGroupCooldown, 0, false, secondaryGroup);
-					player->addCondition(condition);
-				}
+				addCooldowns(player);
 
 				player->sendCancelMessage(ret);
 				g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -771,12 +771,12 @@ void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool pay
 				player->addCondition(condition);
 			}
 
-			if (groupCooldown > 0) {
+			if (group != SPELLGROUP_NONE && groupCooldown > 0) {
 				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
 				player->addCondition(condition);
 			}
 
-			if (secondaryGroupCooldown > 0) {
+			if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
 				Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, secondaryGroupCooldown, 0, false, secondaryGroup);
 				player->addCondition(condition);
 			}
@@ -884,12 +884,12 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 						player->addCondition(condition);
 					}
 
-					if (groupCooldown > 0) {
+					if (group != SPELLGROUP_NONE && groupCooldown > 0) {
 						Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
 						player->addCondition(condition);
 					}
 
-					if (secondaryGroupCooldown > 0) {
+					if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
 						Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, secondaryGroupCooldown, 0, false, secondaryGroup);
 						player->addCondition(condition);
 					}
@@ -944,12 +944,12 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 					player->addCondition(condition);
 				}
 
-				if (groupCooldown > 0) {
+				if (group != SPELLGROUP_NONE && groupCooldown > 0) {
 					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, groupCooldown, 0, false, group);
 					player->addCondition(condition);
 				}
 
-				if (secondaryGroupCooldown > 0) {
+				if (secondaryGroup != SPELLGROUP_NONE && secondaryGroupCooldown > 0) {
 					Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLGROUPCOOLDOWN, secondaryGroupCooldown, 0, false, secondaryGroup);
 					player->addCondition(condition);
 				}

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -416,6 +416,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 		std::string tmpStr = asLowerCaseString(attr.as_string());
 		if (tmpStr == "none" || tmpStr == "0") {
 			group = SPELLGROUP_NONE;
+			groupCooldown = 0;
 		} else if (tmpStr == "attack" || tmpStr == "1") {
 			group = SPELLGROUP_ATTACK;
 		} else if (tmpStr == "healing" || tmpStr == "2") {

--- a/src/spells.h
+++ b/src/spells.h
@@ -188,6 +188,9 @@ class Spell : public BaseSpell
 		}
 		void setGroup(SpellGroup_t g) {
 			group = g;
+			if(group == SPELLGROUP_NONE) {
+				groupCooldown = 0;
+			}
 		}
 		SpellGroup_t getSecondaryGroup() const {
 			return secondaryGroup;

--- a/src/spells.h
+++ b/src/spells.h
@@ -280,6 +280,7 @@ class Spell : public BaseSpell
 		bool playerSpellCheck(Player* player) const;
 		bool playerInstantSpellCheck(Player* player, const Position& toPos);
 		bool playerRuneSpellCheck(Player* player, const Position& toPos);
+		void addCooldowns(Player* player) const;
 
 		VocSpellMap vocSpellMap;
 

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1243,8 +1243,10 @@ int64_t OTSYS_TIME()
 
 SpellGroup_t stringToSpellGroup(const std::string& value)
 {
-	std::string tmpStr = asLowerCaseString(value);
-	if (tmpStr == "attack" || tmpStr == "1") {
+	std::string tmpStr = boost::algorithm::to_lower_copy(value);
+	if (tmpStr == "none" || tmpStr == "0") {
+		return SPELLGROUP_NONE;
+	} else if (tmpStr == "attack" || tmpStr == "1") {
 		return SPELLGROUP_ATTACK;
 	} else if (tmpStr == "healing" || tmpStr == "2") {
 		return SPELLGROUP_HEALING;
@@ -1254,7 +1256,7 @@ SpellGroup_t stringToSpellGroup(const std::string& value)
 		return SPELLGROUP_SPECIAL;
 	}
 
-	return SPELLGROUP_NONE;
+	return SPELLGROUP_UNKNOWN;
 }
 
 std::vector<uint16_t> depotBoxes = {

--- a/src/tools.cpp
+++ b/src/tools.cpp
@@ -1243,7 +1243,7 @@ int64_t OTSYS_TIME()
 
 SpellGroup_t stringToSpellGroup(const std::string& value)
 {
-	std::string tmpStr = boost::algorithm::to_lower_copy(value);
+	std::string tmpStr = asLowerCaseString(value);
 	if (tmpStr == "none" || tmpStr == "0") {
 		return SPELLGROUP_NONE;
 	} else if (tmpStr == "attack" || tmpStr == "1") {


### PR DESCRIPTION
Previous PR (#32) should've adapted XML loading, this should adapt Revscript loading to stop forcing spells to have a group.