### PR TITLE
Quest Log Improvement

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1359,6 +1359,7 @@ void Player::addStorageValue(const uint32_t key, const int32_t value, const bool
 			auto currentFrameTime = g_dispatcher.getDispatcherCycle();
 			if (lastQuestlogUpdate != currentFrameTime && g_game.quests.isQuestStorage(key, value, oldValue)) {
 				lastQuestlogUpdate = currentFrameTime;
+				sendQuestLog();
 				sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your questlog has been updated.");
 			}
 		}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -2093,6 +2093,7 @@ void ProtocolGame::sendQuestLine(const Quest* quest)
 		if (mission.isStarted(player)) {
 			msg.addString(mission.getName(player));
 			msg.addString(mission.getDescription(player));
+			msg.addByte(mission.isCompleted(player));
 		}
 	}
 

--- a/src/quests.cpp
+++ b/src/quests.cpp
@@ -83,9 +83,6 @@ bool Mission::isCompleted(Player* player) const
 
 std::string Mission::getName(Player* player) const
 {
-	if (isCompleted(player)) {
-		return name + " (completed)";
-	}
 	return name;
 }
 


### PR DESCRIPTION
This is the beginning of quest log improvement.

It should be a draft for now, and that is because I suggest sending an additional byte (isCompleted for missions) the OTC/Cipsoft will break unless modified. So, we would have to supply OTC for Black-Tek users.

_What this improves:_
1. Mission `isCompleted` state is specified for client, instead of just changing name server-side (Quests already do that.)
2. `sendQuestLog();` is now used when questlog update happens. Currently, in all implementations of quest log client spamms requests for questlog which is a very bad idea. By doing this, we can remove a lot of redundancy client-side, and let server handle updates, instead of relying on client asking server for it all the time.