### PR TITLE
Fix incorrect summon counting ("max" parameter)

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -114,7 +114,7 @@ class Creature : virtual public Thing, public SharedObject
 			return nullptr;
 		}
 
-		virtual const std::string& getRegisteredName() const = { return getName(); };
+		virtual const std::string& getRegisteredName() const = 0;
 
 		virtual const std::string& getName() const = 0;
 		virtual const std::string& getNameDescription() const = 0;

--- a/src/creature.h
+++ b/src/creature.h
@@ -114,6 +114,8 @@ class Creature : virtual public Thing, public SharedObject
 			return nullptr;
 		}
 
+		virtual const std::string& getRegisteredName() const = { return getName(); };
+
 		virtual const std::string& getName() const = 0;
 		virtual const std::string& getNameDescription() const = 0;
 	

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -951,6 +951,8 @@ void Monster::onThinkDefense(const uint32_t interval)
 			}
 
 			uint32_t summonCount = 0;
+			std::string lowerSummonName = summonBlock.name;
+			toLowerCaseString(lowerSummonName);
 			for (const auto& summon : summons) {
 				if (summon->getRegisteredName() == summonBlock.name) {
 					++summonCount;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -953,8 +953,9 @@ void Monster::onThinkDefense(const uint32_t interval)
 			uint32_t summonCount = 0;
 			std::string lowerSummonName = summonBlock.name;
 			toLowerCaseString(lowerSummonName);
+
 			for (const auto& summon : summons) {
-				if (summon->getRegisteredName() == summonBlock.name) {
+				if (summon->getRegisteredName() == lowerSummonName) {
 					++summonCount;
 				}
 			}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -952,7 +952,7 @@ void Monster::onThinkDefense(const uint32_t interval)
 
 			uint32_t summonCount = 0;
 			for (const auto& summon : summons) {
-				if (summon->getName() == summonBlock.name) {
+				if (summon->getRegisteredName() == summonBlock.name) {
 					++summonCount;
 				}
 			}

--- a/src/monster.h
+++ b/src/monster.h
@@ -53,7 +53,7 @@ class Monster final : public Creature
 		void removeList() override;
 
 		// Returns name that was used in monsters.xml, not the real creature name
-		const std::string& getRegisteredName() { return mType->registeredName; };
+		const std::string& getRegisteredName() const override { return mType->registeredName; };
 
 		const std::string& getName() const override;
 		void setName(const std::string& name);

--- a/src/monster.h
+++ b/src/monster.h
@@ -52,6 +52,9 @@ class Monster final : public Creature
 		void addList() override;
 		void removeList() override;
 
+		// Returns name that was used in monsters.xml, not the real creature name
+		const std::string& getRegisteredName() { return mType->registeredName; };
+
 		const std::string& getName() const override;
 		void setName(const std::string& name);
 

--- a/src/monsters.cpp
+++ b/src/monsters.cpp
@@ -808,6 +808,7 @@ MonsterType* Monsters::loadMonster(const std::string& file, const std::string& m
 		mType->info = {};
 	}
 
+	mType->registeredName = monsterName;
 	mType->name = attr.as_string();
 
 	if ((attr = monsterNode.attribute("nameDescription"))) {

--- a/src/monsters.h
+++ b/src/monsters.h
@@ -163,6 +163,7 @@ class MonsterType
 
 		std::string name;
 		std::string nameDescription;
+		std::string registeredName;
 
 		MonsterInfo info;
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -124,6 +124,10 @@ class Npc final : public Creature
 		bool load();
 		void reload();
 
+		const std::string& getRegisteredName() const override {
+			return getName();
+		}
+
 		const std::string& getName() const override {
 			return name;
 		}

--- a/src/player.h
+++ b/src/player.h
@@ -160,6 +160,10 @@ class Player final : public Creature, public Cylinder
 
 		static MuteCountMap muteCountMap;
 
+		const std::string& getRegisteredName() const override {
+			return getName();
+		}
+
 		const std::string& getName() const override {
 			return name;
 		}


### PR DESCRIPTION
Fix incorrect summon counting, when a monster can summon some monsters, the "max" parameter wasn't working, due to name mismatch.

A way to test - have a monster that has this code in its' xml:
```
<summons maxSummons="12">
        <summon name="Demon (Goblin)" interval="1000" chance="100" max="2" />
    </summons>
```
Despite having max 2, the monster will spawn up to 12 Demons.