### PR TITLE
Raw Pointer conversion for Thing type classes

### DIFF
--- a/src/actions.h
+++ b/src/actions.h
@@ -10,7 +10,7 @@
 
 class Action;
 using Action_ptr = std::unique_ptr<Action>;
-using ActionFunction = std::function<bool(Player* player, Item* item, const Position& fromPosition, Thing* target, const Position& toPosition, bool isHotkey)>;
+using ActionFunction = std::function<bool(PlayerPtr player, ItemPtr item, const Position& fromPosition, ThingPtr target, const Position& toPosition, bool isHotkey)>;
 
 class Action : public Event
 {
@@ -21,12 +21,13 @@ class Action : public Event
 		bool loadFunction(const pugi::xml_attribute& attr, bool isScripted) override;
 
 		//scripting
-		virtual bool executeUse(Player* player, Item* item, const Position& fromPosition,
-			Thing* target, const Position& toPosition, bool isHotkey);
+		virtual bool executeUse(const PlayerPtr& player, const ItemPtr& item, const Position& fromPosition,
+			const ThingPtr& target, const Position& toPosition, bool isHotkey);
 
 		bool getAllowFarUse() const {
 			return allowFarUse;
 		}
+	
 		void setAllowFarUse(bool v) {
 			allowFarUse = v;
 		}
@@ -34,6 +35,7 @@ class Action : public Event
 		bool getCheckLineOfSight() const {
 			return checkLineOfSight;
 		}
+	
 		void setCheckLineOfSight(bool v) {
 			checkLineOfSight = v;
 		}
@@ -41,6 +43,7 @@ class Action : public Event
 		bool getCheckFloor() const {
 			return checkFloor;
 		}
+	
 		void setCheckFloor(bool v) {
 			checkFloor = v;
 		}
@@ -48,9 +51,11 @@ class Action : public Event
 		void clearItemIdRange() {
 			return ids.clear();
 		}
+	
 		const std::vector<uint16_t>& getItemIdRange() const {
 			return ids;
 		}
+	
 		void addItemId(uint16_t id) {
 			ids.emplace_back(id);
 		}
@@ -58,9 +63,11 @@ class Action : public Event
 		void clearUniqueIdRange() {
 			return uids.clear();
 		}
+	
 		const std::vector<uint16_t>& getUniqueIdRange() const {
 			return uids;
 		}
+	
 		void addUniqueId(uint16_t id) {
 			uids.emplace_back(id);
 		}
@@ -68,18 +75,22 @@ class Action : public Event
 		void clearActionIdRange() {
 			return aids.clear();
 		}
+	
 		const std::vector<uint16_t>& getActionIdRange() const {
 			return aids;
 		}
+	
 		void addActionId(uint16_t id) {
 			aids.emplace_back(id);
 		}
 
-		virtual ReturnValue canExecuteAction(const Player* player, const Position& toPos);
+		virtual ReturnValue canExecuteAction(const PlayerConstPtr& player, const Position& toPos);
+	
 		virtual bool hasOwnErrorHandler() {
 			return false;
 		}
-		virtual Thing* getTarget(Player* player, Creature* targetCreature, const Position& toPosition, uint8_t toStackPos) const;
+	
+		virtual ThingPtr getTarget(const PlayerPtr& player, const CreaturePtr& targetCreature, const Position& toPosition, uint8_t toStackPos) const;
 
 		ActionFunction function;
 
@@ -104,18 +115,18 @@ class Actions final : public BaseEvents
 		Actions(const Actions&) = delete;
 		Actions& operator=(const Actions&) = delete;
 
-		bool useItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
-		bool useItemEx(Player* player, const Position& fromPos, const Position& toPos, uint8_t toStackPos, Item* item, bool isHotkey, Creature* creature = nullptr);
+		bool useItem(PlayerPtr player, const Position& pos, uint8_t index, const ItemPtr& item, bool isHotkey);
+		bool useItemEx(const PlayerPtr& player, const Position& fromPos, const Position& toPos, uint8_t toStackPos, const ItemPtr& item, bool isHotkey, const CreaturePtr& creature = nullptr);
 
-		ReturnValue canUse(const Player* player, const Position& pos);
-		ReturnValue canUse(const Player* player, const Position& pos, const Item* item);
-		ReturnValue canUseFar(const Creature* creature, const Position& toPos, bool checkLineOfSight, bool checkFloor);
+		ReturnValue canUse(const PlayerConstPtr& player, const Position& pos);
+		ReturnValue canUse(const PlayerConstPtr& player, const Position& pos, const ItemConstPtr& item);
+		ReturnValue canUseFar(const CreatureConstPtr& creature, const Position& toPos, bool checkLineOfSight, bool checkFloor);
 
 		bool registerLuaEvent(Action* event);
 		void clear(bool fromLua) override final;
 
 	private:
-		ReturnValue internalUseItem(Player* player, const Position& pos, uint8_t index, Item* item, bool isHotkey);
+		ReturnValue internalUseItem(PlayerPtr player, const Position& pos, uint8_t index, const ItemPtr& item, bool isHotkey);
 
 		LuaScriptInterface& getScriptInterface() override;
 		std::string_view getScriptBaseName() const override { return "actions"; }
@@ -127,7 +138,7 @@ class Actions final : public BaseEvents
 		ActionUseMap uniqueItemMap;
 		ActionUseMap actionItemMap;
 
-		Action* getAction(const Item* item);
+		Action* getAction(const ItemConstPtr& item);
 		void clearMap(ActionUseMap& map, bool fromLua);
 
 		LuaScriptInterface scriptInterface;

--- a/src/augment.cpp
+++ b/src/augment.cpp
@@ -8,7 +8,7 @@
 
 #include "augment.h"
 
-Augment::Augment(std::string name, std::string description) : m_name(name), m_description(description) {
+Augment::Augment(const std::string& name, const std::string& description) : m_name(name), m_description(description) {
 	
 }
 

--- a/src/augment.h
+++ b/src/augment.h
@@ -15,7 +15,7 @@ class Augment : public std::enable_shared_from_this<Augment> {
 
 public:
 	Augment() = default;
-	Augment(std::string name, std::string description = "");
+	Augment(const std::string& name, const std::string& description = "");
 	Augment(std::shared_ptr<Augment>& original);
 
 	~Augment() = default;
@@ -30,8 +30,8 @@ public:
 	const std::string getName() const;
 	const std::string getDescription() const;
 
-	void setName(std::string name);
-	void setDescription(std::string description);
+	void setName(const std::string& name);
+	void setDescription(const std::string& description);
 
 	static std::shared_ptr<Augment> MakeAugment(std::string augmentName, std::string description = "");
 	static std::shared_ptr<Augment> MakeAugment(std::shared_ptr<Augment>& originalPointer);
@@ -146,11 +146,11 @@ inline const std::string Augment::getDescription() const
 	return m_description;
 }
 
-inline void Augment::setName(std::string name) {
+inline void Augment::setName(const std::string& name) {
 	m_name = name;
 }
 
-inline void Augment::setDescription(std::string description) {
+inline void Augment::setDescription(const std::string& description) {
 	m_description = description;
 }
 

--- a/src/augments.cpp
+++ b/src/augments.cpp
@@ -331,7 +331,7 @@ void Augments::AddAugment(std::shared_ptr<Augment> augment) {
     }
 }
 
-void Augments::RemoveAugment(std::shared_ptr<Augment> augment) {
+void Augments::RemoveAugment(const std::shared_ptr<Augment>& augment) {
     auto it = global_augments.find(augment->getName().data());
     if (it != global_augments.end()) {
         global_augments.erase(it);
@@ -345,7 +345,7 @@ void Augments::RemoveAugment(std::string_view augName) {
     }
 }
 
-void Augments::RemoveAugment(std::string augName) {
+void Augments::RemoveAugment(const std::string& augName) {
     auto it = global_augments.find(augName);
     if (it != global_augments.end()) {
         global_augments.erase(it);

--- a/src/augments.h
+++ b/src/augments.h
@@ -38,9 +38,9 @@ public:
 	static void clearAll();
 	static void reload();
 	static void AddAugment(std::shared_ptr<Augment> augment);
-	static void RemoveAugment(std::shared_ptr<Augment> augment);
+	static void RemoveAugment(const std::shared_ptr<Augment>& augment);
 	static void RemoveAugment(std::string_view augName);
-	static void RemoveAugment(std::string augName);
+	static void RemoveAugment(const std::string& augName);
 	static std::shared_ptr<Augment> GetAugment(std::string_view augName);
 };
 

--- a/src/baseevents.h
+++ b/src/baseevents.h
@@ -20,6 +20,7 @@ class Event
 		bool checkScript(const std::string& basePath, const std::string& scriptsName, const std::string& scriptFile) const;
 		bool loadScript(const std::string& scriptFile);
 		bool loadCallback();
+	
 		virtual bool loadFunction(const pugi::xml_attribute&, bool) {
 			return false;
 		}
@@ -31,7 +32,8 @@ class Event
 		bool scripted = false;
 		bool fromLua = false;
 
-		int32_t getScriptId() {
+		int32_t getScriptId() const
+		{
 			return scriptId;
 		}
 

--- a/src/bed.h
+++ b/src/bed.h
@@ -14,11 +14,12 @@ class BedItem final : public Item
 	public:
 		explicit BedItem(uint16_t id);
 
-		BedItem* getBed() override {
-			return this;
+		BedItemPtr getBed() override {
+			return dynamic_shared_this<BedItem>();
 		}
-		const BedItem* getBed() const override {
-			return this;
+	
+		BedItemConstPtr getBed() const override {
+			return dynamic_shared_this<const BedItem>();
 		}
 
 		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
@@ -35,22 +36,23 @@ class BedItem final : public Item
 		House* getHouse() const {
 			return house;
 		}
+	
 		void setHouse(House* h) {
 			house = h;
 		}
 
-		bool canUse(Player* player);
+		bool canUse(PlayerPtr player) const;
 
-		bool trySleep(Player* player);
-		bool sleep(Player* player);
-		void wakeUp(Player* player);
+		bool trySleep(const PlayerPtr& player);
+		bool sleep(const PlayerPtr& player);
+		void wakeUp(const PlayerPtr& player);
 
-		BedItem* getNextBedItem() const;
+		BedItemPtr getNextBedItem() const;
 
 	private:
-		void updateAppearance(const Player* player);
-		void regeneratePlayer(Player* player) const;
-		void internalSetSleeper(const Player* player);
+		void updateAppearance(const PlayerConstPtr& player);
+		void regeneratePlayer(const PlayerPtr& player) const;
+		void internalSetSleeper(const PlayerConstPtr& player);
 		void internalRemoveSleeper();
 
 		House* house = nullptr;

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -18,7 +18,7 @@ bool PrivateChatChannel::isInvited(uint32_t guid) const
 	if (guid == getOwner()) {
 		return true;
 	}
-	return invites.find(guid) != invites.end();
+	return invites.contains(guid);
 }
 
 bool PrivateChatChannel::removeInvite(uint32_t guid)
@@ -26,49 +26,49 @@ bool PrivateChatChannel::removeInvite(uint32_t guid)
 	return invites.erase(guid) != 0;
 }
 
-void PrivateChatChannel::invitePlayer(const Player& player, Player& invitePlayer)
+void PrivateChatChannel::invitePlayer(const PlayerConstPtr& player, const PlayerPtr& invitePlayer)
 {
-	auto result = invites.emplace(invitePlayer.getGUID(), &invitePlayer);
+	auto result = invites.emplace(invitePlayer->getGUID(), invitePlayer);
 	if (!result.second) {
 		return;
 	}
 
-	invitePlayer.sendTextMessage(MESSAGE_INFO_DESCR, fmt::format("{:s} invites you to {:s} private chat channel.", player.getName(), player.getSex() == PLAYERSEX_FEMALE ? "her" : "his"));
+	invitePlayer->sendTextMessage(MESSAGE_INFO_DESCR, fmt::format("{:s} invites you to {:s} private chat channel.", player->getName(), player->getSex() == PLAYERSEX_FEMALE ? "her" : "his"));
 
-	player.sendTextMessage(MESSAGE_INFO_DESCR, fmt::format("{:s} has been invited.", invitePlayer.getName()));
+	player->sendTextMessage(MESSAGE_INFO_DESCR, fmt::format("{:s} has been invited.", invitePlayer->getName()));
 
 	for (const auto& it : users) {
-		it.second->sendChannelEvent(id, invitePlayer.getName(), CHANNELEVENT_INVITE);
+		it.second->sendChannelEvent(id, invitePlayer->getName(), CHANNELEVENT_INVITE);
 	}
 }
 
-void PrivateChatChannel::excludePlayer(const Player& player, Player& excludePlayer)
+void PrivateChatChannel::excludePlayer(const PlayerConstPtr& player, const PlayerPtr& excludePlayer)
 {
-	if (!removeInvite(excludePlayer.getGUID())) {
+	if (!removeInvite(excludePlayer->getGUID())) {
 		return;
 	}
-
+	
 	removeUser(excludePlayer);
 
-	player.sendTextMessage(MESSAGE_INFO_DESCR, fmt::format("{:s} has been excluded.", excludePlayer.getName()));
+	player->sendTextMessage(MESSAGE_INFO_DESCR, fmt::format("{:s} has been excluded.", excludePlayer->getName()));
 
-	excludePlayer.sendClosePrivate(id);
+	excludePlayer->sendClosePrivate(id);
 
-	for (const auto& it : users) {
-		it.second->sendChannelEvent(id, excludePlayer.getName(), CHANNELEVENT_EXCLUDE);
+	for (const auto& val : users | std::views::values) {
+		val->sendChannelEvent(id, excludePlayer->getName(), CHANNELEVENT_EXCLUDE);
 	}
 }
 
 void PrivateChatChannel::closeChannel() const
 {
-	for (const auto& it : users) {
-		it.second->sendClosePrivate(id);
+	for (const auto& val : users | std::views::values) {
+		val->sendClosePrivate(id);
 	}
 }
 
-bool ChatChannel::addUser(Player& player)
+bool ChatChannel::addUser(const PlayerPtr& player)
 {
-	if (users.find(player.getID()) != users.end()) {
+	if (users.contains(player->getID())) {
 		return false;
 	}
 
@@ -78,25 +78,25 @@ bool ChatChannel::addUser(Player& player)
 
 	// TODO: Move to script when guild channels can be scripted
 	if (id == CHANNEL_GUILD) {
-		Guild* guild = player.getGuild();
+		auto guild = player->getGuild();
 		if (guild && !guild->getMotd().empty()) {
-			g_scheduler.addEvent(createSchedulerTask(150, [playerID = player.getID()]() { g_game.sendGuildMotd(playerID); }));
+			g_scheduler.addEvent(createSchedulerTask(150, [playerID = player->getID()]() { g_game.sendGuildMotd(playerID); }));
 		}
 	}
 
 	if (!publicChannel) {
-		for (const auto& it : users) {
-			it.second->sendChannelEvent(id, player.getName(), CHANNELEVENT_JOIN);
+		for (const auto& val : users | std::views::values) {
+			val->sendChannelEvent(id, player->getName(), CHANNELEVENT_JOIN);
 		}
 	}
 
-	users[player.getID()] = &player;
+	users[player->getID()] = player;
 	return true;
 }
 
-bool ChatChannel::removeUser(const Player& player)
+bool ChatChannel::removeUser(const PlayerConstPtr& player)
 {
-	auto iter = users.find(player.getID());
+	auto iter = users.find(player->getID());
 	if (iter == users.end()) {
 		return false;
 	}
@@ -104,8 +104,8 @@ bool ChatChannel::removeUser(const Player& player)
 	users.erase(iter);
 
 	if (!publicChannel) {
-		for (const auto& it : users) {
-			it.second->sendChannelEvent(id, player.getName(), CHANNELEVENT_LEAVE);
+		for (const auto& val : users | std::views::values) {
+			val->sendChannelEvent(id, player->getName(), CHANNELEVENT_LEAVE);
 		}
 	}
 
@@ -113,30 +113,30 @@ bool ChatChannel::removeUser(const Player& player)
 	return true;
 }
 
-bool ChatChannel::hasUser(const Player& player) {
-	return users.find(player.getID()) != users.end();
+bool ChatChannel::hasUser(const PlayerConstPtr& player) const {
+	return users.contains(player->getID());
 }
 
 void ChatChannel::sendToAll(const std::string& message, SpeakClasses type) const
 {
-	for (const auto& it : users) {
-		it.second->sendChannelMessage("", message, type, id);
+	for (const auto& val : users | std::views::values) {
+		val->sendChannelMessage("", message, type, id);
 	}
 }
 
-bool ChatChannel::talk(const Player& fromPlayer, SpeakClasses type, const std::string& text)
+bool ChatChannel::talk(const PlayerConstPtr& fromPlayer, SpeakClasses type, const std::string& text)
 {
-	if (users.find(fromPlayer.getID()) == users.end()) {
+	if (!users.contains(fromPlayer->getID())) {
 		return false;
 	}
 
-	for (const auto& it : users) {
-		it.second->sendToChannel(&fromPlayer, type, text, id);
+	for (const auto& val : users | std::views::values) {
+		val->sendToChannel(fromPlayer, type, text, id);
 	}
 	return true;
 }
 
-bool ChatChannel::executeCanJoinEvent(const Player& player)
+bool ChatChannel::executeCanJoinEvent(const PlayerConstPtr& player) const
 {
 	if (canJoinEvent == -1) {
 		return true;
@@ -155,13 +155,13 @@ bool ChatChannel::executeCanJoinEvent(const Player& player)
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(canJoinEvent);
-	LuaScriptInterface::pushUserdata(L, &player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	return scriptInterface->callFunction(1);
 }
 
-bool ChatChannel::executeOnJoinEvent(const Player& player)
+bool ChatChannel::executeOnJoinEvent(const PlayerConstPtr& player) const
 {
 	if (onJoinEvent == -1) {
 		return true;
@@ -180,13 +180,13 @@ bool ChatChannel::executeOnJoinEvent(const Player& player)
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(onJoinEvent);
-	LuaScriptInterface::pushUserdata(L, &player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	return scriptInterface->callFunction(1);
 }
 
-bool ChatChannel::executeOnLeaveEvent(const Player& player)
+bool ChatChannel::executeOnLeaveEvent(const PlayerConstPtr& player) const
 {
 	if (onLeaveEvent == -1) {
 		return true;
@@ -205,13 +205,13 @@ bool ChatChannel::executeOnLeaveEvent(const Player& player)
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(onLeaveEvent);
-	LuaScriptInterface::pushUserdata(L, &player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	return scriptInterface->callFunction(1);
 }
 
-bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, const std::string& message)
+bool ChatChannel::executeOnSpeakEvent(const PlayerConstPtr& player, SpeakClasses& type, const std::string& message) const
 {
 	if (onSpeakEvent == -1) {
 		return true;
@@ -230,7 +230,7 @@ bool ChatChannel::executeOnSpeakEvent(const Player& player, SpeakClasses& type, 
 	lua_State* L = scriptInterface->getLuaState();
 
 	scriptInterface->pushFunction(onSpeakEvent);
-	LuaScriptInterface::pushUserdata(L, &player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	lua_pushinteger(L, type);
@@ -298,8 +298,8 @@ bool Chat::load()
 			}
 
 			UsersMap tempUserMap = std::move(channel.users);
-			for (const auto& pair : tempUserMap) {
-				channel.addUser(*pair.second);
+			for (const auto& val : tempUserMap | std::views::values) {
+				channel.addUser(val);
 			}
 			continue;
 		}
@@ -323,7 +323,7 @@ bool Chat::load()
 	return true;
 }
 
-ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
+ChatChannel* Chat::createChannel(const PlayerConstPtr& player, uint16_t channelId)
 {
 	if (getChannel(player, channelId)) {
 		return nullptr;
@@ -331,7 +331,7 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			Guild* guild = player.getGuild();
+			auto guild = player->getGuild();
 			if (guild) {
 				auto ret = guildChannels.emplace(std::make_pair(guild->getId(), ChatChannel(channelId, guild->getName())));
 				return &ret.first->second;
@@ -340,7 +340,7 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 		}
 
 		case CHANNEL_PARTY: {
-			Party* party = player.getParty();
+			auto party = player->getParty();
 			if (party) {
 				auto ret = partyChannels.emplace(std::make_pair(party, ChatChannel(channelId, "Party")));
 				return &ret.first->second;
@@ -350,16 +350,16 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 
 		case CHANNEL_PRIVATE: {
 			//only 1 private channel for each premium player
-			if (!player.isPremium() || getPrivateChannel(player)) {
+			if (!player->isPremium() || getPrivateChannel(player)) {
 				return nullptr;
 			}
 
 			//find a free private channel slot
 			for (uint16_t i = 100; i < 10000; ++i) {
-				auto ret = privateChannels.emplace(std::make_pair(i, PrivateChatChannel(i, player.getName() + "'s Channel")));
+				auto ret = privateChannels.emplace(std::make_pair(i, PrivateChatChannel(i, player->getName() + "'s Channel")));
 				if (ret.second) { //second is a bool that indicates that a new channel has been placed in the map
 					auto& newChannel = (*ret.first).second;
-					newChannel.setOwner(player.getGUID());
+					newChannel.setOwner(player->getGUID());
 					return &newChannel;
 				}
 			}
@@ -372,16 +372,16 @@ ChatChannel* Chat::createChannel(const Player& player, uint16_t channelId)
 	return nullptr;
 }
 
-bool Chat::deleteChannel(const Player& player, uint16_t channelId)
+bool Chat::deleteChannel(const PlayerConstPtr& player, uint16_t channelId)
 {
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			Guild* guild = player.getGuild();
+			auto guild = player->getGuild();
 			if (!guild) {
 				return false;
 			}
 
-			auto it = guildChannels.find(guild->getId());
+			const auto it = guildChannels.find(guild->getId());
 			if (it == guildChannels.end()) {
 				return false;
 			}
@@ -391,12 +391,12 @@ bool Chat::deleteChannel(const Player& player, uint16_t channelId)
 		}
 
 		case CHANNEL_PARTY: {
-			Party* party = player.getParty();
+			auto party = player->getParty();
 			if (!party) {
 				return false;
 			}
 
-			auto it = partyChannels.find(party);
+			const auto it = partyChannels.find(party);
 			if (it == partyChannels.end()) {
 				return false;
 			}
@@ -406,7 +406,7 @@ bool Chat::deleteChannel(const Player& player, uint16_t channelId)
 		}
 
 		default: {
-			auto it = privateChannels.find(channelId);
+			const auto it = privateChannels.find(channelId);
 			if (it == privateChannels.end()) {
 				return false;
 			}
@@ -420,7 +420,7 @@ bool Chat::deleteChannel(const Player& player, uint16_t channelId)
 	return true;
 }
 
-ChatChannel* Chat::addUserToChannel(Player& player, uint16_t channelId)
+ChatChannel* Chat::addUserToChannel(const PlayerPtr& player, uint16_t channelId)
 {
 	ChatChannel* channel = getChannel(player, channelId);
 	if (channel && channel->addUser(player)) {
@@ -429,39 +429,39 @@ ChatChannel* Chat::addUserToChannel(Player& player, uint16_t channelId)
 	return nullptr;
 }
 
-bool Chat::removeUserFromChannel(const Player& player, uint16_t channelId)
+bool Chat::removeUserFromChannel(const PlayerConstPtr& player, uint16_t channelId)
 {
 	ChatChannel* channel = getChannel(player, channelId);
 	if (!channel || !channel->removeUser(player)) {
 		return false;
 	}
 
-	if (channel->getOwner() == player.getGUID()) {
+	if (channel->getOwner() == player->getGUID()) {
 		deleteChannel(player, channelId);
 	}
 	return true;
 }
 
-void Chat::removeUserFromAllChannels(const Player& player)
+void Chat::removeUserFromAllChannels(const PlayerConstPtr& player)
 {
-	for (auto& it : normalChannels) {
-		it.second.removeUser(player);
+	for (auto& val : normalChannels | std::views::values) {
+		val.removeUser(player);
 	}
 
-	for (auto& it : partyChannels) {
-		it.second.removeUser(player);
+	for (auto& val : partyChannels | std::views::values) {
+		val.removeUser(player);
 	}
 
-	for (auto& it : guildChannels) {
-		it.second.removeUser(player);
+	for (auto& val : guildChannels | std::views::values) {
+		val.removeUser(player);
 	}
 
 	auto it = privateChannels.begin();
 	while (it != privateChannels.end()) {
 		PrivateChatChannel* channel = &it->second;
-		channel->removeInvite(player.getGUID());
+		channel->removeInvite(player->getGUID());
 		channel->removeUser(player);
-		if (channel->getOwner() == player.getGUID()) {
+		if (channel->getOwner() == player->getGUID()) {
 			channel->closeChannel();
 			it = privateChannels.erase(it);
 		} else {
@@ -470,15 +470,15 @@ void Chat::removeUserFromAllChannels(const Player& player)
 	}
 }
 
-bool Chat::talkToChannel(const Player& player, SpeakClasses type, const std::string& text, uint16_t channelId)
+bool Chat::talkToChannel(const PlayerConstPtr& player, SpeakClasses type, const std::string& text, uint16_t channelId)
 {
-	ChatChannel* channel = getChannel(player, channelId);
+	const auto channel = getChannel(player, channelId);
 	if (!channel) {
 		return false;
 	}
 
 	if (channelId == CHANNEL_GUILD) {
-		GuildRank_ptr rank = player.getGuildRank();
+		GuildRank_ptr rank = player->getGuildRank();
 		if (rank && rank->level > 1) {
 			type = TALKTYPE_CHANNEL_O;
 		} else if (type != TALKTYPE_CHANNEL_Y) {
@@ -495,12 +495,11 @@ bool Chat::talkToChannel(const Player& player, SpeakClasses type, const std::str
 	return channel->talk(player, type, text);
 }
 
-ChannelList Chat::getChannelList(const Player& player)
+ChannelList Chat::getChannelList(const PlayerConstPtr& player)
 {
 	ChannelList list;
-	if (player.getGuild()) {
-		ChatChannel* channel = getChannel(player, CHANNEL_GUILD);
-		if (channel) {
+	if (player->getGuild()) {
+		if (auto channel = getChannel(player, CHANNEL_GUILD)) {
 			list.push_back(channel);
 		} else {
 			channel = createChannel(player, CHANNEL_GUILD);
@@ -510,9 +509,8 @@ ChannelList Chat::getChannelList(const Player& player)
 		}
 	}
 
-	if (player.getParty()) {
-		ChatChannel* channel = getChannel(player, CHANNEL_PARTY);
-		if (channel) {
+	if (player->getParty()) {
+		if (auto channel = getChannel(player, CHANNEL_PARTY)) {
 			list.push_back(channel);
 		} else {
 			channel = createChannel(player, CHANNEL_PARTY);
@@ -522,17 +520,16 @@ ChannelList Chat::getChannelList(const Player& player)
 		}
 	}
 
-	for (const auto& it : normalChannels) {
-		ChatChannel* channel = getChannel(player, it.first);
-		if (channel) {
+	for (const auto& key : normalChannels | std::views::keys) {
+		if (auto channel = getChannel(player, key)) {
 			list.push_back(channel);
 		}
 	}
 
 	bool hasPrivate = false;
-	for (auto& it : privateChannels) {
-		if (PrivateChatChannel* channel = &it.second) {
-			uint32_t guid = player.getGUID();
+	for (auto& val : privateChannels | std::views::values) {
+		if (const auto channel = &val) {
+			uint32_t guid = player->getGUID();
 			if (channel->isInvited(guid)) {
 				list.push_back(channel);
 			}
@@ -543,19 +540,18 @@ ChannelList Chat::getChannelList(const Player& player)
 		}
 	}
 
-	if (!hasPrivate && player.isPremium()) {
+	if (!hasPrivate && player->isPremium()) {
 		list.push_front(&dummyPrivate);
 	}
 	return list;
 }
 
-ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
+ChatChannel* Chat::getChannel(const PlayerConstPtr& player, uint16_t channelId)
 {
 	switch (channelId) {
 		case CHANNEL_GUILD: {
-			Guild* guild = player.getGuild();
-			if (guild) {
-				auto it = guildChannels.find(guild->getId());
+			if (auto guild = player->getGuild()) {
+				const auto it = guildChannels.find(guild->getId());
 				if (it != guildChannels.end()) {
 					return &it->second;
 				}
@@ -564,9 +560,8 @@ ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
 		}
 
 		case CHANNEL_PARTY: {
-			Party* party = player.getParty();
-			if (party) {
-				auto it = partyChannels.find(party);
+			if (auto party = player->getParty()) {
+				const auto it = partyChannels.find(party);
 				if (it != partyChannels.end()) {
 					return &it->second;
 				}
@@ -575,7 +570,7 @@ ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
 		}
 
 		default: {
-			auto it = normalChannels.find(channelId);
+			const auto it = normalChannels.find(channelId);
 			if (it != normalChannels.end()) {
 				ChatChannel& channel = it->second;
 				if (!channel.executeCanJoinEvent(player)) {
@@ -584,7 +579,7 @@ ChatChannel* Chat::getChannel(const Player& player, uint16_t channelId)
 				return &channel;
 			} else {
 				auto it2 = privateChannels.find(channelId);
-				if (it2 != privateChannels.end() && it2->second.isInvited(player.getGUID())) {
+				if (it2 != privateChannels.end() && it2->second.isInvited(player->getGUID())) {
 					return &it2->second;
 				}
 			}
@@ -612,10 +607,10 @@ ChatChannel* Chat::getChannelById(uint16_t channelId)
 	return &it->second;
 }
 
-PrivateChatChannel* Chat::getPrivateChannel(const Player& player)
+PrivateChatChannel* Chat::getPrivateChannel(const PlayerConstPtr& player)
 {
 	for (auto& it : privateChannels) {
-		if (it.second.getOwner() == player.getGUID()) {
+		if (it.second.getOwner() == player->getGUID()) {
 			return &it.second;
 		}
 	}

--- a/src/chat.h
+++ b/src/chat.h
@@ -10,8 +10,8 @@
 class Party;
 class Player;
 
-using UsersMap = std::map<uint32_t, Player*>;
-using InvitedMap = std::map<uint32_t, const Player*>;
+using UsersMap = std::map<uint32_t, PlayerPtr>;
+using InvitedMap = std::map<uint32_t, PlayerConstPtr>;
 
 class ChatChannel
 {
@@ -22,22 +22,25 @@ class ChatChannel
 
 		virtual ~ChatChannel() = default;
 
-		bool addUser(Player& player);
-		bool removeUser(const Player& player);
-		bool hasUser(const Player& player);
+		bool addUser(const PlayerPtr& player);
+		bool removeUser(const PlayerConstPtr& player);
+		bool hasUser( const PlayerConstPtr& player) const;
 
-		bool talk(const Player& fromPlayer, SpeakClasses type, const std::string& text);
+		bool talk(const PlayerConstPtr& fromPlayer, SpeakClasses type, const std::string& text);
 		void sendToAll(const std::string& message, SpeakClasses type) const;
 
 		const std::string& getName() const {
 			return name;
 		}
+	
 		uint16_t getId() const {
 			return id;
 		}
+	
 		const UsersMap& getUsers() const {
 			return users;
 		}
+	
 		virtual const InvitedMap* getInvitedUsers() const {
 			return nullptr;
 		}
@@ -48,10 +51,10 @@ class ChatChannel
 
 		bool isPublicChannel() const { return publicChannel; }
 
-		bool executeOnJoinEvent(const Player& player);
-		bool executeCanJoinEvent(const Player& player);
-		bool executeOnLeaveEvent(const Player& player);
-		bool executeOnSpeakEvent(const Player& player, SpeakClasses& type, const std::string& message);
+		bool executeOnJoinEvent(const PlayerConstPtr& player) const;
+		bool executeCanJoinEvent(const PlayerConstPtr& player) const;
+		bool executeOnLeaveEvent(const PlayerConstPtr& player) const;
+		bool executeOnSpeakEvent(const PlayerConstPtr& player, SpeakClasses& type, const std::string& message) const;
 
 	protected:
 		UsersMap users;
@@ -74,19 +77,20 @@ class ChatChannel
 class PrivateChatChannel final : public ChatChannel
 {
 	public:
-		PrivateChatChannel(uint16_t channelId, std::string channelName) : ChatChannel(channelId, channelName) {}
+		PrivateChatChannel(uint16_t channelId, const std::string& channelName) : ChatChannel(channelId, channelName) {}
 
 		uint32_t getOwner() const override {
 			return owner;
 		}
+	
 		void setOwner(uint32_t owner) {
 			this->owner = owner;
 		}
 
 		bool isInvited(uint32_t guid) const;
 
-		void invitePlayer(const Player& player, Player& invitePlayer);
-		void excludePlayer(const Player& player, Player& excludePlayer);
+		void invitePlayer(const PlayerConstPtr& player, const PlayerPtr& invitePlayer);
+		void excludePlayer(const PlayerConstPtr& player, const PlayerPtr& excludePlayer);
 
 		bool removeInvite(uint32_t guid);
 
@@ -114,21 +118,21 @@ class Chat
 
 		bool load();
 
-		ChatChannel* createChannel(const Player& player, uint16_t channelId);
-		bool deleteChannel(const Player& player, uint16_t channelId);
+		ChatChannel* createChannel(const PlayerConstPtr& player, uint16_t channelId);
+		bool deleteChannel(const PlayerConstPtr& player, uint16_t channelId);
 
-		ChatChannel* addUserToChannel(Player& player, uint16_t channelId);
-		bool removeUserFromChannel(const Player& player, uint16_t channelId);
-		void removeUserFromAllChannels(const Player& player);
+		ChatChannel* addUserToChannel(const PlayerPtr& player, uint16_t channelId);
+		bool removeUserFromChannel(const PlayerConstPtr& player, uint16_t channelId);
+		void removeUserFromAllChannels(const PlayerConstPtr& player);
 
-		bool talkToChannel(const Player& player, SpeakClasses type, const std::string& text, uint16_t channelId);
+		bool talkToChannel(const PlayerConstPtr& player, SpeakClasses type, const std::string& text, uint16_t channelId);
 
-		ChannelList getChannelList(const Player& player);
+		ChannelList getChannelList(const PlayerConstPtr& player);
 
-		ChatChannel* getChannel(const Player& player, uint16_t channelId);
+		ChatChannel* getChannel(const PlayerConstPtr& player, uint16_t channelId);
 		ChatChannel* getChannelById(uint16_t channelId);
 		ChatChannel* getGuildChannelById(uint32_t guildId);
-		PrivateChatChannel* getPrivateChannel(const Player& player);
+		PrivateChatChannel* getPrivateChannel(const PlayerConstPtr& player);
 
 		LuaScriptInterface* getScriptInterface() {
 			return &scriptInterface;

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -429,6 +429,7 @@ ReturnValue Container::queryRemove(const ThingPtr& thing, uint32_t count, uint32
 CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
 		uint32_t& flags)
 {
+	std::cout << "Is a container destination query \n";
 	if (!unlocked) {
 		*destItem = nullptr;
 		return getContainer();
@@ -460,13 +461,13 @@ CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, I
 		*destItem = nullptr;
 	}
 
-	const auto item = thing->getItem();
+	auto item = thing->getItem();
 	if (!item) {
 		return getContainer();
 	}
 
 	if (index != INDEX_WHEREEVER) {
-		if (const auto itemFromIndex = getItemByIndex(index)) {
+		if (auto itemFromIndex = getItemByIndex(index)) {
 			*destItem = itemFromIndex;
 		}
 

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -450,7 +450,6 @@ ReturnValue Container::queryRemove(const ThingPtr& thing, uint32_t count, uint32
 CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 		uint32_t& flags)
 {
-	std::cout << "Is a container destination query \n";
 	if (!unlocked) {
 		destItem = nullptr;
 		return getContainer();

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -426,18 +426,18 @@ ReturnValue Container::queryRemove(const ThingPtr& thing, uint32_t count, uint32
 	return RETURNVALUE_NOERROR;
 }
 
-CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 		uint32_t& flags)
 {
 	std::cout << "Is a container destination query \n";
 	if (!unlocked) {
-		*destItem = nullptr;
+		destItem = nullptr;
 		return getContainer();
 	}
 
 	if (index == 254 /*move up*/) {
 		index = INDEX_WHEREEVER;
-		*destItem = nullptr;
+		destItem = nullptr;
 
 		if (auto parentContainer = std::dynamic_pointer_cast<Cylinder>(getParent())) {
 			return parentContainer;
@@ -448,7 +448,7 @@ CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, I
 
 	if (index == 255 /*add wherever*/) {
 		index = INDEX_WHEREEVER;
-		*destItem = nullptr;
+		destItem = nullptr;
 	} else if (index >= static_cast<int32_t>(capacity())) {
 		/*
 		if you have a container, maximize it to show all 20 slots
@@ -458,7 +458,7 @@ CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, I
 		the client calculates the slot position as if the bag has 20 slots
 		*/
 		index = INDEX_WHEREEVER;
-		*destItem = nullptr;
+		destItem = nullptr;
 	}
 
 	auto item = thing->getItem();
@@ -468,19 +468,19 @@ CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, I
 
 	if (index != INDEX_WHEREEVER) {
 		if (auto itemFromIndex = getItemByIndex(index)) {
-			*destItem = itemFromIndex;
+			destItem = itemFromIndex;
 		}
 
-		if (CylinderPtr subCylinder = std::dynamic_pointer_cast<Cylinder>(*destItem)) {
+		if (CylinderPtr subCylinder = std::dynamic_pointer_cast<Cylinder>(destItem)) {
 			index = INDEX_WHEREEVER;
-			*destItem = nullptr;
+			destItem = nullptr;
 			return subCylinder;
 		}
 	}
 
 	bool autoStack = !hasBitSet(FLAG_IGNOREAUTOSTACK, flags);
 	if (autoStack && item->isStackable() && item->getParent().get() != this) {
-		if (*destItem && (*destItem)->equals(item) && (*destItem)->getItemCount() < 100) {
+		if (destItem && (destItem)->equals(item) && (destItem)->getItemCount() < 100) {
 			return getContainer();
 		}
 
@@ -488,7 +488,7 @@ CylinderPtr Container::queryDestination(int32_t& index, const ThingPtr& thing, I
 		uint32_t n = 0;
 		for (auto listItem : itemlist) {
 			if (listItem != item && listItem->equals(item) && listItem->getItemCount() < 100) {
-				*destItem = listItem;
+				destItem = listItem;
 				index = n;
 				return getContainer();
 			}

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -218,6 +218,13 @@ void Container::onAddContainerItem(ItemPtr& item)
 		{
 			const auto t_container = std::dynamic_pointer_cast<Container>(shared_from_this());
 			c_player->sendAddContainerItem(t_container, item);
+		}
+	}
+
+	for (auto spectator : spectators) {
+		if (const auto c_player = spectator->getPlayer())
+		{
+			const auto t_container = std::dynamic_pointer_cast<Container>(shared_from_this());
 			c_player->onAddContainerItem(item);
 		}
 	}
@@ -233,6 +240,13 @@ void Container::onUpdateContainerItem(uint32_t index, const ItemPtr& oldItem, co
 		{
 			auto t_container = std::dynamic_pointer_cast<Container>(shared_from_this());
 			c_player->sendUpdateContainerItem(t_container, index, newItem);
+		}
+	}
+
+	for (auto spectator : spectators) {
+		if (const auto c_player = spectator->getPlayer())
+		{
+			auto t_container = std::dynamic_pointer_cast<Container>(shared_from_this());
 			c_player->onUpdateContainerItem(t_container, oldItem, newItem);
 		}
 	}
@@ -248,6 +262,13 @@ void Container::onRemoveContainerItem(uint32_t index, const ItemPtr& item)
 		{
 			auto t_container = std::dynamic_pointer_cast<Container>(shared_from_this());
 			c_player->sendRemoveContainerItem(t_container, index);
+		}
+	}
+
+	for (auto spectator : spectators) {
+		if (const auto c_player = spectator->getPlayer())
+		{
+			auto t_container = std::dynamic_pointer_cast<Container>(shared_from_this());
 			c_player->onRemoveContainerItem(t_container, item);
 		}
 	}
@@ -705,17 +726,11 @@ void Container::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, in
 {
 	auto topParent = getTopParent();
 	if (topParent->getCreature()) {
-		std::cout << ":: Container :: TopParent is saying its a creature \n";
 		topParent->postRemoveNotification(thing, newParent, index, LINK_TOPPARENT);
 	} else if (topParent.get() == this) {
 		//let the tile class notify surrounding players
-		std::cout << ":: Container :: TopParent is saying its also container \n";
 		if (topParent->getParent()) {
-			std::cout << ":: Container :: TopParent found parent to send notification \n";
 			topParent->getParent()->postRemoveNotification(thing, newParent, index, LINK_NEAR);
-		}
-		else {
-			std::cout << ":: Container :: hitting that else print \n";
 		}
 	} else {
 		topParent->postRemoveNotification(thing, newParent, index, LINK_PARENT);

--- a/src/container.h
+++ b/src/container.h
@@ -147,7 +147,7 @@ class Container : public Item, public Cylinder
 		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t& maxQueryCount,
 				uint32_t flags)  override final;
 		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override final;
-		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 				uint32_t& flags) override final; // again optional ref wrapper
 
 		void addThing(ThingPtr thing) override final;

--- a/src/creature.h
+++ b/src/creature.h
@@ -52,6 +52,15 @@ class Npc;
 class Item;
 class Tile;
 
+using PlayerPtr = std::shared_ptr<Player>;
+using PlayerConstPtr = std::shared_ptr<const Player>;
+
+using MonsterPtr = std::shared_ptr<Monster>;
+using MonsterConstPtr = std::shared_ptr<const Monster>;
+
+using NpcPtr = std::shared_ptr<Npc>;
+using NpcConstPtr = std::shared_ptr<const Npc>;
+
 static constexpr int32_t EVENT_CREATURECOUNT = 10;
 static constexpr int32_t EVENT_CREATURE_THINK_INTERVAL = 1000;
 static constexpr int32_t EVENT_CHECK_CREATURE_INTERVAL = (EVENT_CREATURE_THINK_INTERVAL / EVENT_CREATURECOUNT);
@@ -75,7 +84,7 @@ class FrozenPathingConditionCall
 // Defines the Base class for all creatures and base functions which
 // every creature has
 
-class Creature : virtual public Thing
+class Creature : virtual public Thing, public SharedObject
 {
 	protected:
 		Creature();
@@ -89,37 +98,44 @@ class Creature : virtual public Thing
 		Creature(const Creature&) = delete;
 		Creature& operator=(const Creature&) = delete;
 
-		Creature* getCreature() override final {
-			return this;
+		CreaturePtr getCreature() override final {
+			return dynamic_shared_this<Creature>();
 		}
-		const Creature* getCreature() const override final {
-			return this;
+	
+		CreatureConstPtr getCreature() const override final {
+			return dynamic_shared_this<Creature>();
 		}
-		virtual Player* getPlayer() {
+	
+		virtual PlayerPtr getPlayer() {
 			return nullptr;
 		}
-		virtual const Player* getPlayer() const {
+	
+		virtual PlayerConstPtr getPlayer() const {
 			return nullptr;
 		}
-		virtual Npc* getNpc() {
+	
+		virtual NpcPtr getNpc() {
 			return nullptr;
 		}
-		virtual const Npc* getNpc() const {
+	
+		virtual NpcConstPtr getNpc() const {
 			return nullptr;
 		}
-		virtual Monster* getMonster() {
+	
+		virtual MonsterPtr getMonster() {
 			return nullptr;
 		}
-		virtual const Monster* getMonster() const {
+	
+		virtual MonsterConstPtr getMonster() const {
 			return nullptr;
 		}
 
 		virtual const std::string& getName() const = 0;
 		virtual const std::string& getNameDescription() const = 0;
-
+	
 		virtual CreatureType_t getType() const = 0;
-
 		virtual void setID() = 0;
+	
 		void setRemoved() {
 			isInternalRemoved = true;
 		}
@@ -127,25 +143,31 @@ class Creature : virtual public Thing
 		uint32_t getID() const {
 			return id;
 		}
+	
 		virtual void removeList() = 0;
 		virtual void addList() = 0;
 
 		virtual bool canSee(const Position& pos) const;
-		virtual bool canSeeCreature(const Creature* creature) const;
+		virtual bool canSeeCreature(const CreatureConstPtr& creature) const;
 
 		virtual RaceType_t getRace() const {
 			return RACE_NONE;
 		}
+	
 		virtual Skulls_t getSkull() const {
 			return skull;
 		}
-		virtual Skulls_t getSkullClient(const Creature* creature) const {
+	
+		virtual Skulls_t getSkullClient(const CreatureConstPtr& creature) const {
 			return creature->getSkull();
 		}
+	
 		void setSkull(Skulls_t newSkull);
+	
 		Direction getDirection() const {
 			return direction;
 		}
+	
 		void setDirection(Direction dir) {
 			direction = dir;
 		}
@@ -153,6 +175,7 @@ class Creature : virtual public Thing
 		bool isHealthHidden() const {
 			return hiddenHealth;
 		}
+	
 		void setHiddenHealth(bool b) {
 			hiddenHealth = b;
 		}
@@ -164,19 +187,24 @@ class Creature : virtual public Thing
 		int32_t getThrowRange() const override final {
 			return 1;
 		}
+	
 		bool isPushable() const override {
 			return getWalkDelay() <= 0;
 		}
+	
 		bool isRemoved() const override final {
 			return isInternalRemoved;
 		}
+	
 		virtual bool canSeeInvisibility() const {
 			return false;
 		}
+	
 		virtual bool isInGhostMode() const {
 			return false;
 		}
-		virtual bool canSeeGhostMode(const Creature*) const {
+	
+		virtual bool canSeeGhostMode(const CreatureConstPtr&) const {
 			return false;
 		}
 
@@ -187,12 +215,15 @@ class Creature : virtual public Thing
 		int64_t getEventStepTicks(bool onlyDelay = false) const;
 		int64_t getStepDuration(Direction dir) const;
 		int64_t getStepDuration() const;
+	
 		virtual int32_t getStepSpeed() const {
 			return getSpeed();
 		}
+	
 		int32_t getSpeed() const {
 			return baseSpeed + varSpeed;
 		}
+	
 		void setSpeed(int32_t varSpeedDelta) {
 			int32_t oldSpeed = getSpeed();
 			varSpeed = varSpeedDelta;
@@ -208,12 +239,15 @@ class Creature : virtual public Thing
 		void setBaseSpeed(uint32_t newBaseSpeed) {
 			baseSpeed = newBaseSpeed;
 		}
+	
 		uint32_t getBaseSpeed() const {
 			return baseSpeed;
 		}
+	
 		void setDodgeChance(uint8_t newDodgeChance) {
 			dodgeChance = newDodgeChance;
 		}
+	
 		uint8_t getDodgeChance() const {
 			return dodgeChance;
 		}
@@ -237,15 +271,19 @@ class Creature : virtual public Thing
 		int32_t getHealth() const {
 			return health;
 		}
+	
 		virtual int32_t getMaxHealth() const {
 			return healthMax;
 		}
+	
 		bool isDead() const {
 			return health <= 0;
 		}
+	
 		void setDrunkenness(uint8_t newDrunkenness) {
 			drunkenness = newDrunkenness;
 		}
+	
 		uint8_t getDrunkenness() const {
 			return drunkenness;
 		}
@@ -253,13 +291,17 @@ class Creature : virtual public Thing
 		const Outfit_t getCurrentOutfit() const {
 			return currentOutfit;
 		}
+	
 		void setCurrentOutfit(Outfit_t outfit) {
 			currentOutfit = outfit;
 		}
+	
 		const Outfit_t getDefaultOutfit() const {
 			return defaultOutfit;
 		}
+	
 		bool isInvisible() const;
+	
 		ZoneType_t getZone() const {
 			return getTile()->getZone();
 		}
@@ -278,52 +320,57 @@ class Creature : virtual public Thing
 		virtual void onWalkComplete() {}
 
 		//follow functions
-		Creature* getFollowCreature() const {
+		CreaturePtr getFollowCreature() const {
 			return followCreature;
 		}
-		virtual bool setFollowCreature(Creature* creature);
+	
+		virtual bool setFollowCreature(const CreaturePtr& creature);
 
 		//follow events
-		virtual void onFollowCreature(const Creature*) {}
-		virtual void onFollowCreatureComplete(const Creature*) {}
+		virtual void onFollowCreature(const CreatureConstPtr&) {}
+		virtual void onFollowCreatureComplete(const CreatureConstPtr&) {}
 
 		//combat functions
-		Creature* getAttackedCreature() {
+		CreaturePtr getAttackedCreature() {
 			return attackedCreature;
 		}
-		virtual bool setAttackedCreature(Creature* creature);
-		virtual BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
+		virtual bool setAttackedCreature(const CreaturePtr& creature);
+		virtual BlockType_t blockHit(const CreaturePtr& attacker, CombatType_t combatType, int32_t& damage,
 		                             bool checkDefense = false, bool checkArmor = false, bool field = false, bool ignoreResistances = false);
 
-		bool setMaster(Creature* newMaster);
+		bool setMaster(const CreaturePtr& newMaster);
 
 		void removeMaster() {
 			if (master) {
-				master = nullptr;
-				decrementReferenceCounter();
+				master.reset();
 			}
 		}
 
 		bool isSummon() const {
+			// could use an optional here
 			return master != nullptr;
 		}
-		Creature* getMaster() const {
+	
+		CreaturePtr getMaster() const {
 			return master;
 		}
 
-		const std::list<Creature*>& getSummons() const {
+		const std::list<CreaturePtr>& getSummons() const {
 			return summons;
 		}
 
 		virtual int32_t getArmor() const {
 			return 0;
 		}
+	
 		virtual int32_t getDefense() const {
 			return 0;
 		}
+	
 		virtual float getAttackFactor() const {
 			return 1.0f;
 		}
+	
 		virtual float getDefenseFactor() const {
 			return 1.0f;
 		}
@@ -345,32 +392,36 @@ class Creature : virtual public Thing
 		virtual bool isImmune(ConditionType_t type) const;
 		virtual bool isImmune(CombatType_t type) const;
 		virtual bool isSuppress(ConditionType_t type) const;
+	
 		virtual uint32_t getDamageImmunities() const {
 			return 0;
 		}
+	
 		virtual uint32_t getConditionImmunities() const {
 			return 0;
 		}
+	
 		virtual uint32_t getConditionSuppressions() const {
 			return 0;
 		}
+	
 		virtual bool isAttackable() const {
 			return true;
 		}
 
 		virtual void changeHealth(int32_t healthChange, bool sendHealthChange = true);
 
-		void gainHealth(Creature* healer, int32_t healthGain);
-		virtual void drainHealth(Creature* attacker, int32_t damage);
+		void gainHealth(const CreaturePtr& healer, int32_t healthGain);
+		virtual void drainHealth(const CreaturePtr& attacker, int32_t damage);
 
-		virtual bool challengeCreature(Creature*, bool) {
+		virtual bool challengeCreature(const CreaturePtr&, bool) {
 			return false;
 		}
 
-		CreatureVector getKillers();
+		CreatureVector getKillers() const;
 		void onDeath();
-		virtual uint64_t getGainedExperience(Creature* attacker) const;
-		void addDamagePoints(Creature* attacker, int32_t damagePoints);
+		virtual uint64_t getGainedExperience(const CreaturePtr& attacker) const;
+		void addDamagePoints(const CreaturePtr& attacker, int32_t damagePoints);
 		bool hasBeenAttacked(uint32_t attackerId);
 
 		//combat event functions
@@ -379,12 +430,12 @@ class Creature : virtual public Thing
 		virtual void onEndCondition(ConditionType_t type);
 		void onTickCondition(ConditionType_t type, bool& bRemove);
 		virtual void onCombatRemoveCondition(Condition* condition);
-		virtual void onAttackedCreature(Creature*, bool = true) {}
+		virtual void onAttackedCreature(const CreaturePtr&, bool = true) {}
 		virtual void onAttacked();
-		virtual void onAttackedCreatureDrainHealth(Creature* target, int32_t points);
-		virtual void onTargetCreatureGainHealth(Creature*, int32_t) {}
-		virtual bool onKilledCreature(Creature* target, bool lastHit = true);
-		virtual void onGainExperience(uint64_t gainExp, Creature* target);
+		virtual void onAttackedCreatureDrainHealth(const CreaturePtr& target, int32_t points);
+		virtual void onTargetCreatureGainHealth(const CreaturePtr&, int32_t) {}
+		virtual bool onKilledCreature(const CreaturePtr& target, bool lastHit = true);
+		virtual void onGainExperience(uint64_t gainExp, const CreaturePtr& target);
 		virtual void onAttackedCreatureBlockHit(BlockType_t) {}
 		virtual void onBlockHit() {}
 		virtual void onChangeZone(ZoneType_t zone);
@@ -400,22 +451,20 @@ class Creature : virtual public Thing
 		virtual void onWalk();
 		virtual bool getNextStep(Direction& dir, uint32_t& flags);
 
-		void onAddTileItem(const Tile* tile, const Position& pos);
-		virtual void onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem,
-		                              const ItemType& oldType, const Item* newItem, const ItemType& newType);
-		virtual void onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType,
-		                              const Item* item);
+		void onAddTileItem(TilePtr tile, const Position& pos);
+		virtual void onUpdateTileItem(const TilePtr& tile, const Position& pos, const ItemPtr& oldItem,
+		                              const ItemType& oldType, const ItemPtr& newItem, const ItemType& newType);
+		virtual void onRemoveTileItem(const TilePtr& tile, const Position& pos, const ItemType& iType,
+		                              const ItemPtr& item);
 
-		virtual void onCreatureAppear(Creature* creature, bool isLogin);
-		virtual void onRemoveCreature(Creature* creature, bool isLogout);
-		virtual void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos,
-		                            const Tile* oldTile, const Position& oldPos, bool teleport);
+		virtual void onCreatureAppear(const CreaturePtr& creature, bool isLogin);
+		virtual void onRemoveCreature(const CreaturePtr& creature, bool isLogout);
+		virtual void onCreatureMove(const CreaturePtr& creature, const TilePtr& newTile, const Position& newPos,
+		                            const TilePtr& oldTile, const Position& oldPos, bool teleport);
 
 		virtual void onAttackedCreatureDisappear(bool) {}
 		virtual void onFollowCreatureDisappear(bool) {}
-
-		virtual void onCreatureSay(Creature*, SpeakClasses, const std::string&) {}
-
+		virtual void onCreatureSay(const CreaturePtr&, SpeakClasses, const std::string&) {}
 		virtual void onPlacedCreature() {}
 
 		virtual bool getCombatValues(int32_t&, int32_t&) {
@@ -425,19 +474,24 @@ class Creature : virtual public Thing
 		size_t getSummonCount() const {
 			return summons.size();
 		}
+	
 		void setDropLoot(bool lootDrop) {
 			this->lootDrop = lootDrop;
 		}
+	
 		void setSkillLoss(bool skillLoss) {
 			this->skillLoss = skillLoss;
 		}
+	
 		void setUseDefense(bool useDefense) {
 			canUseDefense = useDefense;
 		}
+	
 		void setMovementBlocked(bool state) {
 			movementBlocked = state;
 			cancelNextWalk = true;
 		}
+	
 		bool isMovementBlocked() const {
 			return movementBlocked;
 		}
@@ -446,23 +500,43 @@ class Creature : virtual public Thing
 		bool registerCreatureEvent(const std::string& name);
 		bool unregisterCreatureEvent(const std::string& name);
 
-		Cylinder* getParent() const override final {
-			return tile;
+		CylinderPtr getParent() override final {
+			[[likely]] if (auto shared_ptr = tile.lock())
+			{
+				return shared_ptr;
+				// this was never casted;
+				// It is a TilePtr which is a derived class of CylinderPtr
+				// is it implicitly casted here?
+			}
+			[[unlikely]] return nullptr;
 		}
-		void setParent(Cylinder* cylinder) override final {
-			tile = static_cast<Tile*>(cylinder);
-			position = tile->getPosition();
+	
+		void setParent(std::weak_ptr<Cylinder> cylinder) override final {
+			if (const auto shared_ptr = cylinder.lock())
+			{
+				tile = shared_ptr->getTile();
+				position = shared_ptr->getPosition();
+			}
 		}
 
 		const Position& getPosition() const override final {
 			return position;
 		}
 
-		Tile* getTile() override final {
-			return tile;
+		TilePtr getTile() override final {
+			[[likely]] if (auto shared_ptr = tile.lock())
+			{
+				return shared_ptr;
+			}
+			[[unlikely]] return nullptr;
 		}
-		const Tile* getTile() const override final {
-			return tile;
+	
+		TileConstPtr getTile() const override final {
+			[[likely]] if (auto shared_ptr = tile.lock())
+			{
+				return shared_ptr;
+			}
+			[[unlikely]] return nullptr;
 		}
 
 		int32_t getWalkCache(const Position& pos) const;
@@ -470,25 +544,17 @@ class Creature : virtual public Thing
 		const Position& getLastPosition() const {
 			return lastPosition;
 		}
+	
 		void setLastPosition(Position newLastPos) {
 			lastPosition = newLastPos;
 		}
 
 		static bool canSee(const Position& myPos, const Position& pos, int32_t viewRangeX, int32_t viewRangeY);
 
-		double getDamageRatio(Creature* attacker) const;
+		double getDamageRatio(const CreaturePtr& attacker) const;
 
-		bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const FindPathParams& fpp) const;
-		bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, int32_t minTargetDist, int32_t maxTargetDist, bool fullPathSearch = true, bool clearSight = true, int32_t maxSearchDist = 0) const;
-
-		void incrementReferenceCounter() {
-			++referenceCounter;
-		}
-		void decrementReferenceCounter() {
-			if (--referenceCounter == 0) {
-				delete this;
-			}
-		}
+		bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, const FindPathParams& fpp);
+		bool getPathTo(const Position& targetPos, std::vector<Direction>& dirList, int32_t minTargetDist, int32_t maxTargetDist, bool fullPathSearch = true, bool clearSight = true, int32_t maxSearchDist = 0);
 
 	protected:
 		virtual bool useCacheMap() const {
@@ -510,19 +576,18 @@ class Creature : virtual public Thing
 		using CountMap = std::map<uint32_t, CountBlock_t>;
 		CountMap damageMap;
 
-		std::list<Creature*> summons;
+		std::list<CreaturePtr> summons;
 		CreatureEventList eventsList;
 		ConditionList conditions;
 
 		std::vector<Direction> listWalkDir;
 
-		Tile* tile = nullptr;
-		Creature* attackedCreature = nullptr;
-		Creature* master = nullptr;
-		Creature* followCreature = nullptr;
+		TileWeakPtr tile;
+		CreaturePtr attackedCreature = nullptr;
+		CreaturePtr master = nullptr;
+		CreaturePtr followCreature = nullptr;
 
 		uint64_t lastStep = 0;
-		uint32_t referenceCounter = 0;
 		uint32_t id = 0;
 		uint32_t scriptEventsBitField = 0;
 		uint32_t eventWalk = 0;
@@ -566,13 +631,15 @@ class Creature : virtual public Thing
 		bool hasEventRegistered(CreatureEventType_t event) const {
 			return (0 != (scriptEventsBitField & (static_cast<uint32_t>(1) << event)));
 		}
-		CreatureEventList getCreatureEvents(CreatureEventType_t type);
+	
+		CreatureEventList getCreatureEvents(CreatureEventType_t type) const;
 
 		void updateMapCache();
-		void updateTileCache(const Tile* tile, int32_t dx, int32_t dy);
-		void updateTileCache(const Tile* tile, const Position& pos);
-		void onCreatureDisappear(const Creature* creature, bool isLogout);
+		void updateTileCache(TilePtr tile, int32_t dx, int32_t dy);
+		void updateTileCache(TilePtr tile, const Position& pos);
+		void onCreatureDisappear(const CreatureConstPtr& creature, bool isLogout);
 		virtual void doAttacking(uint32_t) {}
+	
 		virtual bool hasExtraSwing() {
 			return false;
 		}
@@ -580,14 +647,17 @@ class Creature : virtual public Thing
 		virtual uint64_t getLostExperience() const {
 			return 0;
 		}
-		virtual void dropLoot(Container*, Creature*) {}
+	
+		virtual void dropLoot(const ContainerPtr& corpse, const CreaturePtr& lastHitKiller) {}
+	
 		virtual uint16_t getLookCorpse() const {
 			return 0;
 		}
-		virtual void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const;
-		virtual void death(Creature*) {}
-		virtual bool dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified);
-		virtual Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature);
+	
+		virtual void getPathSearchParams(const CreatureConstPtr& creature, FindPathParams& fpp) const;
+		virtual void death(const CreaturePtr&) {}
+		virtual bool dropCorpse(const CreaturePtr& lastHitCreature, const CreaturePtr& mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified);
+		virtual ItemPtr getCorpse(const CreaturePtr& lastHitCreature, const CreaturePtr& mostDamageCreature);
 
 		friend class Game;
 		friend class Map;

--- a/src/creature.h
+++ b/src/creature.h
@@ -11,7 +11,9 @@
 #include "tile.h"
 #include "enums.h"
 #include "creatureevent.h"
+#include "declarations.h"
 
+class Map;
 using ConditionList = std::list<Condition*>;
 using CreatureEventList = std::list<CreatureEvent*>;
 
@@ -42,24 +44,6 @@ struct FindPathParams {
 	int32_t minTargetDist = -1;
 	int32_t maxTargetDist = -1;
 };
-
-class Map;
-class Thing;
-class Container;
-class Player;
-class Monster;
-class Npc;
-class Item;
-class Tile;
-
-using PlayerPtr = std::shared_ptr<Player>;
-using PlayerConstPtr = std::shared_ptr<const Player>;
-
-using MonsterPtr = std::shared_ptr<Monster>;
-using MonsterConstPtr = std::shared_ptr<const Monster>;
-
-using NpcPtr = std::shared_ptr<Npc>;
-using NpcConstPtr = std::shared_ptr<const Npc>;
 
 static constexpr int32_t EVENT_CREATURECOUNT = 10;
 static constexpr int32_t EVENT_CREATURE_THINK_INTERVAL = 1000;

--- a/src/creature.h
+++ b/src/creature.h
@@ -488,9 +488,14 @@ class Creature : virtual public Thing, public SharedObject
 			[[likely]] if (auto shared_ptr = tile.lock())
 			{
 				return shared_ptr;
-				// this was never casted;
-				// It is a TilePtr which is a derived class of CylinderPtr
-				// is it implicitly casted here?
+			}
+			[[unlikely]] return nullptr;
+		}
+
+		CylinderConstPtr getParent() const override final {
+			[[likely]] if (auto shared_ptr = tile.lock())
+			{
+				return shared_ptr;
 			}
 			[[unlikely]] return nullptr;
 		}

--- a/src/creatureevent.h
+++ b/src/creatureevent.h
@@ -4,9 +4,9 @@
 #ifndef FS_CREATUREEVENT_H
 #define FS_CREATUREEVENT_H
 
-#include "luascript.h"
 #include "baseevents.h"
 #include "enums.h"
+#include "luascript.h"
 
 class CreatureEvent;
 using CreatureEvent_ptr = std::unique_ptr<CreatureEvent>;
@@ -54,21 +54,21 @@ class CreatureEvent final : public Event
 		}
 
 		void clearEvent();
-		void copyEvent(CreatureEvent* creatureEvent);
+		void copyEvent(const CreatureEvent_ptr& creatureEvent);
 
 		//scripting
-		bool executeOnLogin(Player* player) const;
-		bool executeOnLogout(Player* player) const;
-		bool executeOnThink(Creature* creature, uint32_t interval);
-		bool executeOnPrepareDeath(Creature* creature, Creature* killer);
-		bool executeOnDeath(Creature* creature, Item* corpse, Creature* killer, Creature* mostDamageKiller, bool lastHitUnjustified, bool mostDamageUnjustified);
-		void executeOnKill(Creature* creature, Creature* target);
-		bool executeAdvance(Player* player, skills_t, uint32_t, uint32_t);
-		void executeModalWindow(Player* player, uint32_t modalWindowId, uint8_t buttonId, uint8_t choiceId);
-		bool executeTextEdit(Player* player, Item* item, const std::string& text);
-		void executeHealthChange(Creature* creature, Creature* attacker, CombatDamage& damage);
-		void executeManaChange(Creature* creature, Creature* attacker, CombatDamage& damage);
-		void executeExtendedOpcode(Player* player, uint8_t opcode, const std::string& buffer);
+		bool executeOnLogin(const PlayerPtr& player) const;
+		bool executeOnLogout(const PlayerPtr& player) const;
+		bool executeOnThink(const CreaturePtr& creature, uint32_t interval) const;
+		bool executeOnPrepareDeath(const CreaturePtr& creature, const CreaturePtr& killer) const;
+		bool executeOnDeath(const CreaturePtr& creature, const ItemPtr& corpse, const CreaturePtr& killer, const CreaturePtr& mostDamageKiller, bool lastHitUnjustified, bool mostDamageUnjustified) const;
+		void executeOnKill(const CreaturePtr& creature, const CreaturePtr& target) const;
+		bool executeAdvance(const PlayerPtr& player, skills_t, uint32_t, uint32_t) const;
+		void executeModalWindow(const PlayerPtr& player, uint32_t modalWindowId, uint8_t buttonId, uint8_t choiceId) const;
+		bool executeTextEdit(const PlayerPtr& player, const ItemPtr& item, const std::string& text) const;
+		void executeHealthChange(const CreaturePtr& creature, const CreaturePtr& attacker, CombatDamage& damage) const;
+		void executeManaChange(const CreaturePtr& creature, const CreaturePtr& attacker, CombatDamage& damage) const;
+		void executeExtendedOpcode(const PlayerPtr& player, uint8_t opcode, const std::string& buffer) const;
 		//
 
 	private:
@@ -89,9 +89,9 @@ class CreatureEvents final : public BaseEvents
 		CreatureEvents& operator=(const CreatureEvents&) = delete;
 
 		// global events
-		bool playerLogin(Player* player) const;
-		bool playerLogout(Player* player) const;
-		bool playerAdvance(Player* player, skills_t, uint32_t, uint32_t);
+		bool playerLogin(const PlayerPtr& player) const;
+		bool playerLogout(const PlayerPtr& player) const;
+		bool playerAdvance(const PlayerPtr& player, skills_t, uint32_t, uint32_t);
 
 		CreatureEvent* getEventByName(const std::string& name, bool forceLoaded = true);
 

--- a/src/cylinder.cpp
+++ b/src/cylinder.cpp
@@ -5,9 +5,9 @@
 
 #include "cylinder.h"
 
-VirtualCylinder* VirtualCylinder::virtualCylinder = new VirtualCylinder;
+VirtualCylinderPtr VirtualCylinder::virtualCylinder = std::make_shared<VirtualCylinder>();
 
-int32_t Cylinder::getThingIndex(const Thing*) const
+int32_t Cylinder::getThingIndex(ThingPtr)
 {
 	return -1;
 }
@@ -32,17 +32,17 @@ std::map<uint32_t, uint32_t>& Cylinder::getAllItemTypeCount(std::map<uint32_t, u
 	return countMap;
 }
 
-Thing* Cylinder::getThing(size_t) const
+ThingPtr Cylinder::getThing(size_t)
 {
 	return nullptr;
 }
 
-void Cylinder::internalAddThing(Thing*)
+void Cylinder::internalAddThing(ThingPtr)
 {
 	//
 }
 
-void Cylinder::internalAddThing(uint32_t, Thing*)
+void Cylinder::internalAddThing(uint32_t, ThingPtr)
 {
 	//
 }

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -7,9 +7,6 @@
 #include "enums.h"
 #include "thing.h"
 
-class Item;
-class Creature;
-
 static constexpr int32_t INDEX_WHEREEVER = -1;
 
 enum cylinderflags_t {
@@ -44,8 +41,8 @@ class Cylinder : virtual public Thing
 		  * \param actor the creature trying to add the thing
 		  * \returns ReturnValue holds the return value
 		  */
-		virtual ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const = 0;
+		virtual ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                             uint32_t flags, CreaturePtr actor = nullptr) = 0;
 
 		/**
 		  * Query the cylinder how much it can accept
@@ -57,8 +54,8 @@ class Cylinder : virtual public Thing
 		  * \param flags optional flags to modify the default behaviour
 		  * \returns ReturnValue holds the return value
 		  */
-		virtual ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-				uint32_t flags) const = 0;
+		virtual ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t& maxQueryCount,
+				uint32_t flags) = 0;
 
 		/**
 		  * Query if the cylinder can remove an object
@@ -67,7 +64,7 @@ class Cylinder : virtual public Thing
 		  * \param flags optional flags to modify the default behaviour
 		  * \returns ReturnValue holds the return value
 		  */
-		virtual ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* = nullptr) const = 0;
+		virtual ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr = nullptr) = 0;
 
 		/**
 		  * Query the destination cylinder
@@ -79,21 +76,21 @@ class Cylinder : virtual public Thing
 			* this method can modify the flags
 		  * \returns Cylinder returns the destination cylinder
 		  */
-		virtual Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
+		virtual CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem, // maybe make optional here?
 				uint32_t& flags) = 0;
 
 		/**
 		  * Add the object to the cylinder
 		  * \param thing is the object to add
 		  */
-		virtual void addThing(Thing* thing) = 0;
+		virtual void addThing(ThingPtr thing) = 0;
 
 		/**
 		  * Add the object to the cylinder
 		  * \param index points to the destination index (inventory slot/container position)
 		  * \param thing is the object to add
 		  */
-		virtual void addThing(int32_t index, Thing* thing) = 0;
+		virtual void addThing(int32_t index, ThingPtr thing) = 0;
 
 		/**
 		  * Update the item count or type for an object
@@ -101,21 +98,21 @@ class Cylinder : virtual public Thing
 		  * \param itemId is the new item id
 		  * \param count is the new count value
 		  */
-		virtual void updateThing(Thing* thing, uint16_t itemId, uint32_t count) = 0;
+		virtual void updateThing(ThingPtr thing, uint16_t itemId, uint32_t count) = 0;
 
 		/**
 		  * Replace an object with a new
 		  * \param index is the position to change (inventory slot/container position)
 		  * \param thing is the object to update
 		  */
-		virtual void replaceThing(uint32_t index, Thing* thing) = 0;
+		virtual void replaceThing(uint32_t index, ThingPtr thing) = 0;
 
 		/**
 		  * Remove an object
 		  * \param thing is the object to delete
 		  * \param count is the new count value
 		  */
-		virtual void removeThing(Thing* thing, uint32_t count) = 0;
+		virtual void removeThing(ThingPtr thing, uint32_t count) = 0;
 
 		/**
 		  * Is sent after an operation (move/add) to update internal values
@@ -123,7 +120,7 @@ class Cylinder : virtual public Thing
 		  * \param index is the objects new index value
 		  * \param link holds the relation the object has to the cylinder
 		  */
-		virtual void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) = 0;
+		virtual void postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) = 0;
 
 		/**
 		  * Is sent after an operation (move/remove) to update internal values
@@ -131,14 +128,14 @@ class Cylinder : virtual public Thing
 		  * \param index is the previous index of the removed object
 		  * \param link holds the relation the object has to the cylinder
 		  */
-		virtual void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) = 0;
+		virtual void postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) = 0;
 
 		/**
 		  * Gets the index of an object
 		  * \param thing the object to get the index value from
 		  * \returns the index of the object, returns -1 if not found
 		  */
-		virtual int32_t getThingIndex(const Thing* thing) const;
+		virtual int32_t getThingIndex(ThingPtr thing);
 
 		/**
 		  * Returns the first index
@@ -156,7 +153,7 @@ class Cylinder : virtual public Thing
 		  * Gets the object based on index
 		  * \returns the object, returns nullptr if not found
 		  */
-		virtual Thing* getThing(size_t index) const;
+		virtual ThingPtr getThing(size_t index);
 
 		/**
 		  * Get the amount of items of a certain type
@@ -177,57 +174,69 @@ class Cylinder : virtual public Thing
 		  * Adds an object to the cylinder without sending to the client(s)
 		  * \param thing is the object to add
 		  */
-		virtual void internalAddThing(Thing* thing);
+		virtual void internalAddThing(ThingPtr thing);
 
 		/**
 		  * Adds an object to the cylinder without sending to the client(s)
 		  * \param thing is the object to add
 		  * \param index points to the destination index (inventory slot/container position)
 		  */
-		virtual void internalAddThing(uint32_t index, Thing* thing);
+		virtual void internalAddThing(uint32_t index, ThingPtr thing);
 
 		virtual void startDecaying();
 };
 
+class VirtualCylinder;
+using VirtualCylinderPtr = std::shared_ptr<VirtualCylinder>;
+using VirtualCylinderConstPtr = std::shared_ptr<const VirtualCylinder>;
+
 class VirtualCylinder final : public Cylinder
 {
 	public:
-		static VirtualCylinder* virtualCylinder;
+		static VirtualCylinderPtr virtualCylinder;
 
-		virtual ReturnValue queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature* = nullptr) const override {
+		virtual ReturnValue queryAdd(int32_t, const ThingPtr&, uint32_t, uint32_t, CreaturePtr = nullptr) override {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
-		virtual ReturnValue queryMaxCount(int32_t, const Thing&, uint32_t, uint32_t&, uint32_t) const override {
+	
+		virtual ReturnValue queryMaxCount(int32_t, const ThingPtr&, uint32_t, uint32_t&, uint32_t) override {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
-		virtual ReturnValue queryRemove(const Thing&, uint32_t, uint32_t, Creature* = nullptr) const override {
+	
+		virtual ReturnValue queryRemove(const ThingPtr&, uint32_t, uint32_t, CreaturePtr = nullptr ) override {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
-		virtual Cylinder* queryDestination(int32_t&, const Thing&, Item**, uint32_t&) override {
+	
+		virtual CylinderPtr queryDestination(int32_t&, const ThingPtr&, ItemPtr*, uint32_t&) override {
 			return nullptr;
 		}
 
-		virtual void addThing(Thing*) override {}
-		virtual void addThing(int32_t, Thing*) override {}
-		virtual void updateThing(Thing*, uint16_t, uint32_t) override {}
-		virtual void replaceThing(uint32_t, Thing*) override {}
-		virtual void removeThing(Thing*, uint32_t) override {}
+		virtual void addThing(ThingPtr) override {}
+		virtual void addThing(int32_t, ThingPtr) override {}
+		virtual void updateThing(ThingPtr, uint16_t, uint32_t) override {}
+		virtual void replaceThing(uint32_t, ThingPtr) override {}
+		virtual void removeThing(ThingPtr, uint32_t) override {}
 
-		virtual void postAddNotification(Thing*, const Cylinder*, int32_t, cylinderlink_t = LINK_OWNER) override {}
-		virtual void postRemoveNotification(Thing*, const Cylinder*, int32_t, cylinderlink_t = LINK_OWNER) override {}
+		virtual void postAddNotification(ThingPtr,  CylinderPtr, int32_t, cylinderlink_t = LINK_OWNER) override {}
+		virtual void postRemoveNotification(ThingPtr,  CylinderPtr, int32_t, cylinderlink_t = LINK_OWNER) override {}
 
 		bool isPushable() const override {
 			return false;
 		}
+	
 		int32_t getThrowRange() const override {
 			return 1;
 		}
+	
 		std::string getDescription(int32_t) const override {
 			return {};
 		}
+	
 		bool isRemoved() const override {
 			return false;
 		}
 };
+
+
 
 #endif

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -76,7 +76,7 @@ class Cylinder : virtual public Thing
 			* this method can modify the flags
 		  * \returns Cylinder returns the destination cylinder
 		  */
-		virtual CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem, // maybe make optional here?
+		virtual CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem, // maybe make optional here?
 				uint32_t& flags) = 0;
 
 		/**
@@ -207,7 +207,7 @@ class VirtualCylinder final : public Cylinder
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 	
-		virtual CylinderPtr queryDestination(int32_t&, const ThingPtr&, ItemPtr*, uint32_t&) override {
+		virtual CylinderPtr queryDestination(int32_t&, const ThingPtr&, ItemPtr&, uint32_t&) override {
 			return nullptr;
 		}
 

--- a/src/damagemodifier.h
+++ b/src/damagemodifier.h
@@ -144,7 +144,7 @@ public:
 	DamageModifier(const DamageModifier&) = default;
 	DamageModifier& operator=(const DamageModifier&) = default;
 
-	DamageModifier(uint8_t stance, uint8_t modType, uint16_t amount, ModFactor factorType, uint8_t chance, CombatType_t combatType = COMBAT_NONE , CombatOrigin source = ORIGIN_NONE, CreatureType_t creatureType = CREATURETYPE_ATTACKABLE,  RaceType_t race = RACE_NONE, std::string creatureName = "none") :
+	DamageModifier(uint8_t stance, uint8_t modType, uint16_t amount, ModFactor factorType, uint8_t chance, CombatType_t combatType = COMBAT_NONE , CombatOrigin source = ORIGIN_NONE, CreatureType_t creatureType = CREATURETYPE_ATTACKABLE,  RaceType_t race = RACE_NONE, const std::string& creatureName = "none") :
 		m_mod_stance(stance),					// attack / defense
 		m_mod_type(modType),					// the enum specific type
 		m_value(amount),						// value to modify; default = percent

--- a/src/declarations.h
+++ b/src/declarations.h
@@ -1,0 +1,88 @@
+#ifndef BT_DECLARATIONS_H
+#define BT_DECLARATIONS_H
+#include <memory>
+#include <vector>
+
+
+class Thing;
+using ThingPtr = std::shared_ptr<class Thing>;
+using ThingConstPtr = std::shared_ptr<const Thing>;
+
+class Creature;
+using CreaturePtr = std::shared_ptr<Creature>;
+using CreatureConstPtr = std::shared_ptr<const Creature>;
+
+class Player;
+using PlayerPtr = std::shared_ptr<Player>;
+using PlayerConstPtr = std::shared_ptr<const Player>;
+
+class Monster;
+using MonsterPtr = std::shared_ptr<Monster>;
+using MonsterConstPtr = std::shared_ptr<const Monster>;
+
+class Npc;
+using NpcPtr = std::shared_ptr<Npc>;
+using NpcConstPtr = std::shared_ptr<const Npc>;
+
+class Tile;
+using TilePtr = std::shared_ptr<Tile>;
+using TileConstPtr = std::shared_ptr<const Tile>;
+using TileWeakPtr = std::weak_ptr<Tile>;
+
+class Cylinder;
+using CylinderPtr = std::shared_ptr<Cylinder>;
+using CylinderConstPtr = std::shared_ptr<const Cylinder>;
+using CylinderWeakPtr = std::weak_ptr<Cylinder>;
+
+class Item;
+using ItemPtr = std::shared_ptr<Item>;
+using ItemConstPtr = std::shared_ptr<const Item>;
+
+class Container;
+using ContainerPtr = std::shared_ptr<Container>;
+using ContainerConstPtr = std::shared_ptr<const Container>;
+
+class Depot;
+using DepotPtr = std::shared_ptr<Depot>;
+using DepotConstPtr = std::shared_ptr<const Depot>;
+
+class Teleport;
+using TeleportPtr = std::shared_ptr<Teleport>;
+using TeleportConstPtr = std::shared_ptr<const Teleport>;
+
+class TrashHolder;
+using TrashHolderPtr = std::shared_ptr<TrashHolder>;
+using TrashHolderConstPtr = std::shared_ptr<const TrashHolder>;
+
+class Mailbox;
+using MailboxPtr = std::shared_ptr<Mailbox>;
+using MailboxConstPtr = std::shared_ptr<const Mailbox>;
+
+class Door;
+using DoorPtr = std::shared_ptr<Door>;
+using DoorConstPtr = std::shared_ptr<const Door>;
+
+class MagicField;
+using MagicFieldPtr = std::shared_ptr<MagicField>;
+using MagicFieldConstPtr = std::shared_ptr<const MagicField>;
+
+class BedItem;
+using BedItemPtr = std::shared_ptr<BedItem>;
+using BedItemConstPtr = std::shared_ptr<const BedItem>;
+
+class HouseTile;
+using HouseTilePtr = std::shared_ptr<HouseTile>;
+using HouseTileConstPtr = std::shared_ptr<const HouseTile>;
+
+
+/// Object Containers
+class TileItemVector;
+using CreatureVector = std::vector<CreaturePtr>;
+using ItemVector = std::vector<ItemPtr>;
+using TileItemsPtr = std::shared_ptr<TileItemVector>;
+using TileItemsConstPtr = std::shared_ptr<const TileItemVector>;
+using TileCreaturesPtr = std::shared_ptr<CreatureVector>;
+using TileCreaturesConstPtr = std::shared_ptr<const CreatureVector>;
+
+
+#endif

--- a/src/depotchest.cpp
+++ b/src/depotchest.cpp
@@ -9,10 +9,10 @@
 DepotChest::DepotChest(uint16_t type, bool paginated /*= true*/) :
 	Container{ type, items[type].maxItems, true, paginated } {}
 
-ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t count,
-		uint32_t flags, Creature* actor/* = nullptr*/) const
+ReturnValue DepotChest::queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+                                 uint32_t flags, CreaturePtr actor/* = nullptr*/)
 {
-	const Item* item = thing.getItem();
+	auto item = thing->getItem();
 	if (item == nullptr) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -25,8 +25,8 @@ ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t cou
 			addCount = 1;
 		}
 
-		if (item->getTopParent() != this) {
-			if (const Container* container = item->getContainer()) {
+		if (item->getTopParent().get() != this) {
+			if (const auto container = item->getContainer()) {
 				addCount = container->getItemHoldingCount() + 1;
 			} else {
 				addCount = 1;
@@ -41,26 +41,24 @@ ReturnValue DepotChest::queryAdd(int32_t index, const Thing& thing, uint32_t cou
 	return Container::queryAdd(index, thing, count, flags, actor);
 }
 
-void DepotChest::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)
+void DepotChest::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t)
 {
-	Cylinder* parent = getParent();
-	if (parent != nullptr) {
-		parent->postAddNotification(thing, oldParent, index, LINK_PARENT);
+	if (getParent()) {
+		getParent()->postAddNotification(thing, oldParent, index, LINK_PARENT);
 	}
 }
 
-void DepotChest::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t)
+void DepotChest::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t)
 {
-	Cylinder* parent = getParent();
-	if (parent != nullptr) {
-		parent->postRemoveNotification(thing, newParent, index, LINK_PARENT);
+	if (getParent()) {
+		getParent()->postRemoveNotification(thing, newParent, index, LINK_PARENT);
 	}
 }
 
-Cylinder* DepotChest::getParent() const
+CylinderPtr DepotChest::getParent()
 {
-	if (parent) {
-		return parent->getParent();
+	if (parent.lock()) {
+		return parent.lock()->getParent();
 	}
 	return nullptr;
 }

--- a/src/depotchest.h
+++ b/src/depotchest.h
@@ -17,25 +17,29 @@ class DepotChest final : public Container
 		}
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                     uint32_t flags, CreaturePtr actor = nullptr) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 		//overrides
 		bool canRemove() const override {
 			return false;
 		}
 
-		Cylinder* getParent() const override;
-		Cylinder* getRealParent() const override {
-			return parent;
+		CylinderPtr getParent() override;
+	
+		CylinderPtr getRealParent() override {
+			return parent.lock();
 		}
 
 	private:
 		uint32_t maxDepotItems = 0;
 };
+
+using DepotChestPtr = std::shared_ptr<DepotChest>;
+using DepotChestConstPtr = std::shared_ptr<const DepotChest>;
 
 #endif
 

--- a/src/depotlocker.cpp
+++ b/src/depotlocker.cpp
@@ -19,28 +19,28 @@ Attr_ReadValue DepotLocker::readAttr(AttrTypes_t attr, PropStream& propStream)
 	return Item::readAttr(attr, propStream);
 }
 
-ReturnValue DepotLocker::queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature*) const
+ReturnValue DepotLocker::queryAdd(int32_t, const ThingPtr&, uint32_t, uint32_t, CreaturePtr)
 {
 	return RETURNVALUE_NOTENOUGHROOM;
 }
 
-void DepotLocker::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)
+void DepotLocker::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t)
 {
-	if (parent != nullptr) {
-		parent->postAddNotification(thing, oldParent, index, LINK_PARENT);
+	if (getParent()) {
+		getParent()->postAddNotification(thing, oldParent, index, LINK_PARENT);
 	}
 }
 
-void DepotLocker::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t)
+void DepotLocker::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t)
 {
-	if (parent != nullptr) {
-		parent->postRemoveNotification(thing, newParent, index, LINK_PARENT);
+	if (getParent()) {
+		getParent()->postRemoveNotification(thing, newParent, index, LINK_PARENT);
 	}
 }
 
-void DepotLocker::removeInbox(Inbox* inbox)
+void DepotLocker::removeInbox(const InboxPtr& inbox)
 {
-	auto cit = std::find(itemlist.begin(), itemlist.end(), inbox);
+	auto cit = std::ranges::find(itemlist, inbox);
 	if (cit == itemlist.end()) {
 		return;
 	}

--- a/src/depotlocker.h
+++ b/src/depotlocker.h
@@ -7,21 +7,20 @@
 #include "container.h"
 #include "inbox.h"
 
-using DepotLocker_ptr = std::shared_ptr<DepotLocker>;
-
 class DepotLocker final : public Container
 {
 	public:
 		explicit DepotLocker(uint16_t type);
 
-		DepotLocker* getDepotLocker() override {
-			return this;
+		DepotLockerPtr getDepotLocker() override {
+			return dynamic_shared_this<DepotLocker>();
 		}
-		const DepotLocker* getDepotLocker() const override {
-			return this;
+	
+		DepotLockerConstPtr getDepotLocker() const override {
+			return dynamic_shared_this<const DepotLocker>();
 		}
 
-		void removeInbox(Inbox* inbox);
+		void removeInbox(const InboxPtr& inbox);
 
 		//serialization
 		Attr_ReadValue readAttr(AttrTypes_t attr, PropStream& propStream) override;
@@ -29,16 +28,17 @@ class DepotLocker final : public Container
 		uint16_t getDepotId() const {
 			return depotId;
 		}
+	
 		void setDepotId(uint16_t depotId) {
 			this->depotId = depotId;
 		}
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                     uint32_t flags, CreaturePtr actor = nullptr) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 		bool canRemove() const override {
 			return false;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -159,7 +159,7 @@ bool Events::load()
 }
 
 // Monster
-bool Events::eventMonsterOnSpawn(Monster* monster, const Position& position, bool startup, bool artificial)
+bool Events::eventMonsterOnSpawn(const MonsterPtr& monster, const Position& position, bool startup, bool artificial)
 {
 	// Monster:onSpawn(position, startup, artificial)
 	if (info.monsterOnSpawn == -1) {
@@ -177,7 +177,7 @@ bool Events::eventMonsterOnSpawn(Monster* monster, const Position& position, boo
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.monsterOnSpawn);
 
-	LuaScriptInterface::pushUserdata<Monster>(L, monster);
+	LuaScriptInterface::pushSharedPtr(L, monster);
 	LuaScriptInterface::setMetatable(L, -1, "Monster");
 	LuaScriptInterface::pushPosition(L, position);
 	LuaScriptInterface::pushBoolean(L, startup);
@@ -187,7 +187,7 @@ bool Events::eventMonsterOnSpawn(Monster* monster, const Position& position, boo
 }
 
 // Creature
-bool Events::eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& outfit)
+bool Events::eventCreatureOnChangeOutfit(const CreaturePtr& creature, const Outfit_t& outfit)
 {
 	// Creature:onChangeOutfit(outfit) or Creature.onChangeOutfit(self, outfit)
 	if (info.creatureOnChangeOutfit == -1) {
@@ -205,7 +205,7 @@ bool Events::eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& out
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.creatureOnChangeOutfit);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
 	LuaScriptInterface::pushOutfit(L, outfit);
@@ -213,7 +213,7 @@ bool Events::eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& out
 	return scriptInterface.callFunction(2);
 }
 
-ReturnValue Events::eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bool aggressive)
+ReturnValue Events::eventCreatureOnAreaCombat(const CreaturePtr& creature, const TilePtr& tile, bool aggressive)
 {
 	// Creature:onAreaCombat(tile, aggressive) or Creature.onAreaCombat(self, tile, aggressive)
 	if (info.creatureOnAreaCombat == -1) {
@@ -232,13 +232,13 @@ ReturnValue Events::eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bo
 	scriptInterface.pushFunction(info.creatureOnAreaCombat);
 
 	if (creature) {
-		LuaScriptInterface::pushUserdata<Creature>(L, creature);
+		LuaScriptInterface::pushSharedPtr(L, creature);
 		LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 	} else {
 		lua_pushnil(L);
 	}
 
-	LuaScriptInterface::pushUserdata<Tile>(L, tile);
+	LuaScriptInterface::pushSharedPtr(L, tile);
 	LuaScriptInterface::setMetatable(L, -1, "Tile");
 
 	LuaScriptInterface::pushBoolean(L, aggressive);
@@ -256,7 +256,7 @@ ReturnValue Events::eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bo
 	return returnValue;
 }
 
-ReturnValue Events::eventCreatureOnTargetCombat(Creature* creature, Creature* target)
+ReturnValue Events::eventCreatureOnTargetCombat(const CreaturePtr& creature, const CreaturePtr& target)
 {
 	// Creature:onTargetCombat(target) or Creature.onTargetCombat(self, target)
 	if (info.creatureOnTargetCombat == -1) {
@@ -275,13 +275,13 @@ ReturnValue Events::eventCreatureOnTargetCombat(Creature* creature, Creature* ta
 	scriptInterface.pushFunction(info.creatureOnTargetCombat);
 
 	if (creature) {
-		LuaScriptInterface::pushUserdata<Creature>(L, creature);
+		LuaScriptInterface::pushSharedPtr(L, creature);
 		LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 	} else {
 		lua_pushnil(L);
 	}
 
-	LuaScriptInterface::pushUserdata<Creature>(L, target);
+	LuaScriptInterface::pushSharedPtr(L, target);
 	LuaScriptInterface::setCreatureMetatable(L, -1, target);
 
 	ReturnValue returnValue;
@@ -297,7 +297,7 @@ ReturnValue Events::eventCreatureOnTargetCombat(Creature* creature, Creature* ta
 	return returnValue;
 }
 
-void Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type)
+void Events::eventCreatureOnHear(const CreaturePtr& creature, const CreaturePtr& speaker, const std::string& words, SpeakClasses type)
 {
 	// Creature:onHear(speaker, words, type)
 	if (info.creatureOnHear == -1) {
@@ -315,10 +315,10 @@ void Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const st
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.creatureOnHear);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, speaker);
+	LuaScriptInterface::pushSharedPtr(L, speaker);
 	LuaScriptInterface::setCreatureMetatable(L, -1, speaker);
 
 	LuaScriptInterface::pushString(L, words);
@@ -327,7 +327,7 @@ void Events::eventCreatureOnHear(Creature* creature, Creature* speaker, const st
 	scriptInterface.callVoidFunction(4);
 }
 
-void Events::eventCreatureOnAttack(Creature* attacker, Creature* target, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage, bool leechedDamage)
+void Events::eventCreatureOnAttack(const CreaturePtr& attacker, const CreaturePtr& target, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage, bool leechedDamage)
 {
 	// Creature:onAttack(target, blockType, combatType, origin, criticalHit, leechedDamage)
 	if (info.creatureOnAttack == -1) {
@@ -345,10 +345,10 @@ void Events::eventCreatureOnAttack(Creature* attacker, Creature* target, BlockTy
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.creatureOnAttack);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, attacker);
+	LuaScriptInterface::pushSharedPtr(L, attacker);
 	LuaScriptInterface::setCreatureMetatable(L, -1, attacker);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, target);
+	LuaScriptInterface::pushSharedPtr(L, target);
 	LuaScriptInterface::setCreatureMetatable(L, -1, target);
 
 	lua_pushinteger(L, static_cast<uint8_t>(blockType));
@@ -361,7 +361,7 @@ void Events::eventCreatureOnAttack(Creature* attacker, Creature* target, BlockTy
 	scriptInterface.callVoidFunction(7);
 }
 
-void Events::eventCreatureOnDefend(Creature* defender, Creature* attacker, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage, bool leechedDamage)
+void Events::eventCreatureOnDefend(const CreaturePtr& defender, const CreaturePtr& attacker, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage, bool leechedDamage)
 {
 	// Creature:onDefend(attacker, blockType, combatType, origin, criticalHit, leechedDamage)
 	if (info.creatureOnDefend == -1) {
@@ -379,10 +379,10 @@ void Events::eventCreatureOnDefend(Creature* defender, Creature* attacker, Block
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.creatureOnDefend);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, defender);
+	LuaScriptInterface::pushSharedPtr(L, defender);
 	LuaScriptInterface::setCreatureMetatable(L, -1, defender);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, attacker);
+	LuaScriptInterface::pushSharedPtr(L, attacker);
 	LuaScriptInterface::setCreatureMetatable(L, -1, attacker);
 
 	lua_pushinteger(L, static_cast<uint8_t>(blockType));
@@ -396,7 +396,7 @@ void Events::eventCreatureOnDefend(Creature* defender, Creature* attacker, Block
 }
 
 // Party
-bool Events::eventPartyOnJoin(Party* party, Player* player)
+bool Events::eventPartyOnJoin(Party* party, const PlayerPtr& player)
 {
 	// Party:onJoin(player) or Party.onJoin(self, player)
 	if (info.partyOnJoin == -1) {
@@ -417,13 +417,13 @@ bool Events::eventPartyOnJoin(Party* party, Player* player)
 	LuaScriptInterface::pushUserdata<Party>(L, party);
 	LuaScriptInterface::setMetatable(L, -1, "Party");
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
 }
 
-bool Events::eventPartyOnLeave(Party* party, Player* player)
+bool Events::eventPartyOnLeave(Party* party, const PlayerPtr& player)
 {
 	// Party:onLeave(player) or Party.onLeave(self, player)
 	if (info.partyOnLeave == -1) {
@@ -444,7 +444,7 @@ bool Events::eventPartyOnLeave(Party* party, Player* player)
 	LuaScriptInterface::pushUserdata<Party>(L, party);
 	LuaScriptInterface::setMetatable(L, -1, "Party");
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
@@ -507,7 +507,7 @@ void Events::eventPartyOnShareExperience(Party* party, uint64_t& exp)
 	scriptInterface.resetScriptEnv();
 }
 
-bool Events::eventPartyOnInvite(Party* party, Player* player)
+bool Events::eventPartyOnInvite(Party* party, const PlayerPtr& player)
 {
 	// Party:onInvite(player) or Party.onInvite(self, player)
 	if (info.partyOnInvite == -1) {
@@ -528,13 +528,13 @@ bool Events::eventPartyOnInvite(Party* party, Player* player)
 	LuaScriptInterface::pushUserdata<Party>(L, party);
 	LuaScriptInterface::setMetatable(L, -1, "Party");
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
 }
 
-bool Events::eventPartyOnRevokeInvitation(Party* party, Player* player)
+bool Events::eventPartyOnRevokeInvitation(Party* party, const PlayerPtr& player)
 {
 	// Party:onRevokeInvitation(player) or Party.onRevokeInvitation(self, player)
 	if (info.partyOnRevokeInvitation == -1) {
@@ -555,13 +555,13 @@ bool Events::eventPartyOnRevokeInvitation(Party* party, Player* player)
 	LuaScriptInterface::pushUserdata<Party>(L, party);
 	LuaScriptInterface::setMetatable(L, -1, "Party");
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
 }
 
-bool Events::eventPartyOnPassLeadership(Party* party, Player* player)
+bool Events::eventPartyOnPassLeadership(Party* party, const PlayerPtr& player)
 {
 	// Party:onPassLeadership(player) or Party.onPassLeadership(self, player)
 	if (info.partyOnPassLeadership == -1) {
@@ -582,14 +582,14 @@ bool Events::eventPartyOnPassLeadership(Party* party, Player* player)
 	LuaScriptInterface::pushUserdata<Party>(L, party);
 	LuaScriptInterface::setMetatable(L, -1, "Party");
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	return scriptInterface.callFunction(2);
 }
 
 // Player
-bool Events::eventPlayerOnBrowseField(Player* player, const Position& position)
+bool Events::eventPlayerOnBrowseField(const PlayerPtr& player, const Position& position)
 {
 	// Player:onBrowseField(position) or Player.onBrowseField(self, position)
 	if (info.playerOnBrowseField == -1) {
@@ -607,7 +607,7 @@ bool Events::eventPlayerOnBrowseField(Player* player, const Position& position)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnBrowseField);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	LuaScriptInterface::pushPosition(L, position);
@@ -615,7 +615,7 @@ bool Events::eventPlayerOnBrowseField(Player* player, const Position& position)
 	return scriptInterface.callFunction(2);
 }
 
-void Events::eventPlayerOnLook(Player* player, const Position& position, Thing* thing, uint8_t stackpos, int32_t lookDistance)
+void Events::eventPlayerOnLook(const PlayerPtr& player, const Position& position, const ThingPtr& thing, uint8_t stackpos, int32_t lookDistance)
 {
 	// Player:onLook(thing, position, distance) or Player.onLook(self, thing, position, distance)
 	if (info.playerOnLook == -1) {
@@ -633,14 +633,14 @@ void Events::eventPlayerOnLook(Player* player, const Position& position, Thing* 
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnLook);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	if (Creature* creature = thing->getCreature()) {
-		LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	if (auto creature = thing->getCreature()) {
+		LuaScriptInterface::pushSharedPtr(L, creature);
 		LuaScriptInterface::setCreatureMetatable(L, -1, creature);
-	} else if (Item* item = thing->getItem()) {
-		LuaScriptInterface::pushUserdata<Item>(L, item);
+	} else if (auto item = thing->getItem()) {
+		LuaScriptInterface::pushSharedPtr(L, item);
 		LuaScriptInterface::setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -652,7 +652,7 @@ void Events::eventPlayerOnLook(Player* player, const Position& position, Thing* 
 	scriptInterface.callVoidFunction(4);
 }
 
-void Events::eventPlayerOnLookInBattleList(Player* player, Creature* creature, int32_t lookDistance)
+void Events::eventPlayerOnLookInBattleList(const PlayerPtr& player, const CreaturePtr& creature, int32_t lookDistance)
 {
 	// Player:onLookInBattleList(creature, position, distance) or Player.onLookInBattleList(self, creature, position, distance)
 	if (info.playerOnLookInBattleList == -1) {
@@ -670,10 +670,10 @@ void Events::eventPlayerOnLookInBattleList(Player* player, Creature* creature, i
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnLookInBattleList);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
 	lua_pushinteger(L, lookDistance);
@@ -681,7 +681,7 @@ void Events::eventPlayerOnLookInBattleList(Player* player, Creature* creature, i
 	scriptInterface.callVoidFunction(3);
 }
 
-void Events::eventPlayerOnLookInTrade(Player* player, Player* partner, Item* item, int32_t lookDistance)
+void Events::eventPlayerOnLookInTrade(const PlayerPtr& player, const PlayerPtr& partner, const ItemPtr& item, int32_t lookDistance)
 {
 	// Player:onLookInTrade(partner, item, distance) or Player.onLookInTrade(self, partner, item, distance)
 	if (info.playerOnLookInTrade == -1) {
@@ -699,13 +699,13 @@ void Events::eventPlayerOnLookInTrade(Player* player, Player* partner, Item* ite
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnLookInTrade);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Player>(L, partner);
+	LuaScriptInterface::pushSharedPtr(L, partner);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	lua_pushinteger(L, lookDistance);
@@ -713,7 +713,7 @@ void Events::eventPlayerOnLookInTrade(Player* player, Player* partner, Item* ite
 	scriptInterface.callVoidFunction(4);
 }
 
-bool Events::eventPlayerOnLookInShop(Player* player, const ItemType* itemType, uint8_t count, const std::string& description)
+bool Events::eventPlayerOnLookInShop(const PlayerPtr& player, const ItemType* itemType, uint8_t count, const std::string& description)
 {
 	// Player:onLookInShop(itemType, count, description) or Player.onLookInShop(self, itemType, count, description)
 	if (info.playerOnLookInShop == -1) {
@@ -731,7 +731,7 @@ bool Events::eventPlayerOnLookInShop(Player* player, const ItemType* itemType, u
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnLookInShop);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	LuaScriptInterface::pushUserdata<const ItemType>(L, itemType);
@@ -743,7 +743,7 @@ bool Events::eventPlayerOnLookInShop(Player* player, const ItemType* itemType, u
 	return scriptInterface.callFunction(4);
 }
 
-ReturnValue Events::eventPlayerOnMoveItem(Player* player, Item* item, uint16_t count, const Position& fromPosition, const Position& toPosition, Cylinder* fromCylinder, Cylinder* toCylinder)
+ReturnValue Events::eventPlayerOnMoveItem(const PlayerPtr& player, const ItemPtr& item, uint16_t count, const Position& fromPosition, const Position& toPosition, const CylinderPtr& fromCylinder, const CylinderPtr& toCylinder)
 {
 	// Player:onMoveItem(item, count, fromPosition, toPosition) or Player.onMoveItem(self, item, count, fromPosition, toPosition, fromCylinder, toCylinder)
 	if (info.playerOnMoveItem == -1) {
@@ -761,10 +761,10 @@ ReturnValue Events::eventPlayerOnMoveItem(Player* player, Item* item, uint16_t c
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnMoveItem);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	lua_pushinteger(L, count);
@@ -787,7 +787,7 @@ ReturnValue Events::eventPlayerOnMoveItem(Player* player, Item* item, uint16_t c
 	return returnValue;
 }
 
-void Events::eventPlayerOnItemMoved(Player* player, Item* item, uint16_t count, const Position& fromPosition, const Position& toPosition, Cylinder* fromCylinder, Cylinder* toCylinder)
+void Events::eventPlayerOnItemMoved(const PlayerPtr& player, const ItemPtr& item, uint16_t count, const Position& fromPosition, const Position& toPosition, const CylinderPtr& fromCylinder, const CylinderPtr& toCylinder)
 {
 	// Player:onItemMoved(item, count, fromPosition, toPosition) or Player.onItemMoved(self, item, count, fromPosition, toPosition, fromCylinder, toCylinder)
 	if (info.playerOnItemMoved == -1) {
@@ -805,10 +805,10 @@ void Events::eventPlayerOnItemMoved(Player* player, Item* item, uint16_t count, 
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnItemMoved);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	lua_pushinteger(L, count);
@@ -821,7 +821,7 @@ void Events::eventPlayerOnItemMoved(Player* player, Item* item, uint16_t count, 
 	scriptInterface.callVoidFunction(7);
 }
 
-bool Events::eventPlayerOnMoveCreature(Player* player, Creature* creature, const Position& fromPosition, const Position& toPosition)
+bool Events::eventPlayerOnMoveCreature(const PlayerPtr& player, const CreaturePtr& creature, const Position& fromPosition, const Position& toPosition)
 {
 	// Player:onMoveCreature(creature, fromPosition, toPosition) or Player.onMoveCreature(self, creature, fromPosition, toPosition)
 	if (info.playerOnMoveCreature == -1) {
@@ -839,10 +839,10 @@ bool Events::eventPlayerOnMoveCreature(Player* player, Creature* creature, const
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnMoveCreature);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
 	LuaScriptInterface::pushPosition(L, fromPosition);
@@ -851,7 +851,7 @@ bool Events::eventPlayerOnMoveCreature(Player* player, Creature* creature, const
 	return scriptInterface.callFunction(4);
 }
 
-void Events::eventPlayerOnReportRuleViolation(Player* player, const std::string& targetName, uint8_t reportType, uint8_t reportReason, const std::string& comment, const std::string& translation)
+void Events::eventPlayerOnReportRuleViolation(const PlayerPtr& player, const std::string& targetName, uint8_t reportType, uint8_t reportReason, const std::string& comment, const std::string& translation)
 {
 	// Player:onReportRuleViolation(targetName, reportType, reportReason, comment, translation)
 	if (info.playerOnReportRuleViolation == -1) {
@@ -869,7 +869,7 @@ void Events::eventPlayerOnReportRuleViolation(Player* player, const std::string&
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnReportRuleViolation);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	LuaScriptInterface::pushString(L, targetName);
@@ -883,7 +883,7 @@ void Events::eventPlayerOnReportRuleViolation(Player* player, const std::string&
 	scriptInterface.callVoidFunction(6);
 }
 
-bool Events::eventPlayerOnReportBug(Player* player, const std::string& message, const Position& position, uint8_t category)
+bool Events::eventPlayerOnReportBug(const PlayerPtr& player, const std::string& message, const Position& position, uint8_t category)
 {
 	// Player:onReportBug(message, position, category)
 	if (info.playerOnReportBug == -1) {
@@ -901,7 +901,7 @@ bool Events::eventPlayerOnReportBug(Player* player, const std::string& message, 
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnReportBug);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	LuaScriptInterface::pushString(L, message);
@@ -911,7 +911,7 @@ bool Events::eventPlayerOnReportBug(Player* player, const std::string& message, 
 	return scriptInterface.callFunction(4);
 }
 
-bool Events::eventPlayerOnTurn(Player* player, Direction direction)
+bool Events::eventPlayerOnTurn(const PlayerPtr& player, Direction direction)
 {
 	// Player:onTurn(direction) or Player.onTurn(self, direction)
 	if (info.playerOnTurn == -1) {
@@ -929,7 +929,7 @@ bool Events::eventPlayerOnTurn(Player* player, Direction direction)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnTurn);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	lua_pushinteger(L, direction);
@@ -937,7 +937,7 @@ bool Events::eventPlayerOnTurn(Player* player, Direction direction)
 	return scriptInterface.callFunction(2);
 }
 
-bool Events::eventPlayerOnTradeRequest(Player* player, Player* target, Item* item)
+bool Events::eventPlayerOnTradeRequest(const PlayerPtr& player, const PlayerPtr& target, const ItemPtr& item)
 {
 	// Player:onTradeRequest(target, item)
 	if (info.playerOnTradeRequest == -1) {
@@ -955,19 +955,19 @@ bool Events::eventPlayerOnTradeRequest(Player* player, Player* target, Item* ite
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnTradeRequest);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Player>(L, target);
+	LuaScriptInterface::pushSharedPtr(L, target);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	return scriptInterface.callFunction(3);
 }
 
-bool Events::eventPlayerOnTradeAccept(Player* player, Player* target, Item* item, Item* targetItem)
+bool Events::eventPlayerOnTradeAccept(const PlayerPtr& player, const PlayerPtr& target, const ItemPtr& item, const ItemPtr& targetItem)
 {
 	// Player:onTradeAccept(target, item, targetItem)
 	if (info.playerOnTradeAccept == -1) {
@@ -985,22 +985,22 @@ bool Events::eventPlayerOnTradeAccept(Player* player, Player* target, Item* item
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnTradeAccept);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Player>(L, target);
+	LuaScriptInterface::pushSharedPtr(L, target);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
-	LuaScriptInterface::pushUserdata<Item>(L, targetItem);
+	LuaScriptInterface::pushSharedPtr(L, targetItem);
 	LuaScriptInterface::setItemMetatable(L, -1, targetItem);
 
 	return scriptInterface.callFunction(4);
 }
 
-void Events::eventPlayerOnTradeCompleted(Player* player, Player* target, Item* item, Item* targetItem, bool isSuccess)
+void Events::eventPlayerOnTradeCompleted(const PlayerPtr& player, const PlayerPtr& target, const ItemPtr& item, const ItemPtr& targetItem, bool isSuccess)
 {
 	// Player:onTradeCompleted(target, item, targetItem, isSuccess)
 	if (info.playerOnTradeCompleted == -1) {
@@ -1018,16 +1018,16 @@ void Events::eventPlayerOnTradeCompleted(Player* player, Player* target, Item* i
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnTradeCompleted);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Player>(L, target);
+	LuaScriptInterface::pushSharedPtr(L, target);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
-	LuaScriptInterface::pushUserdata<Item>(L, targetItem);
+	LuaScriptInterface::pushSharedPtr(L, targetItem);
 	LuaScriptInterface::setItemMetatable(L, -1, targetItem);
 
 	LuaScriptInterface::pushBoolean(L, isSuccess);
@@ -1035,7 +1035,7 @@ void Events::eventPlayerOnTradeCompleted(Player* player, Player* target, Item* i
 	return scriptInterface.callVoidFunction(5);
 }
 
-void Events::eventPlayerOnGainExperience(Player* player, Creature* source, uint64_t& exp, uint64_t rawExp)
+void Events::eventPlayerOnGainExperience(const PlayerPtr& player, const CreaturePtr& source, uint64_t& exp, uint64_t rawExp)
 {
 	// Player:onGainExperience(source, exp, rawExp)
 	// rawExp gives the original exp which is not multiplied
@@ -1054,11 +1054,11 @@ void Events::eventPlayerOnGainExperience(Player* player, Creature* source, uint6
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnGainExperience);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	if (source) {
-		LuaScriptInterface::pushUserdata<Creature>(L, source);
+		LuaScriptInterface::pushSharedPtr(L, source);
 		LuaScriptInterface::setCreatureMetatable(L, -1, source);
 	} else {
 		lua_pushnil(L);
@@ -1077,7 +1077,7 @@ void Events::eventPlayerOnGainExperience(Player* player, Creature* source, uint6
 	scriptInterface.resetScriptEnv();
 }
 
-void Events::eventPlayerOnLoseExperience(Player* player, uint64_t& exp)
+void Events::eventPlayerOnLoseExperience(const PlayerPtr& player, uint64_t& exp)
 {
 	// Player:onLoseExperience(exp)
 	if (info.playerOnLoseExperience == -1) {
@@ -1095,7 +1095,7 @@ void Events::eventPlayerOnLoseExperience(Player* player, uint64_t& exp)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnLoseExperience);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	lua_pushinteger(L, exp);
@@ -1110,7 +1110,7 @@ void Events::eventPlayerOnLoseExperience(Player* player, uint64_t& exp)
 	scriptInterface.resetScriptEnv();
 }
 
-void Events::eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_t& tries)
+void Events::eventPlayerOnGainSkillTries(const PlayerPtr& player, skills_t skill, uint64_t& tries)
 {
 	// Player:onGainSkillTries(skill, tries)
 	if (info.playerOnGainSkillTries == -1) {
@@ -1128,7 +1128,7 @@ void Events::eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnGainSkillTries);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	lua_pushinteger(L, skill);
@@ -1144,7 +1144,7 @@ void Events::eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_
 	scriptInterface.resetScriptEnv();
 }
 
-void Events::eventPlayerOnWrapItem(Player* player, Item* item)
+void Events::eventPlayerOnWrapItem(const PlayerPtr& player, const ItemPtr& item)
 {
 	// Player:onWrapItem(item)
 	if (info.playerOnWrapItem == -1) {
@@ -1162,16 +1162,16 @@ void Events::eventPlayerOnWrapItem(Player* player, Item* item)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnWrapItem);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	scriptInterface.callVoidFunction(2);
 }
 
-void Events::eventPlayerOnInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip)
+void Events::eventPlayerOnInventoryUpdate(const PlayerPtr& player, const ItemPtr& item, slots_t slot, bool equip)
 {
 	// Player:onInventoryUpdate(item, slot, equip)
 	if (info.playerOnInventoryUpdate == -1) {
@@ -1189,10 +1189,10 @@ void Events::eventPlayerOnInventoryUpdate(Player* player, Item* item, slots_t sl
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnInventoryUpdate);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	lua_pushinteger(L, slot);
@@ -1201,7 +1201,7 @@ void Events::eventPlayerOnInventoryUpdate(Player* player, Item* item, slots_t sl
 	scriptInterface.callVoidFunction(4);
 }
 
-void Events::eventPlayerOnRotateItem(Player* player, Item* item)
+void Events::eventPlayerOnRotateItem(const PlayerPtr& player, const ItemPtr& item)
 {
 	// Player:onRotateItem(item)
 	if (info.playerOnRotateItem == -1) {
@@ -1219,16 +1219,16 @@ void Events::eventPlayerOnRotateItem(Player* player, Item* item)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnRotateItem);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	scriptInterface.callVoidFunction(2);
 }
 
-bool Events::eventPlayerOnSpellTry(Player* player, const Spell* spell, SpellType_t spellType)
+bool Events::eventPlayerOnSpellTry(const PlayerPtr& player, const Spell* spell, SpellType_t spellType)
 {
 	// Player:onSpellTry(spell, spellType)
 	if (info.playerOnSpellTry == -1) {
@@ -1246,7 +1246,7 @@ bool Events::eventPlayerOnSpellTry(Player* player, const Spell* spell, SpellType
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnSpellTry);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	LuaScriptInterface::pushSpell(L, *spell);
@@ -1254,7 +1254,7 @@ bool Events::eventPlayerOnSpellTry(Player* player, const Spell* spell, SpellType
 	return scriptInterface.callFunction(3);
 }
 
-void Events::eventPlayerOnAugment(Player* player, std::shared_ptr<Augment> augment)
+void Events::eventPlayerOnAugment(const PlayerPtr& player, std::shared_ptr<Augment> augment)
 {
 	// Player:onAugment(augment)
 	if (info.playerOnAugment == -1) {
@@ -1272,7 +1272,7 @@ void Events::eventPlayerOnAugment(Player* player, std::shared_ptr<Augment> augme
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnAugment);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	LuaScriptInterface::pushSharedPtr<Augment>(L, augment);
@@ -1281,7 +1281,7 @@ void Events::eventPlayerOnAugment(Player* player, std::shared_ptr<Augment> augme
 	scriptInterface.callVoidFunction(2);
 }
 
-void Events::eventPlayerOnRemoveAugment(Player* player, std::shared_ptr<Augment> augment)
+void Events::eventPlayerOnRemoveAugment(const PlayerPtr& player, std::shared_ptr<Augment> augment)
 {
 	// Player:onRemoveAugment(augment)
 	if (info.playerOnRemoveAugment == -1) {
@@ -1299,7 +1299,7 @@ void Events::eventPlayerOnRemoveAugment(Player* player, std::shared_ptr<Augment>
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.playerOnRemoveAugment);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	LuaScriptInterface::pushSharedPtr<Augment>(L, augment);
@@ -1308,7 +1308,7 @@ void Events::eventPlayerOnRemoveAugment(Player* player, std::shared_ptr<Augment>
 	scriptInterface.callVoidFunction(2);
 }
 
-void Events::eventMonsterOnDropLoot(Monster* monster, Container* corpse)
+void Events::eventMonsterOnDropLoot(const MonsterPtr& monster, const ContainerPtr& corpse)
 {
 	// Monster:onDropLoot(corpse)
 	if (info.monsterOnDropLoot == -1) {
@@ -1326,16 +1326,16 @@ void Events::eventMonsterOnDropLoot(Monster* monster, Container* corpse)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.monsterOnDropLoot);
 
-	LuaScriptInterface::pushUserdata<Monster>(L, monster);
+	LuaScriptInterface::pushSharedPtr(L, monster);
 	LuaScriptInterface::setMetatable(L, -1, "Monster");
 
-	LuaScriptInterface::pushUserdata<Container>(L, corpse);
+	LuaScriptInterface::pushSharedPtr(L, corpse);
 	LuaScriptInterface::setMetatable(L, -1, "Container");
 
 	scriptInterface.callVoidFunction(2);
 }
 
-bool Events::eventItemOnImbue(Item* item, std::shared_ptr<Imbuement> imbuement, bool created)
+bool Events::eventItemOnImbue(const ItemPtr& item, const std::shared_ptr<Imbuement>& imbuement, bool created)
 {
 	// Item:onImbue(imbuement, created)
 	if (info.itemOnImbue == -1) {
@@ -1353,7 +1353,7 @@ bool Events::eventItemOnImbue(Item* item, std::shared_ptr<Imbuement> imbuement, 
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.itemOnImbue);
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	LuaScriptInterface::pushSharedPtr(L, imbuement);
@@ -1364,7 +1364,7 @@ bool Events::eventItemOnImbue(Item* item, std::shared_ptr<Imbuement> imbuement, 
 	return scriptInterface.callFunction(3);
 }
 
-void Events::eventItemOnRemoveImbue(Item* item, ImbuementType imbueType, bool decayed)
+void Events::eventItemOnRemoveImbue(const ItemPtr& item, ImbuementType imbueType, bool decayed)
 {
 	// Item:onRemoveImbue(imbueType, decayed)
 	if (info.itemOnRemoveImbue == -1) {
@@ -1382,7 +1382,7 @@ void Events::eventItemOnRemoveImbue(Item* item, ImbuementType imbueType, bool de
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.itemOnRemoveImbue);
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
 	lua_pushinteger(L, static_cast<uint8_t>(imbueType));
@@ -1391,7 +1391,7 @@ void Events::eventItemOnRemoveImbue(Item* item, ImbuementType imbueType, bool de
 	scriptInterface.callVoidFunction(3);
 }
 
-void Events::eventItemOnAttack(Item* item, Player* itemHolder, Creature* defender, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage, bool leechedDamage)
+void Events::eventItemOnAttack(const ItemPtr& item, const PlayerPtr& itemHolder, const CreaturePtr& defender, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage, bool leechedDamage)
 {
 	// Item:onAttack(attacker, defender, blockType, combatType, origin, criticalDamage, leechedDamage)
 	if (info.itemOnAttack == -1) {
@@ -1409,13 +1409,13 @@ void Events::eventItemOnAttack(Item* item, Player* itemHolder, Creature* defende
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.itemOnAttack);
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
-	LuaScriptInterface::pushUserdata<Player>(L, itemHolder);
+	LuaScriptInterface::pushSharedPtr(L, itemHolder);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Creature>(L, defender);
+	LuaScriptInterface::pushSharedPtr(L, defender);
 	LuaScriptInterface::setCreatureMetatable(L, -1, defender);
 
 	lua_pushinteger(L, static_cast<uint8_t>(blockType));
@@ -1428,7 +1428,7 @@ void Events::eventItemOnAttack(Item* item, Player* itemHolder, Creature* defende
 	scriptInterface.callVoidFunction(8);
 }
 
-void Events::eventItemOnDefend(Item* item, Player* itemHolder, Creature* attacker, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage, bool leechedDamage)
+void Events::eventItemOnDefend(const ItemPtr& item, const PlayerPtr& itemHolder, const CreaturePtr& attacker, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage, bool leechedDamage)
 {
 	// Item:onDefend(defender, attacker, blockType, combatType, origin, criticalDamage, leechedDamage)
 	if (info.itemOnDefend == -1) {
@@ -1446,13 +1446,13 @@ void Events::eventItemOnDefend(Item* item, Player* itemHolder, Creature* attacke
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.itemOnDefend);
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setItemMetatable(L, -1, item);
 
-	LuaScriptInterface::pushUserdata<Player>(L, itemHolder);
+	LuaScriptInterface::pushSharedPtr(L, itemHolder);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
-	LuaScriptInterface::pushUserdata<Creature>(L, attacker);
+	LuaScriptInterface::pushSharedPtr(L, attacker);
 	LuaScriptInterface::setCreatureMetatable(L, -1, attacker);
 
 	lua_pushinteger(L, blockType);
@@ -1465,7 +1465,7 @@ void Events::eventItemOnDefend(Item* item, Player* itemHolder, Creature* attacke
 	scriptInterface.callVoidFunction(8);
 }
 
-void Events::eventItemOnAugment(Item* item, std::shared_ptr<Augment> augment)
+void Events::eventItemOnAugment(const ItemPtr& item, std::shared_ptr<Augment> augment)
 {
 	// Item:onAugment(augment)
 	if (info.itemOnAugment == -1) {
@@ -1483,7 +1483,7 @@ void Events::eventItemOnAugment(Item* item, std::shared_ptr<Augment> augment)
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.itemOnAugment);
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setMetatable(L, -1, "Item");
 
 	LuaScriptInterface::pushSharedPtr<Augment>(L, augment);
@@ -1492,7 +1492,7 @@ void Events::eventItemOnAugment(Item* item, std::shared_ptr<Augment> augment)
 	scriptInterface.callVoidFunction(2);
 }
 
-void Events::eventItemOnRemoveAugment(Item* item, std::shared_ptr<Augment> augment)
+void Events::eventItemOnRemoveAugment(const ItemPtr& item, std::shared_ptr<Augment> augment)
 {
 	// Item:onRemoveAugment(augment)
 	if (info.itemOnRemoveAugment == -1) {
@@ -1510,7 +1510,7 @@ void Events::eventItemOnRemoveAugment(Item* item, std::shared_ptr<Augment> augme
 	lua_State* L = scriptInterface.getLuaState();
 	scriptInterface.pushFunction(info.itemOnRemoveAugment);
 
-	LuaScriptInterface::pushUserdata<Item>(L, item);
+	LuaScriptInterface::pushSharedPtr(L, item);
 	LuaScriptInterface::setMetatable(L, -1, "Item");
 
 	LuaScriptInterface::pushSharedPtr<Augment>(L, augment);

--- a/src/events.h
+++ b/src/events.h
@@ -86,62 +86,62 @@ class Events
 		bool load();
 
 		// Creature
-		bool eventCreatureOnChangeOutfit(Creature* creature, const Outfit_t& outfit);
-		ReturnValue eventCreatureOnAreaCombat(Creature* creature, Tile* tile, bool aggressive);
-		ReturnValue eventCreatureOnTargetCombat(Creature* creature, Creature* target);
-		void eventCreatureOnHear(Creature* creature, Creature* speaker, const std::string& words, SpeakClasses type);
-		void eventCreatureOnAttack(Creature* attacker, Creature* target, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage = false, bool leechedDamage = false);
-		void eventCreatureOnDefend(Creature* defender, Creature* attacker, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage = false, bool leechedDamage = false);
+		bool eventCreatureOnChangeOutfit(const CreaturePtr& creature, const Outfit_t& outfit);
+		ReturnValue eventCreatureOnAreaCombat(const CreaturePtr& creature, const TilePtr& tile, bool aggressive);
+		ReturnValue eventCreatureOnTargetCombat(const CreaturePtr& creature, const CreaturePtr& target);
+		void eventCreatureOnHear(const CreaturePtr& creature, const CreaturePtr& speaker, const std::string& words, SpeakClasses type);
+		void eventCreatureOnAttack(const CreaturePtr& attacker, const CreaturePtr& target, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage = false, bool leechedDamage = false);
+		void eventCreatureOnDefend(const CreaturePtr& defender, const CreaturePtr& attacker, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage = false, bool leechedDamage = false);
 
 		// Party
-		bool eventPartyOnJoin(Party* party, Player* player);
-		bool eventPartyOnLeave(Party* party, Player* player);
+		bool eventPartyOnJoin(Party* party, const PlayerPtr& player);
+		bool eventPartyOnLeave(Party* party, const PlayerPtr& player);
 		bool eventPartyOnDisband(Party* party);
 		void eventPartyOnShareExperience(Party* party, uint64_t& exp);
-		bool eventPartyOnInvite(Party* party, Player* player);
-		bool eventPartyOnRevokeInvitation(Party* party, Player* player);
-		bool eventPartyOnPassLeadership(Party* party, Player* player);
+		bool eventPartyOnInvite(Party* party, const PlayerPtr& player);
+		bool eventPartyOnRevokeInvitation(Party* party, const PlayerPtr& player);
+		bool eventPartyOnPassLeadership(Party* party, const PlayerPtr& player);
 
 		// Player
-		bool eventPlayerOnBrowseField(Player* player, const Position& position);
-		void eventPlayerOnLook(Player* player, const Position& position, Thing* thing, uint8_t stackpos, int32_t lookDistance);
-		void eventPlayerOnLookInBattleList(Player* player, Creature* creature, int32_t lookDistance);
-		void eventPlayerOnLookInTrade(Player* player, Player* partner, Item* item, int32_t lookDistance);
-		bool eventPlayerOnLookInShop(Player* player, const ItemType* itemType, uint8_t count, const std::string& description);
-		ReturnValue eventPlayerOnMoveItem(Player* player, Item* item, uint16_t count, const Position& fromPosition, const Position& toPosition, Cylinder* fromCylinder, Cylinder* toCylinder);
-		void eventPlayerOnItemMoved(Player* player, Item* item, uint16_t count, const Position& fromPosition, const Position& toPosition, Cylinder* fromCylinder, Cylinder* toCylinder);
-		bool eventPlayerOnMoveCreature(Player* player, Creature* creature, const Position& fromPosition, const Position& toPosition);
-		void eventPlayerOnReportRuleViolation(Player* player, const std::string& targetName, uint8_t reportType, uint8_t reportReason, const std::string& comment, const std::string& translation);
-		bool eventPlayerOnReportBug(Player* player, const std::string& message, const Position& position, uint8_t category);
-		bool eventPlayerOnTurn(Player* player, Direction direction);
-		bool eventPlayerOnTradeRequest(Player* player, Player* target, Item* item);
-		bool eventPlayerOnTradeAccept(Player* player, Player* target, Item* item, Item* targetItem);
-		void eventPlayerOnTradeCompleted(Player* player, Player* target, Item* item, Item* targetItem, bool isSuccess);
-		void eventPlayerOnGainExperience(Player* player, Creature* source, uint64_t& exp, uint64_t rawExp);
-		void eventPlayerOnLoseExperience(Player* player, uint64_t& exp);
-		void eventPlayerOnGainSkillTries(Player* player, skills_t skill, uint64_t& tries);
-		void eventPlayerOnWrapItem(Player* player, Item* item);
-		void eventPlayerOnInventoryUpdate(Player* player, Item* item, slots_t slot, bool equip);
-		void eventPlayerOnRotateItem(Player* player, Item* item);
-		bool eventPlayerOnSpellTry(Player* player, const Spell* spell, SpellType_t spellType);
-		void eventPlayerOnAugment(Player* player, std::shared_ptr<Augment> augment);
-		void eventPlayerOnRemoveAugment(Player* player, std::shared_ptr<Augment> augment);
+		bool eventPlayerOnBrowseField(const PlayerPtr& player, const Position& position);
+		void eventPlayerOnLook(const PlayerPtr& player, const Position& position, const ThingPtr& thing, uint8_t stackpos, int32_t lookDistance);
+		void eventPlayerOnLookInBattleList(const PlayerPtr& player, const CreaturePtr& creature, int32_t lookDistance);
+		void eventPlayerOnLookInTrade(const PlayerPtr& player, const PlayerPtr& partner, const ItemPtr& item, int32_t lookDistance);
+		bool eventPlayerOnLookInShop(const PlayerPtr& player, const ItemType* itemType, uint8_t count, const std::string& description);
+		ReturnValue eventPlayerOnMoveItem(const PlayerPtr& player, const ItemPtr& item, uint16_t count, const Position& fromPosition, const Position& toPosition, const CylinderPtr& fromCylinder, const CylinderPtr& toCylinder);
+		void eventPlayerOnItemMoved(const PlayerPtr& player, const ItemPtr& item, uint16_t count, const Position& fromPosition, const Position& toPosition, const CylinderPtr& fromCylinder, const CylinderPtr& toCylinder);
+		bool eventPlayerOnMoveCreature(const PlayerPtr& player, const CreaturePtr& creature, const Position& fromPosition, const Position& toPosition);
+		void eventPlayerOnReportRuleViolation(const PlayerPtr& player, const std::string& targetName, uint8_t reportType, uint8_t reportReason, const std::string& comment, const std::string& translation);
+		bool eventPlayerOnReportBug(const PlayerPtr& player, const std::string& message, const Position& position, uint8_t category);
+		bool eventPlayerOnTurn(const PlayerPtr& player, Direction direction);
+		bool eventPlayerOnTradeRequest(const PlayerPtr& player, const PlayerPtr& target, const ItemPtr& item);
+		bool eventPlayerOnTradeAccept(const PlayerPtr& player, const PlayerPtr& target, const ItemPtr& item, const ItemPtr& targetItem);
+		void eventPlayerOnTradeCompleted(const PlayerPtr& player, const PlayerPtr& target, const ItemPtr& item, const ItemPtr& targetItem, bool isSuccess);
+		void eventPlayerOnGainExperience(const PlayerPtr& player, const CreaturePtr& source, uint64_t& exp, uint64_t rawExp);
+		void eventPlayerOnLoseExperience(const PlayerPtr& player, uint64_t& exp);
+		void eventPlayerOnGainSkillTries(const PlayerPtr& player, skills_t skill, uint64_t& tries);
+		void eventPlayerOnWrapItem(const PlayerPtr& player, const ItemPtr& item);
+		void eventPlayerOnInventoryUpdate(const PlayerPtr& player, const ItemPtr& item, slots_t slot, bool equip);
+		void eventPlayerOnRotateItem(const PlayerPtr& player, const ItemPtr& item);
+		bool eventPlayerOnSpellTry(const PlayerPtr& player, const Spell* spell, SpellType_t spellType);
+		void eventPlayerOnAugment(const PlayerPtr& player, std::shared_ptr<Augment> augment);
+		void eventPlayerOnRemoveAugment(const PlayerPtr& player, std::shared_ptr<Augment> augment);
 
 		// Monster
-		void eventMonsterOnDropLoot(Monster* monster, Container* corpse);
-		bool eventMonsterOnSpawn(Monster* monster, const Position& position, bool startup, bool artificial);
+		void eventMonsterOnDropLoot(const MonsterPtr& monster, const ContainerPtr& corpse);
+		bool eventMonsterOnSpawn(const MonsterPtr& monster, const Position& position, bool startup, bool artificial);
 
 		// Item
-		bool eventItemOnImbue(Item* item, std::shared_ptr<Imbuement> imbuement, bool created = true);
-		void eventItemOnRemoveImbue(Item* item, ImbuementType imbueType, bool decayed = false);
+		bool eventItemOnImbue(const ItemPtr& item, const std::shared_ptr<Imbuement>& imbuement, bool created = true);
+		void eventItemOnRemoveImbue(const ItemPtr& item, ImbuementType imbueType, bool decayed = false);
 
-		void eventItemOnAttack(Item* item, Player* itemHolder, Creature* defender, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage = false, bool leechedDamage = false);
-		void eventItemOnDefend(Item* item, Player* itemHolder, Creature* attacker, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage = false, bool leechedDamage = false);
-		void eventItemOnAugment(Item* item, std::shared_ptr<Augment> augment);
-		void eventItemOnRemoveAugment(Item* item, std::shared_ptr<Augment> augment);
+		void eventItemOnAttack(const ItemPtr& item, const PlayerPtr& itemHolder, const CreaturePtr& defender, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage = false, bool leechedDamage = false);
+		void eventItemOnDefend(const ItemPtr& item, const PlayerPtr& itemHolder, const CreaturePtr& attacker, BlockType_t blockType, CombatType_t combatType, CombatOrigin origin, bool criticalDamage = false, bool leechedDamage = false);
+		void eventItemOnAugment(const ItemPtr& item, std::shared_ptr<Augment> augment);
+		void eventItemOnRemoveAugment(const ItemPtr& item, std::shared_ptr<Augment> augment);
 		
 
-		int32_t getScriptId(EventInfoId eventInfoId) {
+		constexpr auto getScriptId(EventInfoId eventInfoId) const {
 			switch (eventInfoId)
 			{
 			case EventInfoId::CREATURE_ONHEAR:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1119,7 +1119,6 @@ ReturnValue Game::internalMoveItem(CylinderPtr fromCylinder,
 
 	while ((subCylinder = toCylinder->queryDestination(index, item, toItem, flags)) != toCylinder) {
 		toCylinder = subCylinder;
-		std::cout << "ToItem first assigned to : " << toItem->getName() << " \n";
 		//to prevent infinite loop
 		if (++floorN >= MAP_MAX_LAYERS) {
 			break;
@@ -1295,9 +1294,9 @@ ReturnValue Game::internalMoveItem(CylinderPtr fromCylinder,
 
 	if (_moveItem) {
 		if (moveItem) {
-			*_moveItem = moveItem;
+			_moveItem = moveItem;
 		} else {
-			*_moveItem = item;
+			_moveItem = item;
 		}
 	}
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -915,7 +915,7 @@ void Game::playerMoveItem(const PlayerPtr& player,
 							const Position& toPos,
 							uint8_t count,
 							ItemPtr item,
-							CylinderPtr& toCylinder)
+							CylinderPtr toCylinder)
 {
 	if (!player->canDoAction()) {
 		uint32_t delay = player->getNextActionTime();
@@ -1417,6 +1417,8 @@ ReturnValue Game::internalAddItem(CylinderPtr toCylinder, ItemPtr item, int32_t 
 
 ReturnValue Game::internalRemoveItem(ItemPtr item, int32_t count /*= -1*/, bool test /*= false*/, uint32_t flags /*= 0*/)
 {
+	
+	
 	auto cylinder = item->getParent();
 	if (cylinder == nullptr) {
 		return RETURNVALUE_NOTPOSSIBLE;
@@ -1445,7 +1447,9 @@ ReturnValue Game::internalRemoveItem(ItemPtr item, int32_t count /*= -1*/, bool 
 
 	if (!test) {
 		int32_t index = cylinder->getThingIndex(item);
-
+		auto location = std::source_location::current();
+		std::cout << "Game::InternalRemoveItem called from : " << location.function_name() << "  \n";
+		std::cout << "Item up for removal : " << item->getName() << " \n";
 		//remove the item
 		cylinder->removeThing(item, count);
 		std::cout << "Successful removal \n";

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1147,11 +1147,9 @@ ReturnValue Game::internalMoveItem(CylinderPtr fromCylinder,
 	if (ret == RETURNVALUE_NEEDEXCHANGE) {
 		//check if we can add it to source cylinder
 		ret = fromCylinder->queryAdd(fromCylinder->getThingIndex(item), toItem, toItem->getItemCount(), 0);
-		std::cout << "ToItem after the queryAdd inside needexchange : " << toItem->getName() << " \n";
 		if (ret == RETURNVALUE_NOERROR) {
 			if (actorPlayer && fromPos && toPos) {
 				const ReturnValue eventRet = g_events->eventPlayerOnMoveItem(actorPlayer, toItem, toItem->getItemCount(), *toPos, *fromPos, toCylinder, fromCylinder);
-				std::cout << "ToItem after the player event on move item in lua, inside needexchange : " << toItem->getName() << " \n";
 				if (eventRet != RETURNVALUE_NOERROR) {
 					return eventRet;
 				}
@@ -1160,17 +1158,14 @@ ReturnValue Game::internalMoveItem(CylinderPtr fromCylinder,
 			//check how much we can move
 			uint32_t maxExchangeQueryCount = 0;
 			ReturnValue retExchangeMaxCount = fromCylinder->queryMaxCount(INDEX_WHEREEVER, toItem, toItem->getItemCount(), maxExchangeQueryCount, 0);
-			std::cout << "ToItem after the exchange count inside needexchange : " << toItem->getName() << " \n";
 
 			if (retExchangeMaxCount != RETURNVALUE_NOERROR && maxExchangeQueryCount == 0) {
 				return retExchangeMaxCount;
 			}
 
 			if (toCylinder->queryRemove(toItem, toItem->getItemCount(), flags, actor) == RETURNVALUE_NOERROR) {
-				std::cout << "ToItem after the queryRemove inside needexchange : " << toItem->getName() << " \n";
 				int32_t oldToItemIndex = toCylinder->getThingIndex(toItem);
 				toCylinder->removeThing(toItem, toItem->getItemCount());
-				std::cout << "ToItem after the Remove thing inside needexchange : " << toItem->getName() << " \n";
 				fromCylinder->addThing(toItem);
 
 				if (oldToItemIndex != -1) {
@@ -1186,7 +1181,6 @@ ReturnValue Game::internalMoveItem(CylinderPtr fromCylinder,
 
 				if (actorPlayer && fromPos && toPos && !toItem->isRemoved()) {
 					g_events->eventPlayerOnItemMoved(actorPlayer, toItem, toItem->getItemCount(), *toPos, *fromPos, toCylinder, fromCylinder);
-					std::cout << "ToItem after the player item remove on move again tho, quite long, inside needexchange : " << toItem->getName() << " \n";
 				}
 
 				toItem = nullptr;
@@ -1222,16 +1216,12 @@ ReturnValue Game::internalMoveItem(CylinderPtr fromCylinder,
 
 	if (tradeItem) {
 		if (toCylinder->getItem() == tradeItem) {
-			std::cout << "Trade item is apparently : " << tradeItem->getName() << " \n";
-			std::cout << "toCylinder Item is apparently : " << tradeItem->getName() << " \n";
-			std::cout << "trade item is matching" << std::endl;
 			return RETURNVALUE_NOTENOUGHROOM;
 		}
 
 		auto tmpCylinder = toCylinder->getParent();
 		while (tmpCylinder) {
 			if (tmpCylinder->getItem() == tradeItem) {
-				std::cout << "tmpcylinder item is matching" << std::endl;
 				return RETURNVALUE_NOTENOUGHROOM;
 			}
 
@@ -1357,7 +1347,6 @@ ReturnValue Game::internalAddItem(CylinderPtr toCylinder, ItemPtr item, int32_t 
 	ret = destCylinder->queryMaxCount(INDEX_WHEREEVER, item, item->getItemCount(), maxQueryCount, flags);
 
 	if (ret != RETURNVALUE_NOERROR) {
-		std::cout << "getting error trying to add item \n";
 		return ret;
 	}
 
@@ -1416,8 +1405,6 @@ ReturnValue Game::internalAddItem(CylinderPtr toCylinder, ItemPtr item, int32_t 
 
 ReturnValue Game::internalRemoveItem(ItemPtr item, int32_t count /*= -1*/, bool test /*= false*/, uint32_t flags /*= 0*/)
 {
-	
-	
 	auto cylinder = item->getParent();
 	if (cylinder == nullptr) {
 		return RETURNVALUE_NOTPOSSIBLE;
@@ -1436,7 +1423,6 @@ ReturnValue Game::internalRemoveItem(ItemPtr item, int32_t count /*= -1*/, bool 
 	//check if we can remove this item
 	ReturnValue ret = cylinder->queryRemove(item, count, flags | FLAG_IGNORENOTMOVEABLE);
 	if (ret != RETURNVALUE_NOERROR) {
-		std::cout << "Item count on failed removal : " << item->getItemCount() << " \n";
 		return ret;
 	}
 
@@ -1446,37 +1432,15 @@ ReturnValue Game::internalRemoveItem(ItemPtr item, int32_t count /*= -1*/, bool 
 
 	if (!test) {
 		int32_t index = cylinder->getThingIndex(item);
-		auto location = std::source_location::current();
-		std::cout << "Game::InternalRemoveItem called from : " << location.function_name() << "  \n";
-		std::cout << "Item up for removal : " << item->getName() << " \n";
 		//remove the item
 		cylinder->removeThing(item, count);
-		std::cout << "Successful removal \n";
 
 		if (item->isRemoved()) {
 			item->onRemoved();
 			if (item->canDecay()) {
 				decayItems->remove(item);
 			}
-			// ReleaseItem(item);
 		}
-
-		if (auto pl = std::dynamic_pointer_cast<Player>(cylinder)) {
-			std::cout << "------------------------------------------------------ \n";
-			std::cout << "Cylinder is a player : " << pl->getName() << " \n";
-			std::cout << "Item for removal : " << item->getName()
-				<< " count to take : " << count
-				<< " current count: " << item->getItemCount() << " \n";
-		}
-
-		if (auto cl = std::dynamic_pointer_cast<Container>(cylinder)) {
-			std::cout << "------------------------------------------------------ \n";
-			std::cout << "Cylinder is a container : " << cl->getName() << " \n";
-			std::cout << "Item for removal : " << item->getName()
-				<< " count to take : " << count
-				<< " current count: " << item->getItemCount() << " \n";
-		}
-
 		cylinder->postRemoveNotification(item, nullptr, index);
 	}
 

--- a/src/game.h
+++ b/src/game.h
@@ -268,13 +268,13 @@ class Game
 		ReturnValue internalMoveCreature(CreaturePtr creature, Direction direction, uint32_t flags = 0);
 		ReturnValue internalMoveCreature(CreaturePtr creature, TilePtr toTile, uint32_t flags = 0);
 
-		ReturnValue internalMoveItem(CylinderPtr& fromCylinder, CylinderPtr& toCylinder, int32_t index,
-		                             ItemPtr item, uint32_t count, ItemPtr* _moveItem, uint32_t flags = 0, const std::optional<CreaturePtr>& actor = std::nullopt, const std::optional<ItemPtr>& tradeItem = std::nullopt, const Position* fromPos = nullptr, const Position* toPos = nullptr);
+		ReturnValue internalMoveItem(CylinderPtr fromCylinder, CylinderPtr toCylinder, int32_t index,
+		                             ItemPtr item, uint32_t count, ItemPtr* _moveItem, uint32_t flags = 0, CreaturePtr actor = nullptr, ItemPtr tradeItem = nullptr, const Position* fromPos = nullptr, const Position* toPos = nullptr);
 							// another spot to use a ref wrapper and possibly optional for ItemPtr* above
 
-		ReturnValue internalAddItem(CylinderPtr& toCylinder, ItemPtr item, int32_t index = INDEX_WHEREEVER,
+		ReturnValue internalAddItem(CylinderPtr toCylinder, ItemPtr item, int32_t index = INDEX_WHEREEVER,
 		                            uint32_t flags = 0, bool test = false);
-		ReturnValue internalAddItem(CylinderPtr& toCylinder, ItemPtr& item, int32_t index,
+		ReturnValue internalAddItem(CylinderPtr toCylinder, ItemPtr item, int32_t index,
 		                            uint32_t flags, bool test, uint32_t& remainderCount);
 		ReturnValue internalRemoveItem(ItemPtr item, int32_t count = -1, bool test = false, uint32_t flags = 0);
 
@@ -366,7 +366,7 @@ class Game
 		void playerMoveCreature(PlayerPtr& player, CreaturePtr& movingCreature, const Position& movingCreatureOrigPos, TilePtr& toTile);
 		void playerMoveItemByPlayerID(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count);
 		void playerMoveItem(const PlayerPtr& player, const Position& fromPos,
-		                    uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count, ItemPtr& item, CylinderPtr& toCylinder);
+		                    uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count, ItemPtr item, CylinderPtr& toCylinder);
 		void playerEquipItem(uint32_t playerId, uint16_t spriteId);
 		void playerMove(uint32_t playerId, Direction direction);
 		void playerCreatePrivateChannel(uint32_t playerId);
@@ -509,7 +509,7 @@ class Game
 		void addPlayer(PlayerPtr player);
 		void removePlayer(const PlayerPtr& player);
 
-		void addNpc(NpcPtr npc);
+		void addNpc(const NpcPtr& npc);
 		void removeNpc(const NpcPtr& npc);
 
 		void addMonster(MonsterPtr monster);

--- a/src/game.h
+++ b/src/game.h
@@ -269,7 +269,7 @@ class Game
 		ReturnValue internalMoveCreature(CreaturePtr creature, TilePtr toTile, uint32_t flags = 0);
 
 		ReturnValue internalMoveItem(CylinderPtr fromCylinder, CylinderPtr toCylinder, int32_t index,
-		                             ItemPtr item, uint32_t count, ItemPtr* _moveItem, uint32_t flags = 0, CreaturePtr actor = nullptr, ItemPtr tradeItem = nullptr, const Position* fromPos = nullptr, const Position* toPos = nullptr);
+		                             ItemPtr item, uint32_t count, std::optional<std::reference_wrapper<ItemPtr>> _moveItem, uint32_t flags = 0, CreaturePtr actor = nullptr, ItemPtr tradeItem = nullptr, const Position* fromPos = nullptr, const Position* toPos = nullptr);
 							// another spot to use a ref wrapper and possibly optional for ItemPtr* above
 
 		ReturnValue internalAddItem(CylinderPtr toCylinder, ItemPtr item, int32_t index = INDEX_WHEREEVER,

--- a/src/game.h
+++ b/src/game.h
@@ -366,7 +366,7 @@ class Game
 		void playerMoveCreature(PlayerPtr& player, CreaturePtr& movingCreature, const Position& movingCreatureOrigPos, TilePtr& toTile);
 		void playerMoveItemByPlayerID(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count);
 		void playerMoveItem(const PlayerPtr& player, const Position& fromPos,
-		                    uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count, ItemPtr item, CylinderPtr& toCylinder);
+		                    uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count, ItemPtr item, CylinderPtr toCylinder);
 		void playerEquipItem(uint32_t playerId, uint16_t spriteId);
 		void playerMove(uint32_t playerId, Direction direction);
 		void playerCreatePrivateChannel(uint32_t playerId);

--- a/src/game.h
+++ b/src/game.h
@@ -110,12 +110,12 @@ class Game
 			return worldType;
 		}
 
-		Cylinder* internalGetCylinder(Player* player, const Position& pos) const;
-		Thing* internalGetThing(Player* player, const Position& pos, int32_t index,
-		                        uint32_t spriteId, stackPosType_t type) const;
-		static void internalGetPosition(Item* item, Position& pos, uint8_t& stackpos);
+		CylinderPtr internalGetCylinder(const PlayerPtr& player, const Position& pos);
+		ThingPtr internalGetThing(const PlayerPtr& player, const Position& pos, int32_t index,
+		                        uint32_t spriteId, stackPosType_t type);
+		static void internalGetPosition(const ItemPtr& item, Position& pos, uint8_t& stackpos);
 
-		static std::string getTradeErrorDescription(ReturnValue ret, Item* item);
+		static std::string getTradeErrorDescription(ReturnValue ret, const ItemPtr& item);
 
 		// Struct to store damage info for a rewardboss
 		struct PlayerScoreInfo {
@@ -139,70 +139,69 @@ class Game
 		  * \param id is the unique creature id to get a creature pointer to
 		  * \returns A Creature pointer to the creature
 		  */
-		Creature* getCreatureByID(uint32_t id);
+		CreaturePtr getCreatureByID(uint32_t id);
 
 		/**
 		  * Returns a monster based on the unique creature identifier
 		  * \param id is the unique monster id to get a monster pointer to
 		  * \returns A Monster pointer to the monster
 		  */
-		Monster* getMonsterByID(uint32_t id);
+		MonsterPtr getMonsterByID(uint32_t id);
 
 		/**
 		  * Returns an npc based on the unique creature identifier
 		  * \param id is the unique npc id to get a npc pointer to
 		  * \returns A NPC pointer to the npc
 		  */
-		Npc* getNpcByID(uint32_t id);
+		NpcPtr getNpcByID(uint32_t id);
 
 		/**
 		  * Returns a player based on the unique creature identifier
 		  * \param id is the unique player id to get a player pointer to
 		  * \returns A Pointer to the player
 		  */
-		Player* getPlayerByID(uint32_t id);
+		PlayerPtr getPlayerByID(uint32_t id);
 
 		/**
 		  * Returns a creature based on a string name identifier
 		  * \param s is the name identifier
 		  * \returns A Pointer to the creature
 		  */
-		Creature* getCreatureByName(const std::string& s);
+		CreaturePtr getCreatureByName(const std::string& s);
 
 		/**
 		  * Returns a npc based on a string name identifier
 		  * \param s is the name identifier
 		  * \returns A Pointer to the npc
 		  */
-		Npc* getNpcByName(const std::string& s);
+		NpcPtr getNpcByName(const std::string& s) const;
 
 		/**
 		  * Returns a player based on a string name identifier
 		  * \param s is the name identifier
 		  * \returns A Pointer to the player
 		  */
-		Player* getPlayerByName(const std::string& s);
+		PlayerPtr getPlayerByName(const std::string& s);
 
 		/**
 		  * Returns a player based on guid
 		  * \returns A Pointer to the player
 		  */
-		Player* getPlayerByGUID(const uint32_t& guid);
+		PlayerPtr getPlayerByGUID(const uint32_t& guid);
 
 		/**
 		  * Returns a player based on a string name identifier, with support for the "~" wildcard.
 		  * \param s is the name identifier, with or without wildcard
-		  * \param player will point to the found player (if any)
 		  * \return "RETURNVALUE_PLAYERWITHTHISNAMEISNOTONLINE" or "RETURNVALUE_NAMEISTOOAMBIGIOUS"
 		  */
-		ReturnValue getPlayerByNameWildcard(const std::string& s, Player*& player);
+		ReturnValue getPlayerByNameWildcard(const std::string& s);
 
 		/**
 		  * Returns a player based on an account number identifier
 		  * \param acc is the account identifier
 		  * \returns A Pointer to the player
 		  */
-		Player* getPlayerByAccount(uint32_t acc);
+		PlayerPtr getPlayerByAccount(uint32_t acc);
 
 		/**
 		  * Place Creature on the map without sending out events to the surrounding.
@@ -211,7 +210,7 @@ class Game
 		  * \param extendedPos If true, the creature will in first-hand be placed 2 tiles away
 		  * \param forced If true, placing the creature will not fail because of obstacles (creatures/items)
 		  */
-		bool internalPlaceCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false);
+		bool internalPlaceCreature(CreaturePtr creature, const Position& pos, bool extendedPos = false, bool forced = false);
 
 		/**
 		  * Place Creature on the map.
@@ -221,7 +220,7 @@ class Game
 		  * \param force If true, placing the creature will not fail because of obstacles (creatures/items)
 		  * \param MagicEffect the magic effect that appears with creature when placed.
 		  */
-		bool placeCreature(Creature* creature, const Position& pos, bool extendedPos = false, bool forced = false, MagicEffectClasses magicEffect = CONST_ME_TELEPORT);
+		bool placeCreature(CreaturePtr creature, const Position& pos, bool extendedPos = false, bool forced = false, MagicEffectClasses magicEffect = CONST_ME_TELEPORT);
 
 
 
@@ -230,21 +229,24 @@ class Game
 		  * Removes the Creature from the map
 		  * \param c Creature to remove
 		  */
-		bool removeCreature(Creature* creature, bool isLogout = true);
+		bool removeCreature(CreaturePtr creature, bool isLogout = true);
 		void executeDeath(uint32_t creatureId);
 
-		void addCreatureCheck(Creature* creature);
-		static void removeCreatureCheck(Creature* creature);
+		void addCreatureCheck(const CreaturePtr& creature);
+		static void removeCreatureCheck(const CreaturePtr& creature);
 
 		size_t getPlayersOnline() const {
 			return players.size();
 		}
+
 		size_t getMonstersOnline() const {
 			return monsters.size();
 		}
+
 		size_t getNpcsOnline() const {
 			return npcs.size();
 		}
+
 		uint32_t getPlayersRecord() const {
 			return playersRecord;
 		}
@@ -252,6 +254,7 @@ class Game
 		LightInfo getWorldLightInfo() const {
 			return {lightLevel, lightColor};
 		}
+
 		void setWorldLightInfo(LightInfo lightInfo) {
 			lightLevel = lightInfo.level;
 			lightColor = lightInfo.color;
@@ -259,21 +262,23 @@ class Game
 				it.second->sendWorldLight(lightInfo);
 			}
 		}
+
 		void updateWorldLightLevel();
 
-		ReturnValue internalMoveCreature(Creature* creature, Direction direction, uint32_t flags = 0);
-		ReturnValue internalMoveCreature(Creature& creature, Tile& toTile, uint32_t flags = 0);
+		ReturnValue internalMoveCreature(CreaturePtr creature, Direction direction, uint32_t flags = 0);
+		ReturnValue internalMoveCreature(CreaturePtr creature, TilePtr toTile, uint32_t flags = 0);
 
-		ReturnValue internalMoveItem(Cylinder* fromCylinder, Cylinder* toCylinder, int32_t index,
-		                             Item* item, uint32_t count, Item** _moveItem, uint32_t flags = 0, Creature* actor = nullptr, Item* tradeItem = nullptr, const Position* fromPos = nullptr, const Position* toPos = nullptr);
+		ReturnValue internalMoveItem(CylinderPtr& fromCylinder, CylinderPtr& toCylinder, int32_t index,
+		                             ItemPtr item, uint32_t count, ItemPtr* _moveItem, uint32_t flags = 0, const std::optional<CreaturePtr>& actor = std::nullopt, const std::optional<ItemPtr>& tradeItem = std::nullopt, const Position* fromPos = nullptr, const Position* toPos = nullptr);
+							// another spot to use a ref wrapper and possibly optional for ItemPtr* above
 
-		ReturnValue internalAddItem(Cylinder* toCylinder, Item* item, int32_t index = INDEX_WHEREEVER,
+		ReturnValue internalAddItem(CylinderPtr& toCylinder, ItemPtr item, int32_t index = INDEX_WHEREEVER,
 		                            uint32_t flags = 0, bool test = false);
-		ReturnValue internalAddItem(Cylinder* toCylinder, Item* item, int32_t index,
+		ReturnValue internalAddItem(CylinderPtr& toCylinder, ItemPtr& item, int32_t index,
 		                            uint32_t flags, bool test, uint32_t& remainderCount);
-		ReturnValue internalRemoveItem(Item* item, int32_t count = -1, bool test = false, uint32_t flags = 0);
+		ReturnValue internalRemoveItem(ItemPtr item, int32_t count = -1, bool test = false, uint32_t flags = 0);
 
-		ReturnValue internalPlayerAddItem(Player* player, Item* item, bool dropOnMap = true, slots_t slot = CONST_SLOT_WHEREEVER);
+		ReturnValue internalPlayerAddItem(const PlayerPtr& player, ItemPtr item, bool dropOnMap = true, slots_t slot = CONST_SLOT_WHEREEVER);
 
 		/**
 		  * Find an item of a certain type
@@ -284,7 +289,7 @@ class Game
 		  * \param depthSearch if true it will check child containers aswell
 		  * \returns A pointer to the item to an item and nullptr if not found
 		  */
-		Item* findItemOfType(Cylinder* cylinder, uint16_t itemId,
+		ItemPtr findItemOfType(const CylinderPtr& cylinder, uint16_t itemId,
 		                     bool depthSearch = true, int32_t subType = -1) const;
 
 		/**
@@ -294,7 +299,7 @@ class Game
 		  * \param flags optional flags to modify the default behavior
 		  * \returns true if the removal was successful
 		  */
-		bool removeMoney(Cylinder* cylinder, uint64_t money, uint32_t flags = 0);
+		bool removeMoney(CylinderPtr& cylinder, uint64_t money, uint32_t flags = 0);
 
 		/**
 		  * Add item(s) with monetary value
@@ -302,7 +307,7 @@ class Game
 		  * \param money the amount to give
 		  * \param flags optional flags to modify default behavior
 		  */
-		void addMoney(Cylinder* cylinder, uint64_t money, uint32_t flags = 0);
+		void addMoney( CylinderPtr& cylinder, uint64_t money, uint32_t flags = 0);
 
 		/**
 		  * Transform one item to another type/count
@@ -311,7 +316,7 @@ class Game
 		  * \param newCount is the new count value, use default value (-1) to not change it
 		  * \returns true if the transformation was successful
 		  */
-		Item* transformItem(Item* item, uint16_t newId, int32_t newCount = -1);
+		ItemPtr transformItem(const ItemPtr& item, uint16_t newId, int32_t newCount = -1);
 
 		/**
 		  * Teleports an object to another position
@@ -321,14 +326,14 @@ class Game
 		  * \param flags optional flags to modify default behavior
 		  * \returns true if the teleportation was successful
 		  */
-		ReturnValue internalTeleport(Thing* thing, const Position& newPos, bool pushMove = true, uint32_t flags = 0);
+		ReturnValue internalTeleport(const ThingPtr& thing, const Position& newPos, bool pushMove = true, uint32_t flags = 0);
 
 		/**
 		  * Turn a creature to a different direction.
 		  * \param creature Creature to change the direction
 		  * \param dir Direction to turn to
 		  */
-		bool internalCreatureTurn(Creature* creature, Direction dir);
+		bool internalCreatureTurn(const CreaturePtr& creature, Direction dir);
 
 		/**
 		  * Creature wants to say something.
@@ -336,7 +341,7 @@ class Game
 		  * \param type Type of message
 		  * \param text The text to say
 		  */
-		bool internalCreatureSay(Creature* creature, SpeakClasses type, const std::string& text,
+		bool internalCreatureSay(const CreaturePtr& creature, SpeakClasses type, const std::string& text,
 		                         bool ghostMode, SpectatorVec* spectatorsPtr = nullptr, const Position* pos = nullptr, bool echo = false);
 
 		void loadPlayersRecord();
@@ -349,19 +354,19 @@ class Game
 		void playerAnswerModalWindow(uint32_t playerId, uint32_t modalWindowId, uint8_t button, uint8_t choice);
 		void playerReportRuleViolation(uint32_t playerId, const std::string& targetName, uint8_t reportType, uint8_t reportReason, const std::string& comment, const std::string& translation);
 
-		bool internalStartTrade(Player* player, Player* tradePartner, Item* tradeItem);
-		void internalCloseTrade(Player* player, bool sendCancel = true);
-		bool playerBroadcastMessage(Player* player, const std::string& text) const;
+		bool internalStartTrade(const PlayerPtr& player, const PlayerPtr& tradePartner, const ItemPtr& tradeItem);
+		void internalCloseTrade(const PlayerPtr& player, bool sendCancel = true);
+		bool playerBroadcastMessage(const PlayerPtr& player, const std::string& text) const;
 		void broadcastMessage(const std::string& text, MessageClasses type) const;
 
 		//Implementation of player invoked events
 		void playerMoveThing(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos,
 		                     const Position& toPos, uint8_t count);
 		void playerMoveCreatureByID(uint32_t playerId, uint32_t movingCreatureId, const Position& movingCreatureOrigPos, const Position& toPos);
-		void playerMoveCreature(Player* player, Creature* movingCreature, const Position& movingCreatureOrigPos, Tile* toTile);
+		void playerMoveCreature(PlayerPtr& player, CreaturePtr& movingCreature, const Position& movingCreatureOrigPos, TilePtr& toTile);
 		void playerMoveItemByPlayerID(uint32_t playerId, const Position& fromPos, uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count);
-		void playerMoveItem(Player* player, const Position& fromPos,
-		                    uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count, Item* item, Cylinder* toCylinder);
+		void playerMoveItem(const PlayerPtr& player, const Position& fromPos,
+		                    uint16_t spriteId, uint8_t fromStackPos, const Position& toPos, uint8_t count, ItemPtr& item, CylinderPtr& toCylinder);
 		void playerEquipItem(uint32_t playerId, uint16_t spriteId);
 		void playerMove(uint32_t playerId, Direction direction);
 		void playerCreatePrivateChannel(uint32_t playerId);
@@ -433,27 +438,25 @@ class Game
 
 		void parsePlayerExtendedOpcode(uint32_t playerId, uint8_t opcode, const std::string& buffer);
 
-		std::vector<Item*> getMarketItemList(uint16_t wareId, uint16_t sufficientCount, const Player& player);
+		std::vector<ItemPtr> getMarketItemList(uint16_t wareId, uint16_t sufficientCount, const PlayerConstPtr& player);
 
 		void cleanup();
 		void shutdown();
-		void ReleaseCreature(Creature* creature);
-		void ReleaseItem(Item* item);
 
 		bool canThrowObjectTo(const Position& fromPos, const Position& toPos, bool checkLineOfSight = true, bool sameFloor = false,
-		                      int32_t rangex = Map::maxClientViewportX, int32_t rangey = Map::maxClientViewportY) const;
-		bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false) const;
+		                      int32_t rangex = Map::maxClientViewportX, int32_t rangey = Map::maxClientViewportY);
+		bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false);
 
-		void changeSpeed(Creature* creature, int32_t varSpeedDelta);
-		void internalCreatureChangeOutfit(Creature* creature, const Outfit_t& outfit);
-		void internalCreatureChangeVisible(Creature* creature, bool visible);
-		void changeLight(const Creature* creature);
-		void updateCreatureSkull(const Creature* creature);
-		void updatePlayerShield(Player* player);
-		void updatePlayerHelpers(const Player& player);
-		void updateCreatureType(Creature* creature);
-		void updateCreatureWalkthrough(const Creature* creature);
-		void notifySpectators(const Creature* creature);
+		void changeSpeed(const CreaturePtr& creature, int32_t varSpeedDelta);
+		void internalCreatureChangeOutfit(const CreaturePtr& creature, const Outfit_t& outfit);
+		void internalCreatureChangeVisible(const CreaturePtr& creature, bool visible);
+		void changeLight(const CreatureConstPtr& creature);
+		void updateCreatureSkull(const CreatureConstPtr& creature);
+		void updatePlayerShield(const PlayerPtr& player);
+		void updatePlayerHelpers(const PlayerConstPtr& player);
+		void updateCreatureType(const CreaturePtr& creature);
+		void updateCreatureWalkthrough(const CreatureConstPtr& creature);
+		void notifySpectators(const CreatureConstPtr& creature);
 
 		GameState_t getGameState() const;
 		void setGameState(GameState_t newState);
@@ -466,16 +469,16 @@ class Game
 		void checkCreatures(size_t index);
 		void checkLight();
 
-		bool combatBlockHit(CombatDamage& damage, Creature* attacker, Creature* target, bool checkDefense, bool checkArmor, bool field, bool ignoreResistances = false);
+		bool combatBlockHit(CombatDamage& damage, const CreaturePtr& attacker, const CreaturePtr& target, bool checkDefense, bool checkArmor, bool field, bool ignoreResistances = false);
 
-		void combatGetTypeInfo(CombatType_t combatType, Creature* target, TextColor_t& color, uint8_t& effect);
+		void combatGetTypeInfo(CombatType_t combatType, const CreaturePtr& target, TextColor_t& color, uint8_t& effect);
 
-		bool combatChangeHealth(Creature* attacker, Creature* target, CombatDamage& damage);
-		bool combatChangeMana(Creature* attacker, Creature* target, CombatDamage& damage);
+		bool combatChangeHealth(const CreaturePtr& attacker, const CreaturePtr& target, CombatDamage& damage);
+		bool combatChangeMana(const CreaturePtr& attacker, const CreaturePtr& target, CombatDamage& damage);
 
 		//animation help functions
-		void addCreatureHealth(const Creature* target);
-		static void addCreatureHealth(const SpectatorVec& spectators, const Creature* target);
+		void addCreatureHealth(const CreatureConstPtr& target);
+		static void addCreatureHealth(const SpectatorVec& spectators, const CreatureConstPtr& target);
 		void addMagicEffect(const Position& pos, uint8_t effect);
 		static void addMagicEffect(const SpectatorVec& spectators, const Position& pos, uint8_t effect);
 		void addDistanceEffect(const Position& fromPos, const Position& toPos, uint8_t effect);
@@ -486,9 +489,9 @@ class Game
 		void loadAccountStorageValues();
 		bool saveAccountStorageValues() const;
 
-		void startDecay(Item* item);
+		void startDecay(const ItemPtr& item);
 
-		int16_t getWorldTime() { return worldTime; }
+		int16_t getWorldTime() const { return worldTime; }
 		void updateWorldTime();
 
 		void loadMotdNum();
@@ -497,36 +500,36 @@ class Game
 		uint32_t getMotdNum() const { return motdNum; }
 		void incrementMotdNum() { motdNum++; }
 
-		void sendOfflineTrainingDialog(Player* player);
+		void sendOfflineTrainingDialog(const PlayerPtr& player) const;
 
-		const std::unordered_map<uint32_t, Player*>& getPlayers() const { return players; }
-		const std::map<uint32_t, Npc*>& getNpcs() const { return npcs; }
-		const std::map<uint32_t, Monster*>& getMonsters() const { return monsters; }
+		const std::unordered_map<uint32_t, PlayerPtr>& getPlayers() const { return players; }
+		const std::map<uint32_t, NpcPtr>& getNpcs() const { return npcs; }
+		const std::map<uint32_t, MonsterPtr>& getMonsters() const { return monsters; }
 
-		void addPlayer(Player* player);
-		void removePlayer(Player* player);
+		void addPlayer(PlayerPtr player);
+		void removePlayer(const PlayerPtr& player);
 
-		void addNpc(Npc* npc);
-		void removeNpc(Npc* npc);
+		void addNpc(NpcPtr npc);
+		void removeNpc(const NpcPtr& npc);
 
-		void addMonster(Monster* monster);
-		void removeMonster(Monster* monster);
+		void addMonster(MonsterPtr monster);
+		void removeMonster(const MonsterPtr& monster);
 
 		Guild* getGuild(uint32_t id) const;
 		void addGuild(Guild* guild);
 		void removeGuild(uint32_t guildId);
 		void decreaseBrowseFieldRef(const Position& pos);
 
-		std::unordered_map<Tile*, Container*> browseFields;
+		std::unordered_map<TilePtr, ContainerPtr> browseFields;
 
-		void internalRemoveItems(std::vector<Item*> itemList, uint32_t amount, bool stackable);
+		void internalRemoveItems(const std::vector<ItemPtr>& itemList, uint32_t amount, bool stackable);
 
-		BedItem* getBedBySleeper(uint32_t guid) const;
-		void setBedSleeper(BedItem* bed, uint32_t guid);
+		BedItemPtr getBedBySleeper(uint32_t guid) const;
+		void setBedSleeper(const BedItemPtr& bed, uint32_t guid);
 		void removeBedSleeper(uint32_t guid);
 
-		Item* getUniqueItem(uint16_t uniqueId);
-		bool addUniqueItem(uint16_t uniqueId, Item* item);
+		ItemPtr getUniqueItem(uint16_t uniqueId);
+		bool addUniqueItem(uint16_t uniqueId, const ItemPtr& item);
 		void removeUniqueItem(uint16_t uniqueId);
 
 		bool reload(ReloadTypes_t reloadType);
@@ -537,63 +540,67 @@ class Game
 		Raids raids;
 		Quests quests;
 
-		std::forward_list<Item*> toDecayItems;
+		std::forward_list<ItemPtr> toDecayItems;
 
-		std::unordered_set<Tile*> getTilesToClean() const {
+		std::unordered_set<TilePtr> getTilesToClean() const {
 			return tilesToClean;
 		}
-		bool isTileInCleanList(Tile* tile) { 
-			return tilesToClean.find(tile) != tilesToClean.end(); 
+	
+		bool isTileInCleanList(const TilePtr& tile) const { 
+			return tilesToClean.contains(tile); 
 		}
-		void addTileToClean(Tile* tile) {
+	
+		void addTileToClean(TilePtr tile) {
 			tilesToClean.emplace(tile);
 		}
-		void removeTileToClean(Tile* tile) {
+	
+		void removeTileToClean(const TilePtr& tile) {
 			tilesToClean.erase(tile);
 		}
+	
 		void clearTilesToClean() {
 			tilesToClean.clear();
 		}
 
+
 		CURL* curl;
 
 	private:
-		bool playerSaySpell(Player* player, SpeakClasses type, const std::string& text);
-		void playerWhisper(Player* player, const std::string& text);
-		bool playerYell(Player* player, const std::string& text);
-		bool playerSpeakTo(Player* player, SpeakClasses type, const std::string& receiver, const std::string& text);
-		void playerSpeakToNpc(Player* player, const std::string& text);
+		bool playerSaySpell(const PlayerPtr& player, SpeakClasses type, const std::string& text);
+		void playerWhisper(const PlayerPtr& player, const std::string& text);
+		bool playerYell(const PlayerPtr& player, const std::string& text);
+		bool playerSpeakTo(const PlayerPtr& player, SpeakClasses type, const std::string& receiver, const std::string& text);
+		void playerSpeakToNpc(const PlayerPtr& player, const std::string& text);
 
 		void checkDecay();
-		void internalDecayItem(Item* item);
+		void internalDecayItem(const ItemPtr& item);
 
-		std::unordered_map<uint32_t, Player*> players;
-		std::unordered_map<std::string, Player*> mappedPlayerNames;
-		std::unordered_map<uint32_t, Player*> mappedPlayerGuids;
+		std::unordered_map<uint32_t, PlayerPtr> players;
+		std::unordered_map<std::string, PlayerPtr> mappedPlayerNames;
+		std::unordered_map<uint32_t, PlayerPtr> mappedPlayerGuids;
 		std::unordered_map<uint32_t, Guild*> guilds;
-		std::unordered_map<uint16_t, Item*> uniqueItems;
+		std::vector<TilePtr> loaded_tiles;
+		std::vector<ItemPtr> loaded_tile_items;
+		std::unordered_map<uint16_t, ItemPtr> uniqueItems;
 		std::map<uint32_t, uint32_t> stages;
 		std::unordered_map<uint32_t, std::unordered_map<uint32_t, int32_t>> accountStorageMap;
 
-		std::list<Item*> decayItems[EVENT_DECAY_BUCKETS];
-		std::list<Creature*> checkCreatureLists[EVENT_CREATURECOUNT];
-
-		std::vector<Creature*> ToReleaseCreatures;
-		std::vector<Item*> ToReleaseItems;
-
+		std::list<ItemPtr> decayItems[EVENT_DECAY_BUCKETS];
+		std::list<CreaturePtr> checkCreatureLists[EVENT_CREATURECOUNT];
+	
 		size_t lastBucket = 0;
 
 		WildcardTreeNode wildcardTree { false };
 
-		std::map<uint32_t, Npc*> npcs;
-		std::map<uint32_t, Monster*> monsters;
+		std::map<uint32_t, NpcPtr> npcs;
+		std::map<uint32_t, MonsterPtr> monsters;
 
 		//list of items that are in trading state, mapped to the player
-		std::map<Item*, uint32_t> tradeItems;
+		std::map<ItemPtr, uint32_t> tradeItems;
 
-		std::map<uint32_t, BedItem*> bedSleepersMap;
+		std::map<uint32_t, BedItemPtr> bedSleepersMap;
 
-		std::unordered_set<Tile*> tilesToClean;
+		std::unordered_set<TilePtr> tilesToClean;
 
 		ModalWindow offlineTrainingWindow { std::numeric_limits<uint32_t>::max(), "Choose a Skill", "Please choose a skill:" };
 

--- a/src/globalevent.cpp
+++ b/src/globalevent.cpp
@@ -327,7 +327,7 @@ std::string_view GlobalEvent::getScriptEventName() const
 	}
 }
 
-bool GlobalEvent::executeRecord(uint32_t current, uint32_t old)
+bool GlobalEvent::executeRecord(uint32_t current, uint32_t old) const
 {
 	//onRecord(current, old)
 	if (!scriptInterface->reserveScriptEnv()) {

--- a/src/globalevent.h
+++ b/src/globalevent.h
@@ -53,6 +53,7 @@ class GlobalEvents final : public BaseEvents
 		LuaScriptInterface& getScriptInterface() override {
 			return scriptInterface;
 		}
+	
 		LuaScriptInterface scriptInterface;
 
 		GlobalEventMap thinkMap, serverMap, timerMap;
@@ -66,12 +67,13 @@ class GlobalEvent final : public Event
 
 		bool configureEvent(const pugi::xml_node& node) override;
 
-		bool executeRecord(uint32_t current, uint32_t old);
+		bool executeRecord(uint32_t current, uint32_t old) const;
 		bool executeEvent() const;
 
 		GlobalEvent_t getEventType() const {
 			return eventType;
 		}
+	
 		void setEventType(GlobalEvent_t type) {
 			eventType = type;
 		}
@@ -79,13 +81,15 @@ class GlobalEvent final : public Event
 		const std::string& getName() const {
 			return name;
 		}
-		void setName(std::string eventName) {
+	
+		void setName(const std::string& eventName) {
 			name = eventName;
 		}
 
 		uint32_t getInterval() const {
 			return interval;
 		}
+	
 		void setInterval(uint32_t eventInterval) {
 			interval |= eventInterval;
 		}
@@ -93,6 +97,7 @@ class GlobalEvent final : public Event
 		int64_t getNextExecution() const {
 			return nextExecution;
 		}
+	
 		void setNextExecution(int64_t time) {
 			nextExecution = time;
 		}

--- a/src/guild.cpp
+++ b/src/guild.cpp
@@ -9,21 +9,21 @@
 
 extern Game g_game;
 
-void Guild::addMember(Player* player)
+void Guild::addMember(const PlayerPtr& player)
 {
 	membersOnline.push_back(player);
-	for (Player* member : membersOnline) {
-		g_game.updatePlayerHelpers(*member);
+	for (const auto member : membersOnline) {
+		g_game.updatePlayerHelpers(member);
 	}
 }
 
-void Guild::removeMember(Player* player)
+void Guild::removeMember(const PlayerPtr& player)
 {
 	membersOnline.remove(player);
-	for (Player* member : membersOnline) {
-		g_game.updatePlayerHelpers(*member);
+	for (const auto member : membersOnline) {
+		g_game.updatePlayerHelpers(member);
 	}
-	g_game.updatePlayerHelpers(*player);
+	g_game.updatePlayerHelpers(player);
 
 	if (membersOnline.empty()) {
 		g_game.removeGuild(id);
@@ -31,7 +31,7 @@ void Guild::removeMember(Player* player)
 	}
 }
 
-GuildRank_ptr Guild::getRankById(uint32_t rankId)
+GuildRank_ptr Guild::getRankById(const uint32_t rankId) const
 {
 	for (auto rank : ranks) {
 		if (rank->id == rankId) {

--- a/src/guild.h
+++ b/src/guild.h
@@ -3,6 +3,7 @@
 
 #ifndef FS_GUILD_H
 #define FS_GUILD_H
+#include "creature.h"
 
 class Player;
 
@@ -11,7 +12,7 @@ struct GuildRank {
 	std::string name;
 	uint8_t level;
 
-	GuildRank(uint32_t id, std::string_view name, uint8_t level) : id{ id }, name{ name }, level{ level } {}
+	GuildRank(const uint32_t id, const std::string_view name, const uint8_t level) : id{ id }, name{ name }, level{ level } {}
 };
 
 using GuildRank_ptr = std::shared_ptr<GuildRank>;
@@ -19,44 +20,51 @@ using GuildRank_ptr = std::shared_ptr<GuildRank>;
 class Guild
 {
 	public:
-		Guild(uint32_t id, std::string_view name) : name{ name }, id{ id } {}
+		Guild(const uint32_t id, const std::string_view name) : name{ name }, id{ id } {}
 
-		void addMember(Player* player);
-		void removeMember(Player* player);
+		void addMember(const PlayerPtr& player);
+		void removeMember(const PlayerPtr& player);
 
 		uint32_t getId() const {
 			return id;
 		}
+	
 		const std::string& getName() const {
 			return name;
 		}
-		const std::list<Player*>& getMembersOnline() const {
+	
+		const std::list<PlayerPtr>& getMembersOnline() const {
 			return membersOnline;
 		}
+	
 		uint32_t getMemberCount() const {
 			return memberCount;
 		}
-		void setMemberCount(uint32_t count) {
+	
+		void setMemberCount(const uint32_t count) {
 			memberCount = count;
 		}
 
 		const std::vector<GuildRank_ptr>& getRanks() const {
 			return ranks;
 		}
-		GuildRank_ptr getRankById(uint32_t rankId);
+	
+		GuildRank_ptr getRankById(uint32_t rankId) const;
 		GuildRank_ptr getRankByName(const std::string& name) const;
 		GuildRank_ptr getRankByLevel(uint8_t level) const;
+	
 		void addRank(uint32_t rankId, std::string_view rankName, uint8_t level);
 
 		const std::string& getMotd() const {
 			return motd;
 		}
+	
 		void setMotd(const std::string& motd) {
 			this->motd = motd;
 		}
 
 	private:
-		std::list<Player*> membersOnline;
+		std::list<PlayerPtr> membersOnline;
 		std::vector<GuildRank_ptr> ranks;
 		std::string name;
 		std::string motd;

--- a/src/house.cpp
+++ b/src/house.cpp
@@ -236,7 +236,7 @@ bool House::transferToDepot(const PlayerPtr& player) const
 	CylinderPtr inbox = player->getInbox();
 	for (const auto item : moveItemList) {
 		CylinderPtr parent = item->getParent();
-		g_game.internalMoveItem(parent, inbox, INDEX_WHEREEVER, item, item->getItemCount(), nullptr, FLAG_NOLIMIT);
+		g_game.internalMoveItem(parent, inbox, INDEX_WHEREEVER, item, item->getItemCount(), std::nullopt, FLAG_NOLIMIT);
 	}
 	return true;
 }

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -85,7 +85,7 @@ ReturnValue HouseTile::queryAdd(int32_t index, const ThingPtr& thing, uint32_t c
 	return RETURNVALUE_NOERROR;
 }
 
-CylinderPtr HouseTile::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem, uint32_t& flags)
+CylinderPtr HouseTile::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem, uint32_t& flags)
 {
 	if (const auto creature = thing->getCreature()) {
 		if (const auto player = creature->getPlayer()) {
@@ -105,7 +105,7 @@ CylinderPtr HouseTile::queryDestination(int32_t& index, const ThingPtr& thing, I
 				}
 
 				index = -1;
-				*destItem = nullptr;
+				destItem = nullptr;
 				return destTile;
 			}
 		}

--- a/src/housetile.cpp
+++ b/src/housetile.cpp
@@ -93,11 +93,6 @@ CylinderPtr HouseTile::queryDestination(int32_t& index, const ThingPtr& thing, I
 				const Position& entryPos = house->getEntryPosition();
 				auto destTile = g_game.map.getTile(entryPos);
 				if (!destTile) {
-					std::cout << "Error: [HouseTile::queryDestination] House entry not correct"
-					          << " - Name: " << house->getName()
-					          << " - House id: " << house->getId()
-					          << " - Tile not found: " << entryPos << std::endl;
-
 					destTile = g_game.map.getTile(player->getTemplePosition());
 					if (!destTile) {
 						destTile = std::make_shared<StaticTile>(0xFFFF, 0xFFFF, 0xFF);

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -17,7 +17,7 @@ class HouseTile final : public DynamicTile
 		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
 		                     uint32_t flags, CreaturePtr actor = nullptr) override;
 
-		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 				uint32_t& flags) override; // another optional ref wrapper
 
 		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;

--- a/src/housetile.h
+++ b/src/housetile.h
@@ -14,23 +14,31 @@ class HouseTile final : public DynamicTile
 		HouseTile(int32_t x, int32_t y, int32_t z, House* house);
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                     uint32_t flags, CreaturePtr actor = nullptr) override;
 
-		Tile* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
-				uint32_t& flags) override;
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+				uint32_t& flags) override; // another optional ref wrapper
 
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
 
-		void addThing(int32_t index, Thing* thing) override;
-		void internalAddThing(uint32_t index, Thing* thing) override;
+		void addThing(int32_t index, ThingPtr thing) override;
+		void internalAddThing(uint32_t index, ThingPtr thing) override;
 
 		House* getHouse() const {
 			return house;
 		}
 
+		HouseTilePtr getHouseTilePtr() {
+			return dynamic_shared_this<HouseTile>();
+		}
+
+		HouseTileConstPtr getHouseTileConstPtr() {
+			return dynamic_shared_this<const HouseTile>();
+		}
+
 	private:
-		void updateHouse(Item* item);
+		void updateHouse(const ItemPtr& item);
 
 		House* house;
 };

--- a/src/inbox.cpp
+++ b/src/inbox.cpp
@@ -8,19 +8,19 @@
 
 Inbox::Inbox(uint16_t type) : Container(type, 30, false, true) {}
 
-ReturnValue Inbox::queryAdd(int32_t, const Thing& thing, uint32_t,
-		uint32_t flags, Creature*) const
+ReturnValue Inbox::queryAdd(int32_t, const ThingPtr& thing, uint32_t,
+                            uint32_t flags, CreaturePtr)
 {
 	if (!hasBitSet(FLAG_NOLIMIT, flags)) {
 		return RETURNVALUE_CONTAINERNOTENOUGHROOM;
 	}
 
-	const Item* item = thing.getItem();
+	auto item = thing->getItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	if (item == this) {
+	if (item.get() == this) {
 		return RETURNVALUE_THISISIMPOSSIBLE;
 	}
 
@@ -31,26 +31,24 @@ ReturnValue Inbox::queryAdd(int32_t, const Thing& thing, uint32_t,
 	return RETURNVALUE_NOERROR;
 }
 
-void Inbox::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)
+void Inbox::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t)
 {
-	Cylinder* parent = getParent();
-	if (parent != nullptr) {
+	if (const auto parent = getParent(); parent != nullptr) {
 		parent->postAddNotification(thing, oldParent, index, LINK_PARENT);
 	}
 }
 
-void Inbox::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t)
+void Inbox::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t)
 {
-	Cylinder* parent = getParent();
-	if (parent != nullptr) {
+	if (const auto parent = getParent(); parent != nullptr) {
 		parent->postRemoveNotification(thing, newParent, index, LINK_PARENT);
 	}
 }
 
-Cylinder* Inbox::getParent() const
+CylinderPtr Inbox::getParent()
 {
-	if (parent) {
-		return parent->getParent();
+	if (parent.lock()) {
+		return parent.lock()->getParent();
 	}
 	return nullptr;
 }

--- a/src/inbox.h
+++ b/src/inbox.h
@@ -12,22 +12,26 @@ class Inbox final : public Container
 		explicit Inbox(uint16_t type);
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                     uint32_t flags, CreaturePtr actor = nullptr) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 		//overrides
 		bool canRemove() const override {
 			return false;
 		}
 
-		Cylinder* getParent() const override;
-		Cylinder* getRealParent() const override {
-			return parent;
+		CylinderPtr getParent() override;
+	
+		CylinderPtr getRealParent() override {
+			return getParent();
 		}
 };
+
+using InboxPtr = std::shared_ptr<Inbox>;
+using InboxConstPtr = std::shared_ptr<const Inbox>;
 
 #endif
 

--- a/src/iologindata.h
+++ b/src/iologindata.h
@@ -8,7 +8,7 @@
 #include "player.h"
 #include "database.h"
 
-using ItemBlockList = std::list<std::pair<int32_t, Item*>>;
+using ItemBlockList = std::list<std::pair<int32_t, ItemPtr>>;
 
 class IOLoginData
 {
@@ -23,12 +23,12 @@ class IOLoginData
 		static AccountType_t getAccountType(uint32_t accountId);
 		static void setAccountType(uint32_t accountId, AccountType_t accountType);
 		static void updateOnlineStatus(uint32_t guid, bool login);
-		static bool preloadPlayer(Player* player);
+		static bool preloadPlayer(const PlayerPtr& player);
 
-		static bool loadPlayerById(Player* player, uint32_t id);
-		static bool loadPlayerByName(Player* player, const std::string& name);
-		static bool loadPlayer(Player* player, DBResult_ptr result);
-		static bool savePlayer(Player* player);
+		static bool loadPlayerById(const PlayerPtr& player, uint32_t id);
+		static bool loadPlayerByName(const PlayerPtr& player, const std::string& name);
+		static bool loadPlayer(const PlayerPtr& player, DBResult_ptr result);
+		static bool savePlayer(const PlayerPtr& player);
 		static uint32_t getGuidByName(const std::string& name);
 		static bool getGuidByNameEx(uint32_t& guid, bool& specialVip, std::string& name);
 		static std::string getNameByGuid(uint32_t guid);
@@ -46,12 +46,12 @@ class IOLoginData
 		static bool addRewardItems(uint32_t playerId, const ItemBlockList& itemList, DBInsert& query_insert, PropWriteStream& propWriteStream);
 
 	private:
-		using ItemMap = std::map<uint32_t, std::pair<Item*, uint32_t>>;
+		using ItemMap = std::map<uint32_t, std::pair<ItemPtr, uint32_t>>;
 
-		static void loadItems(ItemMap& itemMap, DBResult_ptr result);
-		static bool saveItems(const Player* player, const ItemBlockList& itemList, DBInsert& query_insert, PropWriteStream& propWriteStream);
-		static bool saveAugments(const Player* player, DBInsert& query_insert, PropWriteStream& augmentStream);
-		static void loadPlayerAugments(std::vector<std::shared_ptr<Augment>>& augmentList, DBResult_ptr result);
+		static void loadItems(ItemMap& itemMap, const DBResult_ptr& result);
+		static bool saveItems(const PlayerConstPtr& player, const ItemBlockList& itemList, DBInsert& query_insert, PropWriteStream& propWriteStream);
+		static bool saveAugments(const PlayerConstPtr& player, DBInsert& query_insert, PropWriteStream& augmentStream);
+		static void loadPlayerAugments(std::vector<std::shared_ptr<Augment>>& augmentList, const DBResult_ptr& result);
 };
 
 #endif

--- a/src/iomap.h
+++ b/src/iomap.h
@@ -88,7 +88,7 @@ struct OTBM_Tile_coords {
 
 class IOMap
 {
-	static Tile* createTile(Item*& ground, Item* item, uint16_t x, uint16_t y, uint8_t z);
+	static TilePtr createTile(ItemPtr& ground, ItemPtr item, uint16_t x, uint16_t y, uint8_t z);
 
 	public:
 		bool loadMap(Map* map, const std::filesystem::path& fileName);
@@ -127,7 +127,7 @@ class IOMap
 			return errorString;
 		}
 
-		void setLastErrorString(std::string error) {
+		void setLastErrorString(const std::string& error) {
 			errorString = error;
 		}
 

--- a/src/iomapserialize.h
+++ b/src/iomapserialize.h
@@ -19,11 +19,11 @@ class IOMapSerialize
 		static bool saveHouse(House* house);
 
 	private:
-		static void saveItem(PropWriteStream& stream, const Item* item);
-		static void saveTile(PropWriteStream& stream, const Tile* tile);
+		static void saveItem(PropWriteStream& stream, const ItemPtr& item);
+		static void saveTile(PropWriteStream& stream, const TilePtr& tile);
 
-		static bool loadContainer(PropStream& propStream, Container* container);
-		static bool loadItem(PropStream& propStream, Cylinder* parent);
+		static bool loadContainer(PropStream& propStream, const ContainerPtr& container);
+		static bool loadItem(PropStream& propStream, const CylinderPtr& parent);
 };
 
 #endif

--- a/src/iomarket.cpp
+++ b/src/iomarket.cpp
@@ -95,7 +95,7 @@ HistoryMarketOfferList IOMarket::getOwnHistory(MarketAction_t action, uint32_t p
 	return offerList;
 }
 
-void IOMarket::processExpiredOffers(DBResult_ptr result, bool)
+void IOMarket::processExpiredOffers(const DBResult_ptr& result, bool)
 {
 	if (!result) {
 		return;
@@ -114,11 +114,10 @@ void IOMarket::processExpiredOffers(DBResult_ptr result, bool)
 				continue;
 			}
 
-			Player* player = g_game.getPlayerByGUID(playerId);
+			auto player = g_game.getPlayerByGUID(playerId);
 			if (!player) {
-				player = new Player(nullptr);
+				player = std::make_shared<Player>(nullptr);
 				if (!IOLoginData::loadPlayerById(player, playerId)) {
-					delete player;
 					continue;
 				}
 			}
@@ -127,9 +126,8 @@ void IOMarket::processExpiredOffers(DBResult_ptr result, bool)
 				uint16_t tmpAmount = amount;
 				while (tmpAmount > 0) {
 					uint16_t stackCount = std::min<uint16_t>(100, tmpAmount);
-					Item* item = Item::CreateItem(itemType.id, stackCount);
-					if (g_game.internalAddItem(player->getInbox(), item, INDEX_WHEREEVER, FLAG_NOLIMIT) != RETURNVALUE_NOERROR) {
-						delete item;
+					auto item = Item::CreateItem(itemType.id, stackCount);
+					if (CylinderPtr inbox = player->getInbox(); g_game.internalAddItem(inbox, item, INDEX_WHEREEVER, FLAG_NOLIMIT) != RETURNVALUE_NOERROR) {
 						break;
 					}
 
@@ -144,9 +142,8 @@ void IOMarket::processExpiredOffers(DBResult_ptr result, bool)
 				}
 
 				for (uint16_t i = 0; i < amount; ++i) {
-					Item* item = Item::CreateItem(itemType.id, subType);
-					if (g_game.internalAddItem(player->getInbox(), item, INDEX_WHEREEVER, FLAG_NOLIMIT) != RETURNVALUE_NOERROR) {
-						delete item;
+					auto item = Item::CreateItem(itemType.id, subType);
+					if (CylinderPtr inbox = player->getInbox(); g_game.internalAddItem(inbox, item, INDEX_WHEREEVER, FLAG_NOLIMIT) != RETURNVALUE_NOERROR) {
 						break;
 					}
 				}
@@ -154,13 +151,11 @@ void IOMarket::processExpiredOffers(DBResult_ptr result, bool)
 
 			if (player->isOffline()) {
 				IOLoginData::savePlayer(player);
-				delete player;
 			}
 		} else {
 			uint64_t totalPrice = result->getNumber<uint64_t>("price") * amount;
 
-			Player* player = g_game.getPlayerByGUID(playerId);
-			if (player) {
+			if (const auto player = g_game.getPlayerByGUID(playerId)) {
 				player->setBankBalance(player->getBankBalance() + totalPrice);
 			} else {
 				IOLoginData::increaseBankBalance(playerId, totalPrice);

--- a/src/iomarket.h
+++ b/src/iomarket.h
@@ -19,7 +19,7 @@ class IOMarket
 		static MarketOfferList getOwnOffers(MarketAction_t action, uint32_t playerId);
 		static HistoryMarketOfferList getOwnHistory(MarketAction_t action, uint32_t playerId);
 
-		static void processExpiredOffers(DBResult_ptr result, bool);
+		static void processExpiredOffers(const DBResult_ptr& result, bool);
 		static void checkExpiredOffers();
 
 		static uint32_t getPlayerOfferCount(uint32_t playerId);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -297,6 +297,24 @@ CylinderPtr Item::getTopParent()
 	return aux;
 }
 
+CylinderConstPtr Item::getTopParent() const
+{
+	CylinderConstPtr aux = getParent();
+	CylinderConstPtr prevaux = std::dynamic_pointer_cast<const Cylinder>(shared_from_this());
+	if (!aux) {
+		return prevaux;
+	}
+
+	while (aux->getParent() != nullptr) {
+		prevaux = aux;
+		aux = aux->getParent();
+	}
+
+	if (prevaux) {
+		return prevaux;
+	}
+	return aux;
+}
 
 TilePtr Item::getTile()
 {
@@ -306,6 +324,16 @@ TilePtr Item::getTile()
 		cylinder = cylinder->getParent();
 	}
 	return std::dynamic_pointer_cast<Tile>(cylinder);
+}
+
+std::shared_ptr<const Tile> Item::getTile() const
+{
+	auto cylinder = getTopParent();
+	//get root cylinder
+	if (cylinder && cylinder->getParent()) {
+		cylinder = cylinder->getParent();
+	}
+	return std::dynamic_pointer_cast<const Tile>(cylinder);
 }
 
 uint16_t Item::getSubType() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -326,7 +326,7 @@ TilePtr Item::getTile()
 	return std::dynamic_pointer_cast<Tile>(cylinder);
 }
 
-std::shared_ptr<const Tile> Item::getTile() const
+TileConstPtr Item::getTile() const
 {
 	auto cylinder = getTopParent();
 	//get root cylinder

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -305,7 +305,7 @@ TilePtr Item::getTile()
 	if (cylinder && cylinder->getParent()) {
 		cylinder = cylinder->getParent();
 	}
-	return cylinder->getTile();
+	return std::dynamic_pointer_cast<Tile>(cylinder);
 }
 
 uint16_t Item::getSubType() const

--- a/src/item.h
+++ b/src/item.h
@@ -15,6 +15,7 @@
 #include <boost/variant.hpp>
 #include <deque>
 
+
 class Creature;
 class Player;
 class Container;
@@ -25,6 +26,27 @@ class Mailbox;
 class Door;
 class MagicField;
 class BedItem;
+
+using DepotPtr = std::shared_ptr<Depot>;
+using DepotConstPtr = std::shared_ptr<const Depot>;
+
+using TeleportPtr = std::shared_ptr<Teleport>;
+using TeleportConstPtr = std::shared_ptr<const Teleport>;
+
+using TrashHolderPtr = std::shared_ptr<TrashHolder>;
+using TrashHolderConstPtr = std::shared_ptr<const TrashHolder>;
+
+using MailboxPtr = std::shared_ptr<Mailbox>;
+using MailboxConstPtr = std::shared_ptr<const Mailbox>;
+
+using DoorPtr = std::shared_ptr<Door>;
+using DoorConstPtr = std::shared_ptr<const Door>;
+
+using MagicFieldPtr = std::shared_ptr<MagicField>;
+using MagicFieldConstPtr = std::shared_ptr<const MagicField>;
+
+using BedItemPtr = std::shared_ptr<BedItem>;
+using BedItemConstPtr = std::shared_ptr<const BedItem>;
 
 enum ITEMPROPERTY {
 	CONST_PROP_BLOCKSOLID = 0,
@@ -114,6 +136,7 @@ class ItemAttributes
 		void setSpecialDescription(const std::string& desc) {
 			setStrAttr(ITEM_ATTRIBUTE_DESCRIPTION, desc);
 		}
+	
 		const std::string& getSpecialDescription() const {
 			return getStrAttr(ITEM_ATTRIBUTE_DESCRIPTION);
 		}
@@ -121,9 +144,11 @@ class ItemAttributes
 		void setText(const std::string& text) {
 			setStrAttr(ITEM_ATTRIBUTE_TEXT, text);
 		}
+	
 		void resetText() {
 			removeAttribute(ITEM_ATTRIBUTE_TEXT);
 		}
+	
 		const std::string& getText() const {
 			return getStrAttr(ITEM_ATTRIBUTE_TEXT);
 		}
@@ -131,9 +156,11 @@ class ItemAttributes
 		void setDate(int32_t n) {
 			setIntAttr(ITEM_ATTRIBUTE_DATE, n);
 		}
+	
 		void resetDate() {
 			removeAttribute(ITEM_ATTRIBUTE_DATE);
 		}
+	
 		time_t getDate() const {
 			return static_cast<time_t>(getIntAttr(ITEM_ATTRIBUTE_DATE));
 		}
@@ -141,9 +168,11 @@ class ItemAttributes
 		void setWriter(const std::string& writer) {
 			setStrAttr(ITEM_ATTRIBUTE_WRITER, writer);
 		}
+	
 		void resetWriter() {
 			removeAttribute(ITEM_ATTRIBUTE_WRITER);
 		}
+	
 		const std::string& getWriter() const {
 			return getStrAttr(ITEM_ATTRIBUTE_WRITER);
 		}
@@ -151,6 +180,7 @@ class ItemAttributes
 		void setActionId(uint16_t n) {
 			setIntAttr(ITEM_ATTRIBUTE_ACTIONID, n);
 		}
+	
 		uint16_t getActionId() const {
 			return static_cast<uint16_t>(getIntAttr(ITEM_ATTRIBUTE_ACTIONID));
 		}
@@ -158,6 +188,7 @@ class ItemAttributes
 		void setUniqueId(uint16_t n) {
 			setIntAttr(ITEM_ATTRIBUTE_UNIQUEID, n);
 		}
+	
 		uint16_t getUniqueId() const {
 			return static_cast<uint16_t>(getIntAttr(ITEM_ATTRIBUTE_UNIQUEID));
 		}
@@ -165,6 +196,7 @@ class ItemAttributes
 		void setCharges(uint16_t n) {
 			setIntAttr(ITEM_ATTRIBUTE_CHARGES, n);
 		}
+	
 		uint16_t getCharges() const {
 			return static_cast<uint16_t>(getIntAttr(ITEM_ATTRIBUTE_CHARGES));
 		}
@@ -172,6 +204,7 @@ class ItemAttributes
 		void setFluidType(uint16_t n) {
 			setIntAttr(ITEM_ATTRIBUTE_FLUIDTYPE, n);
 		}
+	
 		uint16_t getFluidType() const {
 			return static_cast<uint16_t>(getIntAttr(ITEM_ATTRIBUTE_FLUIDTYPE));
 		}
@@ -179,6 +212,7 @@ class ItemAttributes
 		void setOwner(uint32_t owner) {
 			setIntAttr(ITEM_ATTRIBUTE_OWNER, owner);
 		}
+	
 		uint32_t getOwner() const {
 			return getIntAttr(ITEM_ATTRIBUTE_OWNER);
 		}
@@ -186,6 +220,7 @@ class ItemAttributes
 		void setCorpseOwner(uint32_t corpseOwner) {
 			setIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER, corpseOwner);
 		}
+	
 		uint32_t getCorpseOwner() const {
 			return getIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER);
 		}
@@ -193,9 +228,11 @@ class ItemAttributes
 		void setDuration(int32_t time) {
 			setIntAttr(ITEM_ATTRIBUTE_DURATION, time);
 		}
+	
 		void decreaseDuration(int32_t time) {
 			increaseIntAttr(ITEM_ATTRIBUTE_DURATION, -time);
 		}
+	
 		uint32_t getDuration() const {
 			return getIntAttr(ITEM_ATTRIBUTE_DURATION);
 		}
@@ -377,10 +414,12 @@ class ItemAttributes
 					memset(&value, 0, sizeof(value));
 				}
 			}
+			
 			Attribute(Attribute&& attribute) : value(attribute.value), type(attribute.type) {
 				memset(&attribute.value, 0, sizeof(value));
 				attribute.type = ITEM_ATTRIBUTE_NONE;
 			}
+			
 			~Attribute() {
 				if (ItemAttributes::isStrAttrType(type)) {
 					delete value.string;
@@ -388,10 +427,12 @@ class ItemAttributes
 					delete value.custom;
 				}
 			}
+			
 			Attribute& operator=(Attribute other) {
 				Attribute::swap(*this, other);
 				return *this;
 			}
+			
 			Attribute& operator=(Attribute&& other) {
 				if (this != &other) {
 					if (ItemAttributes::isStrAttrType(type)) {
@@ -503,13 +544,13 @@ class ItemAttributes
 			return false;
 		}
 
-		const static uint32_t intAttributeTypes = ITEM_ATTRIBUTE_ACTIONID | ITEM_ATTRIBUTE_UNIQUEID | ITEM_ATTRIBUTE_DATE
+		static constexpr uint32_t intAttributeTypes = ITEM_ATTRIBUTE_ACTIONID | ITEM_ATTRIBUTE_UNIQUEID | ITEM_ATTRIBUTE_DATE
 			| ITEM_ATTRIBUTE_WEIGHT | ITEM_ATTRIBUTE_ATTACK | ITEM_ATTRIBUTE_DEFENSE | ITEM_ATTRIBUTE_EXTRADEFENSE
 			| ITEM_ATTRIBUTE_ARMOR | ITEM_ATTRIBUTE_HITCHANCE | ITEM_ATTRIBUTE_SHOOTRANGE | ITEM_ATTRIBUTE_OWNER
 			| ITEM_ATTRIBUTE_DURATION | ITEM_ATTRIBUTE_DECAYSTATE | ITEM_ATTRIBUTE_CORPSEOWNER | ITEM_ATTRIBUTE_CHARGES
 			| ITEM_ATTRIBUTE_FLUIDTYPE | ITEM_ATTRIBUTE_DOORID | ITEM_ATTRIBUTE_DECAYTO | ITEM_ATTRIBUTE_WRAPID | ITEM_ATTRIBUTE_STOREITEM
 			| ITEM_ATTRIBUTE_ATTACK_SPEED | ITEM_ATTRIBUTE_REWARDID;
-		const static uint32_t stringAttributeTypes = ITEM_ATTRIBUTE_DESCRIPTION | ITEM_ATTRIBUTE_TEXT | ITEM_ATTRIBUTE_WRITER
+		static constexpr uint32_t stringAttributeTypes = ITEM_ATTRIBUTE_DESCRIPTION | ITEM_ATTRIBUTE_TEXT | ITEM_ATTRIBUTE_WRITER
 			| ITEM_ATTRIBUTE_NAME | ITEM_ATTRIBUTE_ARTICLE | ITEM_ATTRIBUTE_PLURALNAME | ITEM_ATTRIBUTE_CLASSIFICATION | ITEM_ATTRIBUTE_TIER;
 
 	public:
@@ -530,67 +571,80 @@ class ItemAttributes
 	friend class Item;
 };
 
-class Item : virtual public Thing
+class Item : virtual public Thing, public SharedObject
 {
 	public:
 		//Factory member to create item of right type based on type
-		static Item* CreateItem(const uint16_t type, uint16_t count = 0);
-		static Container* CreateItemAsContainer(const uint16_t type, uint16_t size);
-		static Item* CreateItem(PropStream& propStream);
+		static ItemPtr CreateItem(const uint16_t type, uint16_t count = 0);
+		static ContainerPtr CreateItemAsContainer(const uint16_t type, uint16_t size);
+		static ItemPtr CreateItem(PropStream& propStream);
 		static Items items;
 
 		// Constructor for items
-		Item(const uint16_t type, uint16_t count = 0);
+		explicit Item(const uint16_t type, uint16_t count = 0);
 		Item(const Item& i);
-		virtual Item* clone() const;
+		virtual ItemPtr clone() const;
 
-		virtual ~Item() = default;
+		~Item() = default;
 
 		// non-assignable
 		Item& operator=(const Item&) = delete;
 
-		bool equals(const Item* otherItem) const;
+		bool equals(const ItemConstPtr& otherItem) const;
+	
+		ItemPtr getItem() override final {
+			return dynamic_shared_this<Item>();
+		}
 
-		Item* getItem() override final {
-			return this;
+		ItemConstPtr getItem() const override final {
+			return dynamic_shared_this<const Item>();
 		}
-		const Item* getItem() const override final {
-			return this;
-		}
-		virtual Teleport* getTeleport() {
+	
+		virtual TeleportPtr getTeleport() {
 			return nullptr;
 		}
-		virtual const Teleport* getTeleport() const {
+	
+		virtual TeleportConstPtr getTeleport() const {
 			return nullptr;
 		}
-		virtual TrashHolder* getTrashHolder() {
+	
+		virtual TrashHolderPtr getTrashHolder() {
 			return nullptr;
 		}
-		virtual const TrashHolder* getTrashHolder() const {
+	
+		virtual TrashHolderConstPtr getTrashHolder() const {
 			return nullptr;
 		}
-		virtual Mailbox* getMailbox() {
+	
+		virtual MailboxPtr getMailbox() {
 			return nullptr;
 		}
-		virtual const Mailbox* getMailbox() const {
+	
+		virtual MailboxConstPtr getMailbox() const {
 			return nullptr;
 		}
-		virtual Door* getDoor() {
+	
+		virtual DoorPtr getDoor() {
 			return nullptr;
 		}
-		virtual const Door* getDoor() const {
+	
+		virtual DoorConstPtr getDoor() const {
 			return nullptr;
 		}
-		virtual MagicField* getMagicField() {
+	
+		virtual MagicFieldPtr getMagicField() {
 			return nullptr;
 		}
-		virtual const MagicField* getMagicField() const {
+	
+		virtual MagicFieldConstPtr getMagicField() const {
 			return nullptr;
 		}
-		virtual BedItem* getBed() {
+	
+		virtual BedItemPtr getBed() {
 			return nullptr;
 		}
-		virtual const BedItem* getBed() const {
+	
+		virtual BedItemConstPtr getBed() const {
 			return nullptr;
 		}
 
@@ -612,18 +666,21 @@ class Item : virtual public Thing
 			}
 			return attributes->getIntAttr(type);
 		}
+	
 		void setIntAttr(itemAttrTypes type, int64_t value) {
 			getAttributes()->setIntAttr(type, value);
 		}
+	
 		void increaseIntAttr(itemAttrTypes type, int64_t value) {
 			getAttributes()->increaseIntAttr(type, value);
 		}
 
-		void removeAttribute(itemAttrTypes type) {
+		void removeAttribute(itemAttrTypes type) const {
 			if (attributes) {
 				attributes->removeAttribute(type);
 			}
 		}
+	
 		bool hasAttribute(itemAttrTypes type) const {
 			if (!attributes) {
 				return false;
@@ -680,9 +737,10 @@ class Item : virtual public Thing
 			setStrAttr(ITEM_ATTRIBUTE_TEXT, text); 
 		}
 
-		void resetText() {
+		void resetText() const {
 			removeAttribute(ITEM_ATTRIBUTE_TEXT);
 		}
+	
 		const std::string& getText() const {
 			return getStrAttr(ITEM_ATTRIBUTE_TEXT);
 		}
@@ -690,9 +748,12 @@ class Item : virtual public Thing
 		void setDate(int32_t n) {
 			setIntAttr(ITEM_ATTRIBUTE_DATE, n);
 		}
-		void resetDate() {
+	
+		void resetDate() const
+		{
 			removeAttribute(ITEM_ATTRIBUTE_DATE);
 		}
+	
 		time_t getDate() const {
 			return static_cast<time_t>(getIntAttr(ITEM_ATTRIBUTE_DATE));
 		}
@@ -701,9 +762,10 @@ class Item : virtual public Thing
 			setStrAttr(ITEM_ATTRIBUTE_WRITER, writer); 
 		}
 
-		void resetWriter() {
+		void resetWriter() const {
 			removeAttribute(ITEM_ATTRIBUTE_WRITER);
 		}
+	
 		const std::string& getWriter() const {
 			return getStrAttr(ITEM_ATTRIBUTE_WRITER);
 		}
@@ -715,6 +777,7 @@ class Item : virtual public Thing
 
 			setIntAttr(ITEM_ATTRIBUTE_ACTIONID, n);
 		}
+	
 		uint16_t getActionId() const {
 			if (!attributes) {
 				return 0;
@@ -732,6 +795,7 @@ class Item : virtual public Thing
 		void setCharges(uint16_t n) {
 			setIntAttr(ITEM_ATTRIBUTE_CHARGES, n);
 		}
+	
 		uint16_t getCharges() const {
 			if (!attributes) {
 				return 0;
@@ -742,6 +806,7 @@ class Item : virtual public Thing
 		void setFluidType(uint16_t n) {
 			setIntAttr(ITEM_ATTRIBUTE_FLUIDTYPE, n);
 		}
+	
 		uint16_t getFluidType() const {
 			if (!attributes) {
 				return 0;
@@ -752,6 +817,7 @@ class Item : virtual public Thing
 		void setOwner(uint32_t owner) {
 			setIntAttr(ITEM_ATTRIBUTE_OWNER, owner);
 		}
+	
 		uint32_t getOwner() const {
 			if (!attributes) {
 				return 0;
@@ -762,6 +828,7 @@ class Item : virtual public Thing
 		void setCorpseOwner(uint32_t corpseOwner) {
 			setIntAttr(ITEM_ATTRIBUTE_CORPSEOWNER, corpseOwner);
 		}
+	
 		uint32_t getCorpseOwner() const {
 			if (!attributes) {
 				return 0;
@@ -772,9 +839,11 @@ class Item : virtual public Thing
 		void setDuration(int32_t time) {
 			setIntAttr(ITEM_ATTRIBUTE_DURATION, time);
 		}
+	
 		void decreaseDuration(int32_t time) {
 			increaseIntAttr(ITEM_ATTRIBUTE_DURATION, -time);
 		}
+	
 		uint32_t getDuration() const {
 			if (!attributes) {
 				return 0;
@@ -785,6 +854,7 @@ class Item : virtual public Thing
 		void setDecaying(ItemDecayState_t decayState) {
 			setIntAttr(ITEM_ATTRIBUTE_DECAYSTATE, decayState);
 		}
+	
 		ItemDecayState_t getDecaying() const {
 			if (!attributes) {
 				return DECAYING_FALSE;
@@ -802,6 +872,7 @@ class Item : virtual public Thing
 		void setDecayTo(int32_t decayTo) {
 			setIntAttr(ITEM_ATTRIBUTE_DECAYTO, decayTo);
 		}
+	
 		int32_t getDecayTo() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_DECAYTO)) {
 				return getIntAttr(ITEM_ATTRIBUTE_DECAYTO);
@@ -809,11 +880,11 @@ class Item : virtual public Thing
 			return items[id].decayTo;
 		}
 
-		const bool isEquipped() const;
+		const bool isEquipped();
 		void decayImbuements(bool infight);
 
-		static std::string getDescription(const ItemType& it, int32_t lookDistance, const Item* item = nullptr, int32_t subType = -1, bool addArticle = true);
-		static std::string getNameDescription(const ItemType& it, const Item* item = nullptr, int32_t subType = -1, bool addArticle = true);
+		static std::string getDescription(const ItemType& it, int32_t lookDistance, const ItemConstPtr& item = nullptr, int32_t subType = -1, bool addArticle = true);
+		static std::string getNameDescription(const ItemType& it, const ItemConstPtr& item = nullptr, int32_t subType = -1, bool addArticle = true);
 		static std::string getWeightDescription(const ItemType& it, uint32_t weight, uint32_t count = 1);
 
 		std::string getDescription(int32_t lookDistance) const override final;
@@ -831,6 +902,7 @@ class Item : virtual public Thing
 		bool isPushable() const override final {
 			return isMoveable();
 		}
+	
 		int32_t getThrowRange() const override final {
 			return (isPickupable() ? 15 : 2);
 		}
@@ -838,20 +910,24 @@ class Item : virtual public Thing
 		uint16_t getID() const {
 			return id;
 		}
+	
 		uint16_t getClientID() const {
 			return items[id].clientId;
 		}
+	
 		void setID(uint16_t newid);
 
 		// Returns the player that is holding this item in his inventory
-		Player* getHoldingPlayer() const;
+		PlayerPtr getHoldingPlayer();
 
 		WeaponType_t getWeaponType() const {
 			return items[id].weaponType;
 		}
+	
 		Ammo_t getAmmoType() const {
 			return items[id].ammoType;
 		}
+	
 		uint8_t getShootRange() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_SHOOTRANGE)) {
 				return getIntAttr(ITEM_ATTRIBUTE_SHOOTRANGE);
@@ -860,45 +936,53 @@ class Item : virtual public Thing
 		}
 
 		virtual uint32_t getWeight() const;
+	
 		uint32_t getBaseWeight() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_WEIGHT)) {
 				return getIntAttr(ITEM_ATTRIBUTE_WEIGHT);
 			}
 			return items[id].weight;
 		}
+	
 		int32_t getAttack() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_ATTACK)) {
 				return getIntAttr(ITEM_ATTRIBUTE_ATTACK);
 			}
 			return items[id].attack;
 		}
+	
 		uint32_t getAttackSpeed() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_ATTACK_SPEED)) {
 				return getIntAttr(ITEM_ATTRIBUTE_ATTACK_SPEED);
 			}
 			return items[id].attackSpeed;
 		}
+	
 		int32_t getArmor() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_ARMOR)) {
 				return getIntAttr(ITEM_ATTRIBUTE_ARMOR);
 			}
 			return items[id].armor;
 		}
+	
 		int32_t getDefense() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_DEFENSE)) {
 				return getIntAttr(ITEM_ATTRIBUTE_DEFENSE);
 			}
 			return items[id].defense;
 		}
+	
 		int32_t getExtraDefense() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_EXTRADEFENSE)) {
 				return getIntAttr(ITEM_ATTRIBUTE_EXTRADEFENSE);
 			}
 			return items[id].extraDefense;
 		}
+	
 		int32_t getSlotPosition() const {
 			return items[id].slotPosition;
 		}
+	
 		int8_t getHitChance() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_HITCHANCE)) {
 				return getIntAttr(ITEM_ATTRIBUTE_HITCHANCE);
@@ -914,37 +998,48 @@ class Item : virtual public Thing
 		LightInfo getLightInfo() const;
 
 		bool hasProperty(ITEMPROPERTY prop) const;
+	
 		bool isBlocking() const {
 			return items[id].blockSolid;
 		}
+	
 		bool isStackable() const {
 			return items[id].stackable;
 		}
+	
 		bool isAlwaysOnTop() const {
 			return items[id].alwaysOnTop;
 		}
+	
 		bool isGroundTile() const {
 			return items[id].isGroundTile();
 		}
+	
 		bool isMagicField() const {
 			return items[id].isMagicField();
 		}
+	
 		bool isMoveable() const {
 			return items[id].moveable;
 		}
+	
 		bool isPickupable() const {
 			return items[id].pickupable;
 		}
+	
 		bool isUseable() const {
 			return items[id].useable;
 		}
+	
 		bool isHangable() const {
 			return items[id].isHangable;
 		}
+	
 		bool isRotatable() const {
 			const ItemType& it = items[id];
 			return it.rotatable && it.rotateTo;
 		}
+	
 		bool hasWalkStack() const {
 			return items[id].walkStack;
 		}
@@ -952,36 +1047,42 @@ class Item : virtual public Thing
 		void setStoreItem(bool storeItem) {
 			setIntAttr(ITEM_ATTRIBUTE_STOREITEM, static_cast<int64_t>(storeItem));
 		}
+	
 		bool isStoreItem() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_STOREITEM)) {
 				return getIntAttr(ITEM_ATTRIBUTE_STOREITEM) == 1;
 			}
 			return items[id].storeItem;
 		}
+	
 		const std::string& getName() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_NAME)) {
 				return getStrAttr(ITEM_ATTRIBUTE_NAME);
 			}
 			return items[id].name;
 		}
+	
 		const std::string getPluralName() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_PLURALNAME)) {
 				return getStrAttr(ITEM_ATTRIBUTE_PLURALNAME);
 			}
 			return items[id].getPluralName();
 		}
+	
 		const std::string& getArticle() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_ARTICLE)) {
 				return getStrAttr(ITEM_ATTRIBUTE_ARTICLE);
 			}
 			return items[id].article;
 		}
+	
 		const std::string getClassification() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_CLASSIFICATION)) {
 				return getStrAttr(ITEM_ATTRIBUTE_CLASSIFICATION);
 			}
 			return items[id].classification;
 		}
+	
 		const std::string getTier() const {
 			if (hasAttribute(ITEM_ATTRIBUTE_TIER)) {
 				return getStrAttr(ITEM_ATTRIBUTE_TIER);
@@ -993,11 +1094,12 @@ class Item : virtual public Thing
 		uint16_t getItemCount() const {
 			return count;
 		}
+	
 		void setItemCount(uint8_t n) {
 			count = n;
 		}
 
-		static uint32_t countByType(const Item* i, int32_t subType) {
+		static uint32_t countByType(const ItemConstPtr& i, int32_t subType) {
 			if (subType == -1 || subType == i->getSubType()) {
 				return i->getItemCount();
 			}
@@ -1017,28 +1119,34 @@ class Item : virtual public Thing
 				setDuration(duration);
 			}
 		}
+	
 		uint32_t getDefaultDuration() const {
 			return items[id].decayTime * 1000;
 		}
-		bool canDecay() const;
+	
+		bool canDecay();
 
 		virtual bool canRemove() const {
 			return true;
 		}
+	
 		virtual bool canTransform() const {
 			return true;
 		}
+	
 		virtual void onRemoved();
-		virtual void onTradeEvent(TradeEvents_t, Player*) {}
+		virtual void onTradeEvent(TradeEvents_t, const PlayerPtr&) {}
 
 		virtual void startDecaying();
 
 		bool isLoadedFromMap() const {
 			return loadedFromMap;
 		}
+	
 		void setLoadedFromMap(bool value) {
 			loadedFromMap = value;
 		}
+	
 		bool isCleanable() const {
 			return !loadedFromMap && canRemove() && isPickupable() && !hasAttribute(ITEM_ATTRIBUTE_UNIQUEID) && !hasAttribute(ITEM_ATTRIBUTE_ACTIONID);
 		}
@@ -1051,46 +1159,46 @@ class Item : virtual public Thing
 			}
 			return attributes;
 		}
-
-		void incrementReferenceCounter() {
-			++referenceCounter;
+	
+		CylinderPtr getParent() override {
+			return parent.lock();
 		}
-		void decrementReferenceCounter() {
-			if (--referenceCounter == 0) {
-				delete this;
-			}
-		}
-
-		Cylinder* getParent() const override {
-			return parent;
-		}
-		void setParent(Cylinder* cylinder) override {
+	
+		void setParent(std::weak_ptr<Cylinder> cylinder) override {
 			parent = cylinder;
 		}
-		Cylinder* getTopParent();
-		const Cylinder* getTopParent() const;
-		Tile* getTile() override;
-		const Tile* getTile() const override;
-		bool isRemoved() const override {
-			return !parent || parent->isRemoved();
+
+		void clearParent() override
+		{
+			parent.reset();
+		};
+	
+		CylinderPtr getTopParent();
+		TilePtr getTile() override;
+	
+		bool isRemoved() {
+			if (parent.lock()) {
+				return parent.lock()->isRemoved();
+			}
+			return true;
 		}
 
 		uint16_t getImbuementSlots() const;
 		uint16_t getFreeImbuementSlots() const;
-		bool canImbue() const;
+		bool canImbue();
 		bool addImbuementSlots(const uint16_t amount);
 		bool removeImbuementSlots(const uint16_t amount, const bool destroyImbues = false);
 		bool hasImbuementType(const ImbuementType imbuetype) const;
 		bool hasImbuement(const std::shared_ptr<Imbuement>& imbuement) const;
 		bool hasImbuements() const; /// change to isImbued();
 		bool addImbuement(std::shared_ptr<Imbuement> imbuement, bool created = true);
-		bool removeImbuement(std::shared_ptr<Imbuement> imbuement, bool decayed = false);
+		bool removeImbuement(const std::shared_ptr<Imbuement>& imbuement, bool decayed = false);
 		std::vector<std::shared_ptr<Imbuement>>& getImbuements();
 		const std::vector<std::shared_ptr<Imbuement>>& getImbuements() const;
 
 
 		const bool addAugment(std::string_view augmentName);
-		const bool addAugment(std::shared_ptr<Augment>& augment);
+		const bool addAugment(const std::shared_ptr<Augment>& augment);
 		
 		const bool removeAugment(std::string_view name);
 		const bool removeAugment(std::shared_ptr<Augment>& augment);
@@ -1102,7 +1210,7 @@ class Item : virtual public Thing
 		const std::vector<std::shared_ptr<Augment>>& getAugments();
 
 	protected:
-		Cylinder* parent = nullptr;
+		std::weak_ptr<Cylinder> parent;
 
 		uint16_t id; // the same id as in ItemType
 
@@ -1114,7 +1222,6 @@ class Item : virtual public Thing
 		uint16_t imbuementSlots = 0;
 		std::vector<std::shared_ptr<Imbuement>> imbuements{};
 		std::vector<std::shared_ptr<Augment>> augments{};
-		uint32_t referenceCounter = 0;
 
 		uint8_t count = 1; // number of stacked items
 		bool loadedFromMap = false;
@@ -1122,7 +1229,7 @@ class Item : virtual public Thing
 		//Don't add variables here, use the ItemAttribute class.
 };
 
-using ItemList = std::list<Item*>;
-using ItemDeque = std::deque<Item*>;
+using ItemList = std::list<ItemPtr>;
+using ItemDeque = std::deque<ItemPtr>;
 
 #endif

--- a/src/item.h
+++ b/src/item.h
@@ -1163,6 +1163,10 @@ class Item : virtual public Thing, public SharedObject
 		CylinderPtr getParent() override {
 			return parent.lock();
 		}
+
+		CylinderConstPtr getParent() const override {
+			return parent.lock();
+		}
 	
 		void setParent(std::weak_ptr<Cylinder> cylinder) override {
 			parent = cylinder;
@@ -1174,7 +1178,9 @@ class Item : virtual public Thing, public SharedObject
 		};
 	
 		CylinderPtr getTopParent();
+		CylinderConstPtr getTopParent() const;
 		TilePtr getTile() override;
+		std::shared_ptr<const Tile> getTile() const override;
 	
 		bool isRemoved() {
 			if (parent.lock()) {

--- a/src/itemloader.h
+++ b/src/itemloader.h
@@ -4,8 +4,6 @@
 #ifndef FS_ITEMLOADER_H
 #define FS_ITEMLOADER_H
 
-#include "fileloader.h"
-
 enum itemgroup_t {
 	ITEM_GROUP_NONE,
 

--- a/src/items.h
+++ b/src/items.h
@@ -188,12 +188,15 @@ class ItemType
 		bool isGroundTile() const {
 			return group == ITEM_GROUP_GROUND;
 		}
+	
 		bool isContainer() const {
 			return group == ITEM_GROUP_CONTAINER;
 		}
+	
 		bool isSplash() const {
 			return group == ITEM_GROUP_SPLASH;
 		}
+	
 		bool isFluidContainer() const {
 			return group == ITEM_GROUP_FLUID;
 		}
@@ -201,42 +204,55 @@ class ItemType
 		bool isDoor() const {
 			return (type == ITEM_TYPE_DOOR);
 		}
+	
 		bool isMagicField() const {
 			return (type == ITEM_TYPE_MAGICFIELD);
 		}
+	
 		bool isTeleport() const {
 			return (type == ITEM_TYPE_TELEPORT);
 		}
+	
 		bool isKey() const {
 			return (type == ITEM_TYPE_KEY);
 		}
+	
 		bool isDepot() const {
 			return (type == ITEM_TYPE_DEPOT);
 		}
+	
 		bool isRewardChest() const {
 			return (type == ITEM_TYPE_REWARDCHEST);
 		}
+	
 		bool isRewardContainer() const {
 			return (type == ITEM_TYPE_REWARDCONTAINER);
 		}
+	
 		bool isMailbox() const {
 			return (type == ITEM_TYPE_MAILBOX);
 		}
+	
 		bool isTrashHolder() const {
 			return (type == ITEM_TYPE_TRASHHOLDER);
 		}
+	
 		bool isBed() const {
 			return (type == ITEM_TYPE_BED);
 		}
+	
 		bool isRune() const {
 			return (type == ITEM_TYPE_RUNE);
 		}
+	
 		bool isPickupable() const {
 			return (allowPickupable || pickupable);
 		}
+	
 		bool isUseable() const {
 			return (useable);
 		}
+	
 		bool hasSubType() const {
 			return (isFluidContainer() || isSplash() || stackable || charges != 0);
 		}
@@ -389,6 +405,7 @@ class Items
 		const ItemType& operator[](size_t id) const {
 			return getItemType(id);
 		}
+	
 		const ItemType& getItemType(size_t id) const;
 		ItemType& getItemType(size_t id);
 		const ItemType& getItemIdByClientId(uint16_t spriteId) const;
@@ -403,6 +420,7 @@ class Items
 		void parseItemNode(const pugi::xml_node& itemNode, uint16_t id);
 
 		void buildInventoryList();
+	
 		const InventoryVector& getInventory() const {
 			return inventory;
 		}
@@ -428,6 +446,7 @@ class Items
 					if (clientId >= vec.size()) {
 						vec.resize(clientId + 1, 0);
 					}
+					
 					if (vec[clientId] == 0) {
 						vec[clientId] = serverId;
 					}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -48,7 +48,7 @@ extern Weapons* g_weapons;
 ScriptEnvironment::DBResultMap ScriptEnvironment::tempResults;
 uint32_t ScriptEnvironment::lastResultId = 0;
 
-std::multimap<ScriptEnvironment*, Item*> ScriptEnvironment::tempItems;
+std::multimap<ScriptEnvironment*, ItemPtr> ScriptEnvironment::tempItems;
 
 LuaEnvironment g_luaEnvironment;
 
@@ -74,9 +74,9 @@ void ScriptEnvironment::resetEnv()
 	auto pair = tempItems.equal_range(this);
 	auto it = pair.first;
 	while (it != pair.second) {
-		Item* item = it->second;
+		auto item = it->second;
 		if (item && item->getParent() == VirtualCylinder::virtualCylinder) {
-			g_game.ReleaseItem(item);
+			// g_game.ReleaseItem(item);
 		}
 		it = tempItems.erase(it);
 	}
@@ -105,18 +105,17 @@ void ScriptEnvironment::getEventInfo(int32_t& scriptId, LuaScriptInterface*& scr
 	timerEvent = this->timerEvent;
 }
 
-uint32_t ScriptEnvironment::addThing(Thing* thing)
+uint32_t ScriptEnvironment::addThing(const ThingPtr& thing)
 {
 	if (!thing || thing->isRemoved()) {
 		return 0;
 	}
 
-	Creature* creature = thing->getCreature();
-	if (creature) {
+	if (const auto creature = thing->getCreature()) {
 		return creature->getID();
 	}
 
-	Item* item = thing->getItem();
+	const auto item = thing->getItem();
 	if (item && item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID)) {
 		return item->getUniqueId();
 	}
@@ -131,7 +130,7 @@ uint32_t ScriptEnvironment::addThing(Thing* thing)
 	return lastUID;
 }
 
-void ScriptEnvironment::insertItem(uint32_t uid, Item* item)
+void ScriptEnvironment::insertItem(uint32_t uid, const ItemPtr& item)
 {
 	auto result = localMap.emplace(uid, item);
 	if (!result.second) {
@@ -139,23 +138,22 @@ void ScriptEnvironment::insertItem(uint32_t uid, Item* item)
 	}
 }
 
-Thing* ScriptEnvironment::getThingByUID(uint32_t uid)
+ThingPtr ScriptEnvironment::getThingByUID(const uint32_t uid)
 {
 	if (uid >= 0x10000000) {
 		return g_game.getCreatureByID(uid);
 	}
 
 	if (uid <= std::numeric_limits<uint16_t>::max()) {
-		Item* item = g_game.getUniqueItem(uid);
+		auto item = g_game.getUniqueItem(uid);
 		if (item && !item->isRemoved()) {
 			return item;
 		}
 		return nullptr;
 	}
 
-	auto it = localMap.find(uid);
-	if (it != localMap.end()) {
-		Item* item = it->second;
+	if (const auto it = localMap.find(uid); it != localMap.end()) {
+		auto item = it->second;
 		if (!item->isRemoved()) {
 			return item;
 		}
@@ -163,43 +161,42 @@ Thing* ScriptEnvironment::getThingByUID(uint32_t uid)
 	return nullptr;
 }
 
-Item* ScriptEnvironment::getItemByUID(uint32_t uid)
+ItemPtr ScriptEnvironment::getItemByUID(const uint32_t uid)
 {
-	Thing* thing = getThingByUID(uid);
+	const auto thing = getThingByUID(uid);
 	if (!thing) {
 		return nullptr;
 	}
 	return thing->getItem();
 }
 
-Container* ScriptEnvironment::getContainerByUID(uint32_t uid)
+ContainerPtr ScriptEnvironment::getContainerByUID(const uint32_t uid)
 {
-	Item* item = getItemByUID(uid);
+	const auto item = getItemByUID(uid);
 	if (!item) {
 		return nullptr;
 	}
 	return item->getContainer();
 }
 
-void ScriptEnvironment::removeItemByUID(uint32_t uid)
+void ScriptEnvironment::removeItemByUID(const uint32_t uid)
 {
 	if (uid <= std::numeric_limits<uint16_t>::max()) {
 		g_game.removeUniqueItem(uid);
 		return;
 	}
 
-	auto it = localMap.find(uid);
-	if (it != localMap.end()) {
+	if (auto it = localMap.find(uid); it != localMap.end()) {
 		localMap.erase(it);
 	}
 }
 
-void ScriptEnvironment::addTempItem(Item* item)
+void ScriptEnvironment::addTempItem(const ItemPtr& item)
 {
 	tempItems.emplace(this, item);
 }
 
-void ScriptEnvironment::removeTempItem(Item* item)
+void ScriptEnvironment::removeTempItem(const ItemPtr& item)
 {
 	for (auto it = tempItems.begin(), end = tempItems.end(); it != end; ++it) {
 		if (it->second == item) {
@@ -209,7 +206,7 @@ void ScriptEnvironment::removeTempItem(Item* item)
 	}
 }
 
-uint32_t ScriptEnvironment::addResult(DBResult_ptr res)
+uint32_t ScriptEnvironment::addResult(const DBResult_ptr& res)
 {
 	tempResults[++lastResultId] = res;
 	return lastResultId;
@@ -291,7 +288,7 @@ int LuaScriptInterface::protectedCall(lua_State* L, int nargs, int nresults)
 	return ret;
 }
 
-int32_t LuaScriptInterface::loadFile(const std::string& file, Npc* npc /* = nullptr*/)
+int32_t LuaScriptInterface::loadFile(const std::string& file, std::optional<NpcPtr> npc /* = std::nullopt*/)
 {
 	//loads file as a chunk at stack top
 	int ret = luaL_loadfile(luaState, file.c_str());
@@ -315,7 +312,11 @@ int32_t LuaScriptInterface::loadFile(const std::string& file, Npc* npc /* = null
 
 	ScriptEnvironment* env = getScriptEnv();
 	env->setScriptId(EVENT_ID_LOADING, this);
-	env->setNpc(npc);
+	if (npc.has_value()) {
+		// probably need to use move here??
+		env->setNpc(npc.value());
+	}
+	
 
 	//execute it
 	ret = protectedCall(luaState, 0, 0);
@@ -467,7 +468,7 @@ void LuaScriptInterface::reportError(const char* function, const std::string& er
 	}
 }
 
-bool LuaScriptInterface::pushFunction(int32_t functionId)
+bool LuaScriptInterface::pushFunction(int32_t functionId) const
 {
 	lua_rawgeti(luaState, LUA_REGISTRYINDEX, eventTableRef);
 	if (!isTable(luaState, -1)) {
@@ -515,7 +516,7 @@ int LuaScriptInterface::luaErrorHandler(lua_State* L)
 	return 1;
 }
 
-bool LuaScriptInterface::callFunction(int params)
+bool LuaScriptInterface::callFunction(int params) const
 {
 	bool result = false;
 	int size = lua_gettop(luaState);
@@ -534,7 +535,7 @@ bool LuaScriptInterface::callFunction(int params)
 	return result;
 }
 
-void LuaScriptInterface::callVoidFunction(int params)
+void LuaScriptInterface::callVoidFunction(int params) const
 {
 	int size = lua_gettop(luaState);
 	if (protectedCall(luaState, params, 0) != 0) {
@@ -577,7 +578,7 @@ void LuaScriptInterface::pushVariant(lua_State* L, const LuaVariant& var)
 	setMetatable(L, -1, "Variant");
 }
 
-void LuaScriptInterface::pushThing(lua_State* L, Thing* thing)
+void LuaScriptInterface::pushThing(lua_State* L, const ThingPtr& thing)
 {
 	if (!thing) {
 		lua_createtable(L, 0, 4);
@@ -588,27 +589,27 @@ void LuaScriptInterface::pushThing(lua_State* L, Thing* thing)
 		return;
 	}
 
-	if (Item* item = thing->getItem()) {
-		pushUserdata<Item>(L, item);
+	if (auto item = thing->getItem()) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
-	} else if (Creature* creature = thing->getCreature()) {
-		pushUserdata<Creature>(L, creature);
+	} else if (auto creature = thing->getCreature()) {
+		pushSharedPtr(L, creature);
 		setCreatureMetatable(L, -1, creature);
 	} else {
 		lua_pushnil(L);
 	}
 }
 
-void LuaScriptInterface::pushCylinder(lua_State* L, Cylinder* cylinder)
+void LuaScriptInterface::pushCylinder(lua_State* L, const CylinderPtr& cylinder)
 {
-	if (Creature* creature = cylinder->getCreature()) {
-		pushUserdata<Creature>(L, creature);
+	if (auto creature = cylinder->getCreature()) {
+		pushSharedPtr(L, creature);
 		setCreatureMetatable(L, -1, creature);
-	} else if (Item* parentItem = cylinder->getItem()) {
-		pushUserdata<Item>(L, parentItem);
+	} else if (auto parentItem = cylinder->getItem()) {
+		pushSharedPtr(L, parentItem);
 		setItemMetatable(L, -1, parentItem);
-	} else if (Tile* tile = cylinder->getTile()) {
-		pushUserdata<Tile>(L, tile);
+	} else if (auto tile = cylinder->getTile()) {
+		pushSharedPtr(L, tile);
 		setMetatable(L, -1, "Tile");
 	} else if (cylinder == VirtualCylinder::virtualCylinder) {
 		pushBoolean(L, true);
@@ -685,7 +686,7 @@ void LuaScriptInterface::setWeakMetatable(lua_State* L, int32_t index, const std
 	lua_setmetatable(L, index - 1);
 }
 
-void LuaScriptInterface::setItemMetatable(lua_State* L, int32_t index, const Item* item)
+void LuaScriptInterface::setItemMetatable(lua_State* L, int32_t index, const ItemConstPtr& item)
 {
 	if (item->getContainer()) {
 		luaL_getmetatable(L, "Container");
@@ -697,7 +698,7 @@ void LuaScriptInterface::setItemMetatable(lua_State* L, int32_t index, const Ite
 	lua_setmetatable(L, index - 1);
 }
 
-void LuaScriptInterface::setCreatureMetatable(lua_State* L, int32_t index, const Creature* creature)
+void LuaScriptInterface::setCreatureMetatable(lua_State* L, int32_t index, const CreatureConstPtr& creature)
 {
 	if (creature->getPlayer()) {
 		luaL_getmetatable(L, "Player");
@@ -823,29 +824,29 @@ InstantSpell* LuaScriptInterface::getInstantSpell(lua_State* L, int32_t arg)
 	return spell;
 }
 
-Thing* LuaScriptInterface::getThing(lua_State* L, int32_t arg)
+ThingPtr LuaScriptInterface::getThing(lua_State* L, int32_t arg)
 {
-	Thing* thing;
+	ThingPtr thing;
 	if (lua_getmetatable(L, arg) != 0) {
 		lua_rawgeti(L, -1, 't');
 		switch(getNumber<uint32_t>(L, -1)) {
 			case LuaData_Item:
-				thing = getUserdata<Item>(L, arg);
+				thing = getSharedPtr<Item>(L, arg);
 				break;
 			case LuaData_Container:
-				thing = getUserdata<Container>(L, arg);
+				thing = getSharedPtr<Container>(L, arg);
 				break;
 			case LuaData_Teleport:
-				thing = getUserdata<Teleport>(L, arg);
+				thing = getSharedPtr<Teleport>(L, arg);
 				break;
 			case LuaData_Player:
-				thing = getUserdata<Player>(L, arg);
+				thing = getSharedPtr<Player>(L, arg);
 				break;
 			case LuaData_Monster:
-				thing = getUserdata<Monster>(L, arg);
+				thing = getSharedPtr<Monster>(L, arg);
 				break;
 			case LuaData_Npc:
-				thing = getUserdata<Npc>(L, arg);
+				thing = getSharedPtr<Npc>(L, arg);
 				break;
 			default:
 				thing = nullptr;
@@ -858,18 +859,18 @@ Thing* LuaScriptInterface::getThing(lua_State* L, int32_t arg)
 	return thing;
 }
 
-Creature* LuaScriptInterface::getCreature(lua_State* L, int32_t arg)
+CreaturePtr LuaScriptInterface::getCreature(lua_State* L, int32_t arg)
 {
 	if (isUserdata(L, arg)) {
-		return getUserdata<Creature>(L, arg);
+		return getSharedPtr<Creature>(L, arg);
 	}
 	return g_game.getCreatureByID(getNumber<uint32_t>(L, arg));
 }
 
-Player* LuaScriptInterface::getPlayer(lua_State* L, int32_t arg)
+PlayerPtr LuaScriptInterface::getPlayer(lua_State* L, int32_t arg)
 {
 	if (isUserdata(L, arg)) {
-		return getUserdata<Player>(L, arg);
+		return getSharedPtr<Player>(L, arg);
 	}
 	return g_game.getPlayerByID(getNumber<uint32_t>(L, arg));
 }
@@ -3328,7 +3329,7 @@ void LuaScriptInterface::registerFunctions()
 #undef registerEnum
 #undef registerEnumIn
 
-void LuaScriptInterface::registerClass(const std::string& className, const std::string& baseClass, lua_CFunction newFunction/* = nullptr*/)
+void LuaScriptInterface::registerClass(const std::string& className, const std::string& baseClass, lua_CFunction newFunction/* = nullptr*/) const
 {
 	// className = {}
 	lua_newtable(luaState);
@@ -3402,14 +3403,14 @@ void LuaScriptInterface::registerClass(const std::string& className, const std::
 	lua_pop(luaState, 2);
 }
 
-void LuaScriptInterface::registerTable(const std::string& tableName)
+void LuaScriptInterface::registerTable(const std::string& tableName) const
 {
 	// _G[tableName] = {}
 	lua_newtable(luaState);
 	lua_setglobal(luaState, tableName.c_str());
 }
 
-void LuaScriptInterface::registerMethod(const std::string& globalName, const std::string& methodName, lua_CFunction func)
+void LuaScriptInterface::registerMethod(const std::string& globalName, const std::string& methodName, lua_CFunction func) const
 {
 	// globalName.methodName = func
 	lua_getglobal(luaState, globalName.c_str());
@@ -3420,7 +3421,7 @@ void LuaScriptInterface::registerMethod(const std::string& globalName, const std
 	lua_pop(luaState, 1);
 }
 
-void LuaScriptInterface::registerMetaMethod(const std::string& className, const std::string& methodName, lua_CFunction func)
+void LuaScriptInterface::registerMetaMethod(const std::string& className, const std::string& methodName, lua_CFunction func) const
 {
 	// className.metatable.methodName = func
 	luaL_getmetatable(luaState, className.c_str());
@@ -3431,14 +3432,14 @@ void LuaScriptInterface::registerMetaMethod(const std::string& className, const 
 	lua_pop(luaState, 1);
 }
 
-void LuaScriptInterface::registerGlobalMethod(const std::string& functionName, lua_CFunction func)
+void LuaScriptInterface::registerGlobalMethod(const std::string& functionName, lua_CFunction func) const
 {
 	// _G[functionName] = func
 	lua_pushcfunction(luaState, func);
 	lua_setglobal(luaState, functionName.c_str());
 }
 
-void LuaScriptInterface::registerVariable(const std::string& tableName, const std::string& name, lua_Number value)
+void LuaScriptInterface::registerVariable(const std::string& tableName, const std::string& name, lua_Number value) const
 {
 	// tableName.name = value
 	lua_getglobal(luaState, tableName.c_str());
@@ -3448,14 +3449,14 @@ void LuaScriptInterface::registerVariable(const std::string& tableName, const st
 	lua_pop(luaState, 1);
 }
 
-void LuaScriptInterface::registerGlobalVariable(const std::string& name, lua_Number value)
+void LuaScriptInterface::registerGlobalVariable(const std::string& name, lua_Number value) const
 {
 	// _G[name] = value
 	lua_pushinteger(luaState, value);
 	lua_setglobal(luaState, name.c_str());
 }
 
-void LuaScriptInterface::registerGlobalBoolean(const std::string& name, bool value)
+void LuaScriptInterface::registerGlobalBoolean(const std::string& name, bool value) const
 {
 	// _G[name] = value
 	pushBoolean(luaState, value);
@@ -3466,7 +3467,7 @@ int LuaScriptInterface::luaDoPlayerAddItem(lua_State* L)
 {
 	//doPlayerAddItem(cid, itemid, <optional: default: 1> count/subtype, <optional: default: 1> canDropOnMap)
 	//doPlayerAddItem(cid, itemid, <optional: default: 1> count, <optional: default: 1> canDropOnMap, <optional: default: 1>subtype)
-	Player* player = getPlayer(L, 1);
+	auto player = getPlayer(L, 1);
 	if (!player) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		pushBoolean(L, false);
@@ -3502,7 +3503,7 @@ int LuaScriptInterface::luaDoPlayerAddItem(lua_State* L)
 			stackCount = 100;
 		}
 
-		Item* newItem = Item::CreateItem(itemId, stackCount);
+		auto newItem = Item::CreateItem(itemId, stackCount);
 		if (!newItem) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 			pushBoolean(L, false);
@@ -3515,7 +3516,7 @@ int LuaScriptInterface::luaDoPlayerAddItem(lua_State* L)
 
 		ReturnValue ret = g_game.internalPlayerAddItem(player, newItem, canDropOnMap);
 		if (ret != RETURNVALUE_NOERROR) {
-			delete newItem;
+			newItem.reset();
 			pushBoolean(L, false);
 			return 1;
 		}
@@ -3662,7 +3663,7 @@ int LuaScriptInterface::luaCreateCombatArea(lua_State* L)
 int LuaScriptInterface::luaDoAreaCombat(lua_State* L)
 {
 	//doAreaCombat(cid, type, pos, area, min, max, effect[, origin = ORIGIN_SPELL[, blockArmor = false[, blockShield = false[, ignoreResistances = false]]]])
-	Creature* creature = getCreature(L, 1);
+	auto creature = getCreature(L, 1);
 	if (!creature && (!isNumber(L, 1) || getNumber<uint32_t>(L, 1) != 0)) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -3698,14 +3699,14 @@ int LuaScriptInterface::luaDoAreaCombat(lua_State* L)
 int LuaScriptInterface::luaDoTargetCombat(lua_State* L)
 {
 	//doTargetCombat(cid, target, type, min, max, effect[, origin = ORIGIN_SPELL[, blockArmor = false[, blockShield = false[, ignoreResistances = false]]]])
-	Creature* creature = getCreature(L, 1);
+	auto creature = getCreature(L, 1);
 	if (!creature && (!isNumber(L, 1) || getNumber<uint32_t>(L, 1) != 0)) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	Creature* target = getCreature(L, 2);
+	auto target = getCreature(L, 2);
 	if (!target) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -3734,14 +3735,14 @@ int LuaScriptInterface::luaDoTargetCombat(lua_State* L)
 int LuaScriptInterface::luaDoChallengeCreature(lua_State* L)
 {
 	//doChallengeCreature(cid, target[, force = false])
-	Creature* creature = getCreature(L, 1);
+	auto creature = getCreature(L, 1);
 	if (!creature) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	Creature* target = getCreature(L, 2);
+	auto target = getCreature(L, 2);
 	if (!target) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -3763,7 +3764,7 @@ int LuaScriptInterface::luaIsValidUID(lua_State* L)
 int LuaScriptInterface::luaIsDepot(lua_State* L)
 {
 	//isDepot(uid)
-	Container* container = getScriptEnv()->getContainerByUID(getNumber<uint32_t>(L, -1));
+	auto container = getScriptEnv()->getContainerByUID(getNumber<uint32_t>(L, -1));
 	pushBoolean(L, container && container->getDepotLocker());
 	return 1;
 }
@@ -3772,7 +3773,7 @@ int LuaScriptInterface::luaIsMoveable(lua_State* L)
 {
 	//isMoveable(uid)
 	//isMovable(uid)
-	Thing* thing = getScriptEnv()->getThingByUID(getNumber<uint32_t>(L, -1));
+	auto thing = getScriptEnv()->getThingByUID(getNumber<uint32_t>(L, -1));
 	pushBoolean(L, thing && thing->isPushable());
 	return 1;
 }
@@ -3782,14 +3783,14 @@ int LuaScriptInterface::luaGetDepotId(lua_State* L)
 	//getDepotId(uid)
 	uint32_t uid = getNumber<uint32_t>(L, -1);
 
-	Container* container = getScriptEnv()->getContainerByUID(uid);
+	auto container = getScriptEnv()->getContainerByUID(uid);
 	if (!container) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CONTAINER_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	DepotLocker* depotLocker = container->getDepotLocker();
+	auto depotLocker = container->getDepotLocker();
 	if (!depotLocker) {
 		reportErrorFunc(L, "Depot not found");
 		pushBoolean(L, false);
@@ -3959,14 +3960,14 @@ int LuaScriptInterface::luaCleanMap(lua_State* L)
 int LuaScriptInterface::luaIsInWar(lua_State* L)
 {
 	//isInWar(cid, target)
-	Player* player = getPlayer(L, 1);
+	auto player = getPlayer(L, 1);
 	if (!player) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	Player* targetPlayer = getPlayer(L, 2);
+	auto targetPlayer = getPlayer(L, 2);
 	if (!targetPlayer) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		pushBoolean(L, false);
@@ -3982,8 +3983,7 @@ int LuaScriptInterface::luaGetWaypointPositionByName(lua_State* L)
 	//getWaypointPositionByName(name)
 	auto& waypoints = g_game.map.waypoints;
 
-	auto it = waypoints.find(getString(L, -1));
-	if (it != waypoints.end()) {
+	if (const auto it = waypoints.find(getString(L, -1)); it != waypoints.end()) {
 		pushPosition(L, it->second);
 	} else {
 		pushBoolean(L, false);
@@ -4186,7 +4186,7 @@ int LuaScriptInterface::luaDatabaseAsyncStoreQuery(lua_State* L)
 	if (lua_gettop(L) > 1) {
 		int32_t ref = luaL_ref(L, LUA_REGISTRYINDEX);
 		auto scriptId = getScriptEnv()->getScriptId();
-		callback = [ref, scriptId](DBResult_ptr result, bool) {
+		callback = [ref, scriptId](const DBResult_ptr& result, bool) {
 			lua_State* luaState = g_luaEnvironment.getLuaState();
 			if (!luaState) {
 				return;
@@ -4495,8 +4495,8 @@ int LuaScriptInterface::luaGameGetSpectators(lua_State* L)
 	lua_createtable(L, spectators.size(), 0);
 
 	int index = 0;
-	for (Creature* creature : spectators) {
-		pushUserdata<Creature>(L, creature);
+	for (auto creature : spectators) {
+		pushSharedPtr(L, creature);
 		setCreatureMetatable(L, -1, creature);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -4509,8 +4509,8 @@ int LuaScriptInterface::luaGameGetPlayers(lua_State* L)
 	lua_createtable(L, g_game.getPlayersOnline(), 0);
 
 	int index = 0;
-	for (const auto& playerEntry : g_game.getPlayers()) {
-		pushUserdata<Player>(L, playerEntry.second);
+	for (const auto& val : g_game.getPlayers() | std::views::values) {
+		pushSharedPtr(L, val);
 		setMetatable(L, -1, "Player");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -4523,8 +4523,8 @@ int LuaScriptInterface::luaGameGetNpcs(lua_State* L)
 	lua_createtable(L, g_game.getNpcsOnline(), 0);
 
 	int index = 0;
-	for (const auto& npcEntry : g_game.getNpcs()) {
-		pushUserdata<Npc>(L, npcEntry.second);
+	for (const auto& val : g_game.getNpcs() | std::views::values) {
+		pushSharedPtr(L, val);
 		setMetatable(L, -1, "Npc");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -4537,8 +4537,8 @@ int LuaScriptInterface::luaGameGetMonsters(lua_State* L)
 	lua_createtable(L, g_game.getMonstersOnline(), 0);
 
 	int index = 0;
-	for (const auto& monsterEntry : g_game.getMonsters()) {
-		pushUserdata<Monster>(L, monsterEntry.second);
+	for (const auto& val : g_game.getMonsters() | std::views::values) {
+		pushSharedPtr(L, val);
 		setMetatable(L, -1, "Monster");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -4623,8 +4623,8 @@ int LuaScriptInterface::luaGameGetCurrencyItems(lua_State* L)
 	size_t size = currencyItems.size();
 	lua_createtable(L, size, 0);
 
-	for (const auto& it : currencyItems) {
-		const ItemType& itemType = Item::items[it.second];
+	for (const auto& val : currencyItems | std::views::values) {
+		const ItemType& itemType = Item::items[val];
 		pushUserdata<const ItemType>(L, &itemType);
 		setMetatable(L, -1, "ItemType");
 		lua_rawseti(L, -2, size--);
@@ -4639,8 +4639,8 @@ int LuaScriptInterface::luaGameGetTowns(lua_State* L)
 	lua_createtable(L, towns.size(), 0);
 
 	int index = 0;
-	for (auto townEntry : towns) {
-		pushUserdata<Town>(L, townEntry.second);
+	for (auto val : towns | std::views::values) {
+		pushUserdata<Town>(L, val);
 		setMetatable(L, -1, "Town");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -4654,8 +4654,8 @@ int LuaScriptInterface::luaGameGetHouses(lua_State* L)
 	lua_createtable(L, houses.size(), 0);
 
 	int index = 0;
-	for (auto houseEntry : houses) {
-		pushUserdata<House>(L, houseEntry.second);
+	for (auto val : houses | std::views::values) {
+		pushUserdata<House>(L, val);
 		setMetatable(L, -1, "House");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -4783,7 +4783,7 @@ int LuaScriptInterface::luaGameCreateItem(lua_State* L)
 		count = std::min<uint16_t>(count, 100);
 	}
 
-	Item* item = Item::CreateItem(id, count);
+	auto item = Item::CreateItem(id, count);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -4791,9 +4791,9 @@ int LuaScriptInterface::luaGameCreateItem(lua_State* L)
 
 	if (lua_gettop(L) >= 3) {
 		const Position& position = getPosition(L, 3);
-		Tile* tile = g_game.map.getTile(position);
+		CylinderPtr tile = g_game.map.getTile(position);
 		if (!tile) {
-			delete item;
+			item.reset();
 			lua_pushnil(L);
 			return 1;
 		}
@@ -4804,7 +4804,7 @@ int LuaScriptInterface::luaGameCreateItem(lua_State* L)
 		item->setParent(VirtualCylinder::virtualCylinder);
 	}
 
-	pushUserdata<Item>(L, item);
+	pushSharedPtr(L, item);
 	setItemMetatable(L, -1, item);
 	return 1;
 }
@@ -4824,7 +4824,7 @@ int LuaScriptInterface::luaGameCreateContainer(lua_State* L)
 		}
 	}
 
-	Container* container = Item::CreateItemAsContainer(id, size);
+	auto container = Item::CreateItemAsContainer(id, size);
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -4832,9 +4832,9 @@ int LuaScriptInterface::luaGameCreateContainer(lua_State* L)
 
 	if (lua_gettop(L) >= 3) {
 		const Position& position = getPosition(L, 3);
-		Tile* tile = g_game.map.getTile(position);
+		CylinderPtr tile = g_game.map.getTile(position);
 		if (!tile) {
-			delete container;
+			container.reset();
 			lua_pushnil(L);
 			return 1;
 		}
@@ -4845,7 +4845,7 @@ int LuaScriptInterface::luaGameCreateContainer(lua_State* L)
 		container->setParent(VirtualCylinder::virtualCylinder);
 	}
 
-	pushUserdata<Container>(L, container);
+	pushSharedPtr(L, container);
 	setMetatable(L, -1, "Container");
 	return 1;
 }
@@ -4853,7 +4853,7 @@ int LuaScriptInterface::luaGameCreateContainer(lua_State* L)
 int LuaScriptInterface::luaGameCreateMonster(lua_State* L)
 {
 	// Game.createMonster(monsterName, position[, extended = false[, force = false[, magicEffect = CONST_ME_TELEPORT]]])
-	Monster* monster = Monster::createMonster(getString(L, 1));
+	auto monster = Monster::createMonster(getString(L, 1));
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -4865,14 +4865,12 @@ int LuaScriptInterface::luaGameCreateMonster(lua_State* L)
 	MagicEffectClasses magicEffect = getNumber<MagicEffectClasses>(L, 5, CONST_ME_TELEPORT);
 	if (g_events->eventMonsterOnSpawn(monster, position, false, true) || force) {
 		if (g_game.placeCreature(monster, position, extended, force, magicEffect)) {
-			pushUserdata<Monster>(L, monster);
+			pushSharedPtr(L, monster);
 			setMetatable(L, -1, "Monster");
 		} else {
-			delete monster;
 			lua_pushnil(L);
 		}
 	} else {
-		delete monster;
 		lua_pushnil(L);
 	}
 	return 1;
@@ -4881,7 +4879,7 @@ int LuaScriptInterface::luaGameCreateMonster(lua_State* L)
 int LuaScriptInterface::luaGameCreateNpc(lua_State* L)
 {
 	// Game.createNpc(npcName, position[, extended = false[, force = false[, magicEffect = CONST_ME_TELEPORT]]])
-	Npc* npc = Npc::createNpc(getString(L, 1));
+	auto npc = Npc::createNpc(getString(L, 1));
 	if (!npc) {
 		lua_pushnil(L);
 		return 1;
@@ -4892,10 +4890,10 @@ int LuaScriptInterface::luaGameCreateNpc(lua_State* L)
 	bool force = getBoolean(L, 4, false);
 	MagicEffectClasses magicEffect = getNumber<MagicEffectClasses>(L, 5, CONST_ME_TELEPORT);
 	if (g_game.placeCreature(npc, position, extended, force, magicEffect)) {
-		pushUserdata<Npc>(L, npc);
+		pushSharedPtr(L, npc);
 		setMetatable(L, -1, "Npc");
 	} else {
-		delete npc;
+		npc.reset();
 		lua_pushnil(L);
 	}
 	return 1;
@@ -4917,18 +4915,18 @@ int LuaScriptInterface::luaGameCreateTile(lua_State* L)
 		isDynamic = getBoolean(L, 4, false);
 	}
 
-	Tile* tile = g_game.map.getTile(position);
+	TilePtr tile = g_game.map.getTile(position);
 	if (!tile) {
 		if (isDynamic) {
-			tile = new DynamicTile(position.x, position.y, position.z);
+			tile = std::make_shared<DynamicTile>(position.x, position.y, position.z);
 		} else {
-			tile = new StaticTile(position.x, position.y, position.z);
+			tile = std::make_shared<StaticTile>(position.x, position.y, position.z);
 		}
 
 		g_game.map.setTile(position, tile);
 	}
 
-	pushUserdata(L, tile);
+	pushSharedPtr(L, tile);
 	setMetatable(L, -1, "Tile");
 	return 1;
 }
@@ -4975,7 +4973,7 @@ int LuaScriptInterface::luaGameStartRaid(lua_State* L)
 	// Game.startRaid(raidName)
 	const std::string& raidName = getString(L, 1);
 
-	Raid* raid = g_game.raids.getRaidByName(raidName);
+	const auto raid = g_game.raids.getRaidByName(raidName);
 	if (!raid || !raid->isLoaded()) {
 		lua_pushinteger(L, RETURNVALUE_NOSUCHRAIDEXISTS);
 		return 1;
@@ -5139,7 +5137,7 @@ int LuaScriptInterface::luaVariantCreate(lua_State* L)
 	// Variant(number or string or position or thing)
 	LuaVariant variant;
 	if (isUserdata(L, 2)) {
-		if (Thing* thing = getThing(L, 2)) {
+		if (auto thing = getThing(L, 2)) {
 			variant.setTargetPosition(thing->getPosition());
 		}
 	} else if (isTable(L, 2)) {
@@ -5289,8 +5287,7 @@ int LuaScriptInterface::luaPositionSendMagicEffect(lua_State* L)
 	// position:sendMagicEffect(magicEffect[, player = nullptr])
 	SpectatorVec spectators;
 	if (lua_gettop(L) >= 3) {
-		Player* player = getPlayer(L, 3);
-		if (player) {
+		if (const auto player = getPlayer(L, 3)) {
 			spectators.emplace_back(player);
 		}
 	}
@@ -5316,8 +5313,7 @@ int LuaScriptInterface::luaPositionSendDistanceEffect(lua_State* L)
 	// position:sendDistanceEffect(positionEx, distanceEffect[, player = nullptr])
 	SpectatorVec spectators;
 	if (lua_gettop(L) >= 4) {
-		Player* player = getPlayer(L, 4);
-		if (player) {
+		if (const auto player = getPlayer(L, 4)) {
 			spectators.emplace_back(player);
 		}
 	}
@@ -5340,7 +5336,7 @@ int LuaScriptInterface::luaTileCreate(lua_State* L)
 {
 	// Tile(x, y, z)
 	// Tile(position)
-	Tile* tile;
+	TilePtr tile;
 	if (isTable(L, 2)) {
 		tile = g_game.map.getTile(getPosition(L, 2));
 	} else {
@@ -5351,7 +5347,7 @@ int LuaScriptInterface::luaTileCreate(lua_State* L)
 	}
 
 	if (tile) {
-		pushUserdata<Tile>(L, tile);
+		pushSharedPtr(L, tile);
 		setMetatable(L, -1, "Tile");
 	} else {
 		lua_pushnil(L);
@@ -5362,7 +5358,7 @@ int LuaScriptInterface::luaTileCreate(lua_State* L)
 int LuaScriptInterface::luaTileRemove(lua_State* L)
 {
 	// tile:remove()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -5380,8 +5376,7 @@ int LuaScriptInterface::luaTileRemove(lua_State* L)
 int LuaScriptInterface::luaTileGetPosition(lua_State* L)
 {
 	// tile:getPosition()
-	Tile* tile = getUserdata<Tile>(L, 1);
-	if (tile) {
+	if (const auto tile = getSharedPtr<Tile>(L, 1)) {
 		pushPosition(L, tile->getPosition());
 	} else {
 		lua_pushnil(L);
@@ -5392,9 +5387,9 @@ int LuaScriptInterface::luaTileGetPosition(lua_State* L)
 int LuaScriptInterface::luaTileGetGround(lua_State* L)
 {
 	// tile:getGround()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	auto tile = getSharedPtr<Tile>(L, 1);
 	if (tile && tile->getGround()) {
-		pushUserdata<Item>(L, tile->getGround());
+		pushSharedPtr(L, tile->getGround());
 		setItemMetatable(L, -1, tile->getGround());
 	} else {
 		lua_pushnil(L);
@@ -5406,23 +5401,23 @@ int LuaScriptInterface::luaTileGetThing(lua_State* L)
 {
 	// tile:getThing(index)
 	int32_t index = getNumber<int32_t>(L, 2);
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Thing* thing = tile->getThing(index);
+	const auto thing = tile->getThing(index);
 	if (!thing) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	if (Creature* creature = thing->getCreature()) {
-		pushUserdata<Creature>(L, creature);
+	if (const auto creature = thing->getCreature()) {
+		pushSharedPtr(L, creature);
 		setCreatureMetatable(L, -1, creature);
-	} else if (Item* item = thing->getItem()) {
-		pushUserdata<Item>(L, item);
+	} else if (const auto item = thing->getItem()) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -5433,8 +5428,7 @@ int LuaScriptInterface::luaTileGetThing(lua_State* L)
 int LuaScriptInterface::luaTileGetThingCount(lua_State* L)
 {
 	// tile:getThingCount()
-	Tile* tile = getUserdata<Tile>(L, 1);
-	if (tile) {
+	if (const auto tile = getSharedPtr<Tile>(L, 1)) {
 		lua_pushinteger(L, tile->getThingCount());
 	} else {
 		lua_pushnil(L);
@@ -5445,24 +5439,24 @@ int LuaScriptInterface::luaTileGetThingCount(lua_State* L)
 int LuaScriptInterface::luaTileGetTopVisibleThing(lua_State* L)
 {
 	// tile:getTopVisibleThing(creature)
-	Creature* creature = getCreature(L, 2);
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto creature = getCreature(L, 2);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Thing* thing = tile->getTopVisibleThing(creature);
+	const auto thing = tile->getTopVisibleThing(creature);
 	if (!thing) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	if (Creature* visibleCreature = thing->getCreature()) {
-		pushUserdata<Creature>(L, visibleCreature);
+	if (const auto visibleCreature = thing->getCreature()) {
+		pushSharedPtr(L, visibleCreature);
 		setCreatureMetatable(L, -1, visibleCreature);
-	} else if (Item* visibleItem = thing->getItem()) {
-		pushUserdata<Item>(L, visibleItem);
+	} else if (const auto visibleItem = thing->getItem()) {
+		pushSharedPtr(L, visibleItem);
 		setItemMetatable(L, -1, visibleItem);
 	} else {
 		lua_pushnil(L);
@@ -5473,15 +5467,14 @@ int LuaScriptInterface::luaTileGetTopVisibleThing(lua_State* L)
 int LuaScriptInterface::luaTileGetTopTopItem(lua_State* L)
 {
 	// tile:getTopTopItem()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item* item = tile->getTopTopItem();
-	if (item) {
-		pushUserdata<Item>(L, item);
+	if (const auto item = tile->getTopTopItem()) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -5492,15 +5485,14 @@ int LuaScriptInterface::luaTileGetTopTopItem(lua_State* L)
 int LuaScriptInterface::luaTileGetTopDownItem(lua_State* L)
 {
 	// tile:getTopDownItem()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item* item = tile->getTopDownItem();
-	if (item) {
-		pushUserdata<Item>(L, item);
+	if (const auto item = tile->getTopDownItem()) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -5511,15 +5503,14 @@ int LuaScriptInterface::luaTileGetTopDownItem(lua_State* L)
 int LuaScriptInterface::luaTileGetFieldItem(lua_State* L)
 {
 	// tile:getFieldItem()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item* item = tile->getFieldItem();
-	if (item) {
-		pushUserdata<Item>(L, item);
+	if (const auto item = tile->getFieldItem()) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -5530,7 +5521,7 @@ int LuaScriptInterface::luaTileGetFieldItem(lua_State* L)
 int LuaScriptInterface::luaTileGetItemById(lua_State* L)
 {
 	// tile:getItemById(itemId[, subType = -1])
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -5548,9 +5539,8 @@ int LuaScriptInterface::luaTileGetItemById(lua_State* L)
 	}
 	int32_t subType = getNumber<int32_t>(L, 3, -1);
 
-	Item* item = g_game.findItemOfType(tile, itemId, false, subType);
-	if (item) {
-		pushUserdata<Item>(L, item);
+	if (const auto item = g_game.findItemOfType(tile, itemId, false, subType)) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -5561,7 +5551,7 @@ int LuaScriptInterface::luaTileGetItemById(lua_State* L)
 int LuaScriptInterface::luaTileGetItemByType(lua_State* L)
 {
 	// tile:getItemByType(itemType)
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -5599,20 +5589,20 @@ int LuaScriptInterface::luaTileGetItemByType(lua_State* L)
 		return 1;
 	}
 
-	if (Item* item = tile->getGround()) {
+	if (const auto item = tile->getGround()) {
 		const ItemType& it = Item::items[item->getID()];
 		if (it.type == itemType) {
-			pushUserdata<Item>(L, item);
+			pushSharedPtr(L, item);
 			setItemMetatable(L, -1, item);
 			return 1;
 		}
 	}
 
-	if (const TileItemVector* items = tile->getItemList()) {
-		for (Item* item : *items) {
+	if (const TileItemsPtr items = tile->getItemList()) {
+		for (const auto item : *items) {
 			const ItemType& it = Item::items[item->getID()];
 			if (it.type == itemType) {
-				pushUserdata<Item>(L, item);
+				pushSharedPtr(L, item);
 				setItemMetatable(L, -1, item);
 				return 1;
 			}
@@ -5634,13 +5624,13 @@ int LuaScriptInterface::luaTileGetItemByTopOrder(lua_State* L)
 
 	int32_t topOrder = getNumber<int32_t>(L, 2);
 
-	Item* item = tile->getItemByTopOrder(topOrder);
+	const auto item = tile->getItemByTopOrder(topOrder);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	pushUserdata<Item>(L, item);
+	pushSharedPtr(L, item);
 	setItemMetatable(L, -1, item);
 	return 1;
 }
@@ -5648,7 +5638,7 @@ int LuaScriptInterface::luaTileGetItemByTopOrder(lua_State* L)
 int LuaScriptInterface::luaTileGetItemCountById(lua_State* L)
 {
 	// tile:getItemCountById(itemId[, subType = -1])
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -5674,19 +5664,19 @@ int LuaScriptInterface::luaTileGetItemCountById(lua_State* L)
 int LuaScriptInterface::luaTileGetBottomCreature(lua_State* L)
 {
 	// tile:getBottomCreature()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const Creature* creature = tile->getBottomCreature();
+	const auto creature = tile->getBottomCreature();
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	pushUserdata<const Creature>(L, creature);
+	pushSharedPtr(L, creature);
 	setCreatureMetatable(L, -1, creature);
 	return 1;
 }
@@ -5694,19 +5684,19 @@ int LuaScriptInterface::luaTileGetBottomCreature(lua_State* L)
 int LuaScriptInterface::luaTileGetTopCreature(lua_State* L)
 {
 	// tile:getTopCreature()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* creature = tile->getTopCreature();
+	const auto creature = tile->getTopCreature();
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	pushUserdata<Creature>(L, creature);
+	pushSharedPtr(L, creature);
 	setCreatureMetatable(L, -1, creature);
 	return 1;
 }
@@ -5714,21 +5704,20 @@ int LuaScriptInterface::luaTileGetTopCreature(lua_State* L)
 int LuaScriptInterface::luaTileGetBottomVisibleCreature(lua_State* L)
 {
 	// tile:getBottomVisibleCreature(creature)
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* creature = getCreature(L, 2);
+	const auto creature = getCreature(L, 2);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const Creature* visibleCreature = tile->getBottomVisibleCreature(creature);
-	if (visibleCreature) {
-		pushUserdata<const Creature>(L, visibleCreature);
+	if (const auto visibleCreature = tile->getBottomVisibleCreature(creature)) {
+		pushSharedPtr(L, visibleCreature);
 		setCreatureMetatable(L, -1, visibleCreature);
 	} else {
 		lua_pushnil(L);
@@ -5739,21 +5728,20 @@ int LuaScriptInterface::luaTileGetBottomVisibleCreature(lua_State* L)
 int LuaScriptInterface::luaTileGetTopVisibleCreature(lua_State* L)
 {
 	// tile:getTopVisibleCreature(creature)
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* creature = getCreature(L, 2);
+	const auto creature = getCreature(L, 2);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* visibleCreature = tile->getTopVisibleCreature(creature);
-	if (visibleCreature) {
-		pushUserdata<Creature>(L, visibleCreature);
+	if (const auto visibleCreature = tile->getTopVisibleCreature(creature)) {
+		pushSharedPtr(L, visibleCreature);
 		setCreatureMetatable(L, -1, visibleCreature);
 	} else {
 		lua_pushnil(L);
@@ -5764,13 +5752,13 @@ int LuaScriptInterface::luaTileGetTopVisibleCreature(lua_State* L)
 int LuaScriptInterface::luaTileGetItems(lua_State* L)
 {
 	// tile:getItems()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	TileItemVector* itemVector = tile->getItemList();
+	auto itemVector = tile->getItemList();
 	if (!itemVector) {
 		lua_pushnil(L);
 		return 1;
@@ -5779,8 +5767,8 @@ int LuaScriptInterface::luaTileGetItems(lua_State* L)
 	lua_createtable(L, itemVector->size(), 0);
 
 	int index = 0;
-	for (Item* item : *itemVector) {
-		pushUserdata<Item>(L, item);
+	for (const auto item : *itemVector) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -5790,7 +5778,7 @@ int LuaScriptInterface::luaTileGetItems(lua_State* L)
 int LuaScriptInterface::luaTileGetItemCount(lua_State* L)
 {
 	// tile:getItemCount()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -5803,8 +5791,7 @@ int LuaScriptInterface::luaTileGetItemCount(lua_State* L)
 int LuaScriptInterface::luaTileGetDownItemCount(lua_State* L)
 {
 	// tile:getDownItemCount()
-	Tile* tile = getUserdata<Tile>(L, 1);
-	if (tile) {
+	if (const auto tile = getSharedPtr<Tile>(L, 1)) {
 		lua_pushinteger(L, tile->getDownItemCount());
 	} else {
 		lua_pushnil(L);
@@ -5815,7 +5802,7 @@ int LuaScriptInterface::luaTileGetDownItemCount(lua_State* L)
 int LuaScriptInterface::luaTileGetTopItemCount(lua_State* L)
 {
 	// tile:getTopItemCount()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -5828,13 +5815,13 @@ int LuaScriptInterface::luaTileGetTopItemCount(lua_State* L)
 int LuaScriptInterface::luaTileGetCreatures(lua_State* L)
 {
 	// tile:getCreatures()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	CreatureVector* creatureVector = tile->getCreatures();
+	const auto creatureVector = tile->getCreatures();
 	if (!creatureVector) {
 		lua_pushnil(L);
 		return 1;
@@ -5843,8 +5830,8 @@ int LuaScriptInterface::luaTileGetCreatures(lua_State* L)
 	lua_createtable(L, creatureVector->size(), 0);
 
 	int index = 0;
-	for (Creature* creature : *creatureVector) {
-		pushUserdata<Creature>(L, creature);
+	for (const auto creature : *creatureVector) {
+		pushSharedPtr(L, creature);
 		setCreatureMetatable(L, -1, creature);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -5854,7 +5841,7 @@ int LuaScriptInterface::luaTileGetCreatures(lua_State* L)
 int LuaScriptInterface::luaTileGetCreatureCount(lua_State* L)
 {
 	// tile:getCreatureCount()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -5867,15 +5854,15 @@ int LuaScriptInterface::luaTileGetCreatureCount(lua_State* L)
 int LuaScriptInterface::luaTileHasProperty(lua_State* L)
 {
 	// tile:hasProperty(property[, item])
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item* item;
+	ItemPtr item;
 	if (lua_gettop(L) >= 3) {
-		item = getUserdata<Item>(L, 3);
+		item = getSharedPtr<Item>(L, 3);
 	} else {
 		item = nullptr;
 	}
@@ -5892,13 +5879,13 @@ int LuaScriptInterface::luaTileHasProperty(lua_State* L)
 int LuaScriptInterface::luaTileGetThingIndex(lua_State* L)
 {
 	// tile:getThingIndex(thing)
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Thing* thing = getThing(L, 2);
+	const auto thing = getThing(L, 2);
 	if (thing) {
 		lua_pushinteger(L, tile->getThingIndex(thing));
 	} else {
@@ -5910,8 +5897,7 @@ int LuaScriptInterface::luaTileGetThingIndex(lua_State* L)
 int LuaScriptInterface::luaTileHasFlag(lua_State* L)
 {
 	// tile:hasFlag(flag)
-	Tile* tile = getUserdata<Tile>(L, 1);
-	if (tile) {
+	if (const auto tile = getSharedPtr<Tile>(L, 1)) {
 		tileflags_t flag = getNumber<tileflags_t>(L, 2);
 		pushBoolean(L, tile->hasFlag(flag));
 	} else {
@@ -5923,27 +5909,27 @@ int LuaScriptInterface::luaTileHasFlag(lua_State* L)
 int LuaScriptInterface::luaTileQueryAdd(lua_State* L)
 {
 	// tile:queryAdd(thing[, flags])
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Thing* thing = getThing(L, 2);
+	const auto thing = getThing(L, 2);
 	if (!thing) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	if (Creature* creature = thing->getCreature()) {
+	if (const auto creature = thing->getCreature()) {
 		uint32_t flags = getNumber<uint32_t>(L, 3, 0);
-		lua_pushinteger(L, tile->queryAdd(*creature, flags));
+		lua_pushinteger(L, tile->queryAdd(creature, flags));
 		return 1;
 	}
 
-	if (Item* item = thing->getItem()) {
+	if (const auto item = thing->getItem()) {
 		uint32_t flags = getNumber<uint32_t>(L, 3, 0);
-		lua_pushinteger(L, tile->queryAdd(*item, flags));
+		lua_pushinteger(L, tile->queryAdd(item, flags));
 		return 1;
 	}
 	
@@ -5954,7 +5940,7 @@ int LuaScriptInterface::luaTileQueryAdd(lua_State* L)
 int LuaScriptInterface::luaTileAddItem(lua_State* L)
 {
 	// tile:addItem(itemId[, count/subType = 1[, flags = 0]])
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -5973,20 +5959,20 @@ int LuaScriptInterface::luaTileAddItem(lua_State* L)
 
 	uint32_t subType = getNumber<uint32_t>(L, 3, 1);
 
-	Item* item = Item::CreateItem(itemId, std::min<uint32_t>(subType, 100));
+	auto item = Item::CreateItem(itemId, std::min<uint32_t>(subType, 100));
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	uint32_t flags = getNumber<uint32_t>(L, 4, 0);
-
-	ReturnValue ret = g_game.internalAddItem(tile, item, INDEX_WHEREEVER, flags);
+	CylinderPtr holder = tile;
+	ReturnValue ret = g_game.internalAddItem(holder, item, INDEX_WHEREEVER, flags);
 	if (ret == RETURNVALUE_NOERROR) {
-		pushUserdata<Item>(L, item);
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
-		delete item;
+		item.reset();
 		lua_pushnil(L);
 	}
 	return 1;
@@ -5995,13 +5981,13 @@ int LuaScriptInterface::luaTileAddItem(lua_State* L)
 int LuaScriptInterface::luaTileAddItemEx(lua_State* L)
 {
 	// tile:addItemEx(item[, flags = 0])
-	Item* item = getUserdata<Item>(L, 2);
+	const auto item = getSharedPtr<Item>(L, 2);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
@@ -6014,7 +6000,8 @@ int LuaScriptInterface::luaTileAddItemEx(lua_State* L)
 	}
 
 	uint32_t flags = getNumber<uint32_t>(L, 3, 0);
-	ReturnValue ret = g_game.internalAddItem(tile, item, INDEX_WHEREEVER, flags);
+	CylinderPtr holder = tile;
+	ReturnValue ret = g_game.internalAddItem(holder, item, INDEX_WHEREEVER, flags);
 	if (ret == RETURNVALUE_NOERROR) {
 		ScriptEnvironment::removeTempItem(item);
 	}
@@ -6025,13 +6012,13 @@ int LuaScriptInterface::luaTileAddItemEx(lua_State* L)
 int LuaScriptInterface::luaTileGetHouse(lua_State* L)
 {
 	// tile:getHouse()
-	Tile* tile = getUserdata<Tile>(L, 1);
+	const auto tile = getSharedPtr<Tile>(L, 1);
 	if (!tile) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	if (HouseTile* houseTile = dynamic_cast<HouseTile*>(tile)) {
+	if (HouseTilePtr houseTile = std::dynamic_pointer_cast<HouseTile>(tile)) {
 		pushUserdata<House>(L, houseTile->getHouse());
 		setMetatable(L, -1, "House");
 	} else {
@@ -6232,7 +6219,7 @@ int LuaScriptInterface::luaNetworkMessageAddDouble(lua_State* L)
 int LuaScriptInterface::luaNetworkMessageAddItem(lua_State* L)
 {
 	// networkMessage:addItem(item)
-	Item* item = getUserdata<Item>(L, 2);
+	const auto item = getSharedPtr<Item>(L, 2);
 	if (!item) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		lua_pushnil(L);
@@ -6346,8 +6333,7 @@ int LuaScriptInterface::luaNetworkMessageSendToPlayer(lua_State* L)
 		return 1;
 	}
 
-	Player* player = getPlayer(L, 2);
-	if (player) {
+	if (const auto player = getPlayer(L, 2)) {
 		player->sendNetworkMessage(*message);
 		pushBoolean(L, true);
 	} else {
@@ -6576,7 +6562,7 @@ int LuaScriptInterface::luaModalWindowSetPriority(lua_State* L)
 int LuaScriptInterface::luaModalWindowSendToPlayer(lua_State* L)
 {
 	// modalWindow:sendToPlayer(player)
-	Player* player = getPlayer(L, 2);
+	const auto player = getPlayer(L, 2);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -6600,9 +6586,8 @@ int LuaScriptInterface::luaItemCreate(lua_State* L)
 	// Item(uid)
 	uint32_t id = getNumber<uint32_t>(L, 2);
 
-	Item* item = getScriptEnv()->getItemByUID(id);
-	if (item) {
-		pushUserdata<Item>(L, item);
+	if (const auto item = getScriptEnv()->getItemByUID(id)) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -6613,20 +6598,20 @@ int LuaScriptInterface::luaItemCreate(lua_State* L)
 int LuaScriptInterface::luaItemIsItem(lua_State* L)
 {
 	// item:isItem()
-	pushBoolean(L, getUserdata<const Item>(L, 1) != nullptr);
+	pushBoolean(L, getSharedPtr<const Item>(L, 1) != nullptr);
 	return 1;
 }
 
 int LuaScriptInterface::luaItemGetParent(lua_State* L)
 {
 	// item:getParent()
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Cylinder* parent = item->getParent();
+	CylinderPtr parent = item->getParent();
 	if (!parent) {
 		lua_pushnil(L);
 		return 1;
@@ -6639,13 +6624,13 @@ int LuaScriptInterface::luaItemGetParent(lua_State* L)
 int LuaScriptInterface::luaItemGetTopParent(lua_State* L)
 {
 	// item:getTopParent()
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Cylinder* topParent = item->getTopParent();
+	CylinderPtr topParent = item->getTopParent();
 	if (!topParent) {
 		lua_pushnil(L);
 		return 1;
@@ -6658,8 +6643,7 @@ int LuaScriptInterface::luaItemGetTopParent(lua_State* L)
 int LuaScriptInterface::luaItemGetId(lua_State* L)
 {
 	// item:getId()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		lua_pushinteger(L, item->getID());
 	} else {
 		lua_pushnil(L);
@@ -6670,13 +6654,13 @@ int LuaScriptInterface::luaItemGetId(lua_State* L)
 int LuaScriptInterface::luaItemClone(lua_State* L)
 {
 	// item:clone()
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item* clone = item->clone();
+	const auto clone = item->clone();
 	if (!clone) {
 		lua_pushnil(L);
 		return 1;
@@ -6685,7 +6669,7 @@ int LuaScriptInterface::luaItemClone(lua_State* L)
 	getScriptEnv()->addTempItem(clone);
 	clone->setParent(VirtualCylinder::virtualCylinder);
 
-	pushUserdata<Item>(L, clone);
+	pushSharedPtr(L, clone);
 	setItemMetatable(L, -1, clone);
 	return 1;
 }
@@ -6693,13 +6677,13 @@ int LuaScriptInterface::luaItemClone(lua_State* L)
 int LuaScriptInterface::luaItemSplit(lua_State* L)
 {
 	// item:split([count = 1])
-	Item** itemPtr = getRawUserdata<Item>(L, 1);
+	auto& itemPtr = getSharedPtr<Item>(L, 1);
 	if (!itemPtr) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item* item = *itemPtr;
+	ItemPtr item = itemPtr;
 	if (!item || !item->isStackable()) {
 		lua_pushnil(L);
 		return 1;
@@ -6708,7 +6692,7 @@ int LuaScriptInterface::luaItemSplit(lua_State* L)
 	uint16_t count = std::min<uint16_t>(getNumber<uint16_t>(L, 2, 1), item->getItemCount());
 	uint16_t diff = item->getItemCount() - count;
 
-	Item* splitItem = item->clone();
+	ItemPtr splitItem = item->clone();
 	if (!splitItem) {
 		lua_pushnil(L);
 		return 1;
@@ -6719,7 +6703,7 @@ int LuaScriptInterface::luaItemSplit(lua_State* L)
 	ScriptEnvironment* env = getScriptEnv();
 	uint32_t uid = env->addThing(item);
 
-	Item* newItem = g_game.transformItem(item, item->getID(), diff);
+	ItemPtr newItem = g_game.transformItem(item, item->getID(), diff);
 	if (item->isRemoved()) {
 		env->removeItemByUID(uid);
 	}
@@ -6728,12 +6712,12 @@ int LuaScriptInterface::luaItemSplit(lua_State* L)
 		env->insertItem(uid, newItem);
 	}
 
-	*itemPtr = newItem;
-
+	itemPtr.reset(newItem.get());
+	
 	splitItem->setParent(VirtualCylinder::virtualCylinder);
 	env->addTempItem(splitItem);
 
-	pushUserdata<Item>(L, splitItem);
+	pushSharedPtr(L, splitItem);
 	setItemMetatable(L, -1, splitItem);
 	return 1;
 }
@@ -6741,9 +6725,9 @@ int LuaScriptInterface::luaItemSplit(lua_State* L)
 int LuaScriptInterface::luaItemRemove(lua_State* L)
 {
 	// item:remove([count = -1])
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (item) {
-		int32_t count = getNumber<int32_t>(L, 2, -1);
+		const int32_t count = getNumber<int32_t>(L, 2, -1);
 		pushBoolean(L, g_game.internalRemoveItem(item, count) == RETURNVALUE_NOERROR);
 	} else {
 		lua_pushnil(L);
@@ -6754,8 +6738,7 @@ int LuaScriptInterface::luaItemRemove(lua_State* L)
 int LuaScriptInterface::luaItemGetUniqueId(lua_State* L)
 {
 	// item:getUniqueId()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		uint32_t uniqueId = item->getUniqueId();
 		if (uniqueId == 0) {
 			uniqueId = getScriptEnv()->addThing(item);
@@ -6770,8 +6753,7 @@ int LuaScriptInterface::luaItemGetUniqueId(lua_State* L)
 int LuaScriptInterface::luaItemGetActionId(lua_State* L)
 {
 	// item:getActionId()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		lua_pushinteger(L, item->getActionId());
 	} else {
 		lua_pushnil(L);
@@ -6783,8 +6765,7 @@ int LuaScriptInterface::luaItemSetActionId(lua_State* L)
 {
 	// item:setActionId(actionId)
 	uint16_t actionId = getNumber<uint16_t>(L, 2);
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		item->setActionId(actionId);
 		pushBoolean(L, true);
 	} else {
@@ -6796,8 +6777,7 @@ int LuaScriptInterface::luaItemSetActionId(lua_State* L)
 int LuaScriptInterface::luaItemGetCount(lua_State* L)
 {
 	// item:getCount()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		lua_pushinteger(L, item->getItemCount());
 	} else {
 		lua_pushnil(L);
@@ -6808,8 +6788,7 @@ int LuaScriptInterface::luaItemGetCount(lua_State* L)
 int LuaScriptInterface::luaItemGetCharges(lua_State* L)
 {
 	// item:getCharges()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		lua_pushinteger(L, item->getCharges());
 	} else {
 		lua_pushnil(L);
@@ -6820,8 +6799,7 @@ int LuaScriptInterface::luaItemGetCharges(lua_State* L)
 int LuaScriptInterface::luaItemGetFluidType(lua_State* L)
 {
 	// item:getFluidType()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		lua_pushinteger(L, item->getFluidType());
 	} else {
 		lua_pushnil(L);
@@ -6832,8 +6810,7 @@ int LuaScriptInterface::luaItemGetFluidType(lua_State* L)
 int LuaScriptInterface::luaItemGetWeight(lua_State* L)
 {
 	// item:getWeight()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		lua_pushinteger(L, item->getWeight());
 	} else {
 		lua_pushnil(L);
@@ -6844,8 +6821,7 @@ int LuaScriptInterface::luaItemGetWeight(lua_State* L)
 int LuaScriptInterface::luaItemGetWorth(lua_State* L)
 {
 	// item:getWorth()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		lua_pushinteger(L, item->getWorth());
 	} else {
 		lua_pushnil(L);
@@ -6856,8 +6832,7 @@ int LuaScriptInterface::luaItemGetWorth(lua_State* L)
 int LuaScriptInterface::luaItemGetSubType(lua_State* L)
 {
 	// item:getSubType()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		lua_pushinteger(L, item->getSubType());
 	} else {
 		lua_pushnil(L);
@@ -6868,8 +6843,7 @@ int LuaScriptInterface::luaItemGetSubType(lua_State* L)
 int LuaScriptInterface::luaItemGetName(lua_State* L)
 {
 	// item:getName()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		pushString(L, item->getName());
 	} else {
 		lua_pushnil(L);
@@ -6880,8 +6854,7 @@ int LuaScriptInterface::luaItemGetName(lua_State* L)
 int LuaScriptInterface::luaItemGetPluralName(lua_State* L)
 {
 	// item:getPluralName()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		pushString(L, item->getPluralName());
 	} else {
 		lua_pushnil(L);
@@ -6892,8 +6865,7 @@ int LuaScriptInterface::luaItemGetPluralName(lua_State* L)
 int LuaScriptInterface::luaItemGetArticle(lua_State* L)
 {
 	// item:getArticle()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		pushString(L, item->getArticle());
 	} else {
 		lua_pushnil(L);
@@ -6904,8 +6876,7 @@ int LuaScriptInterface::luaItemGetArticle(lua_State* L)
 int LuaScriptInterface::luaItemGetPosition(lua_State* L)
 {
 	// item:getPosition()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		pushPosition(L, item->getPosition());
 	} else {
 		lua_pushnil(L);
@@ -6916,15 +6887,14 @@ int LuaScriptInterface::luaItemGetPosition(lua_State* L)
 int LuaScriptInterface::luaItemGetTile(lua_State* L)
 {
 	// item:getTile()
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Tile* tile = item->getTile();
-	if (tile) {
-		pushUserdata<Tile>(L, tile);
+	if (const auto tile = item->getTile()) {
+		pushSharedPtr(L, tile);
 		setMetatable(L, -1, "Tile");
 	} else {
 		lua_pushnil(L);
@@ -6935,7 +6905,7 @@ int LuaScriptInterface::luaItemGetTile(lua_State* L)
 int LuaScriptInterface::luaItemHasAttribute(lua_State* L)
 {
 	// item:hasAttribute(key)
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getUserdata<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -6957,7 +6927,7 @@ int LuaScriptInterface::luaItemHasAttribute(lua_State* L)
 int LuaScriptInterface::luaItemGetAttribute(lua_State* L)
 {
 	// item:getAttribute(key)
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -6985,7 +6955,7 @@ int LuaScriptInterface::luaItemGetAttribute(lua_State* L)
 int LuaScriptInterface::luaItemSetAttribute(lua_State* L)
 {
 	// item:setAttribute(key, value)
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7021,7 +6991,7 @@ int LuaScriptInterface::luaItemSetAttribute(lua_State* L)
 int LuaScriptInterface::luaItemRemoveAttribute(lua_State* L)
 {
 	// item:removeAttribute(key)
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7048,7 +7018,7 @@ int LuaScriptInterface::luaItemRemoveAttribute(lua_State* L)
 
 int LuaScriptInterface::luaItemGetCustomAttribute(lua_State* L) {
 	// item:getCustomAttribute(key)
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7074,7 +7044,7 @@ int LuaScriptInterface::luaItemGetCustomAttribute(lua_State* L) {
 
 int LuaScriptInterface::luaItemSetCustomAttribute(lua_State* L) {
 	// item:setCustomAttribute(key, value)
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7114,7 +7084,7 @@ int LuaScriptInterface::luaItemSetCustomAttribute(lua_State* L) {
 
 int LuaScriptInterface::luaItemRemoveCustomAttribute(lua_State* L) {
 	// item:removeCustomAttribute(key)
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7133,30 +7103,29 @@ int LuaScriptInterface::luaItemRemoveCustomAttribute(lua_State* L) {
 int LuaScriptInterface::luaItemMoveTo(lua_State* L)
 {
 	// item:moveTo(position or cylinder[, flags])
-	Item** itemPtr = getRawUserdata<Item>(L, 1);
+	auto& itemPtr = getSharedPtr<Item>(L, 1);
 	if (!itemPtr) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item* item = *itemPtr;
+	ItemPtr item = itemPtr;
 	if (!item || item->isRemoved()) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Cylinder* toCylinder;
+	CylinderPtr toCylinder;
 	if (isUserdata(L, 2)) {
-		const LuaDataType type = getUserdataType(L, 2);
-		switch (type) {
+		switch (const LuaDataType type = getUserdataType(L, 2)) {
 			case LuaData_Container:
-				toCylinder = getUserdata<Container>(L, 2);
+				toCylinder = getSharedPtr<Container>(L, 2);
 				break;
 			case LuaData_Player:
-				toCylinder = getUserdata<Player>(L, 2);
+				toCylinder = getSharedPtr<Player>(L, 2);
 				break;
 			case LuaData_Tile:
-				toCylinder = getUserdata<Tile>(L, 2);
+				toCylinder = getSharedPtr<Tile>(L, 2);
 				break;
 			default:
 				toCylinder = nullptr;
@@ -7181,10 +7150,11 @@ int LuaScriptInterface::luaItemMoveTo(lua_State* L)
 	if (item->getParent() == VirtualCylinder::virtualCylinder) {
 		pushBoolean(L, g_game.internalAddItem(toCylinder, item, INDEX_WHEREEVER, flags) == RETURNVALUE_NOERROR);
 	} else {
-		Item* moveItem = nullptr;
-		ReturnValue ret = g_game.internalMoveItem(item->getParent(), toCylinder, INDEX_WHEREEVER, item, item->getItemCount(), &moveItem, flags);
+		ItemPtr moveItem = nullptr;
+		CylinderPtr i_parent = item->getParent();
+		ReturnValue ret = g_game.internalMoveItem(i_parent, toCylinder, INDEX_WHEREEVER, item, item->getItemCount(), &moveItem, flags);
 		if (moveItem) {
-			*itemPtr = moveItem;
+			itemPtr = moveItem;
 		}
 		pushBoolean(L, ret == RETURNVALUE_NOERROR);
 	}
@@ -7194,13 +7164,13 @@ int LuaScriptInterface::luaItemMoveTo(lua_State* L)
 int LuaScriptInterface::luaItemTransform(lua_State* L)
 {
 	// item:transform(itemId[, count/subType = -1])
-	Item** itemPtr = getRawUserdata<Item>(L, 1);
+	auto& itemPtr = getSharedPtr<Item>(L, 1);
 	if (!itemPtr) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item*& item = *itemPtr;
+	ItemPtr item = itemPtr;
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7236,7 +7206,7 @@ int LuaScriptInterface::luaItemTransform(lua_State* L)
 	ScriptEnvironment* env = getScriptEnv();
 	uint32_t uid = env->addThing(item);
 
-	Item* newItem = g_game.transformItem(item, itemId, subType);
+	const auto newItem = g_game.transformItem(item, itemId, subType);
 	if (item->isRemoved()) {
 		env->removeItemByUID(uid);
 	}
@@ -7253,8 +7223,7 @@ int LuaScriptInterface::luaItemTransform(lua_State* L)
 int LuaScriptInterface::luaItemDecay(lua_State* L)
 {
 	// item:decay(decayId)
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 
 		if (item->isAugmented() || item->hasImbuements()) {
 			lua_pushboolean(L, false);
@@ -7276,8 +7245,7 @@ int LuaScriptInterface::luaItemDecay(lua_State* L)
 int LuaScriptInterface::luaItemGetDescription(lua_State* L)
 {
 	// item:getDescription(distance)
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		int32_t distance = getNumber<int32_t>(L, 2);
 		pushString(L, item->getDescription(distance));
 	} else {
@@ -7289,8 +7257,7 @@ int LuaScriptInterface::luaItemGetDescription(lua_State* L)
 int LuaScriptInterface::luaItemGetSpecialDescription(lua_State* L)
 {
 	// item:getSpecialDescription()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		pushString(L, item->getSpecialDescription());
 	} else {
 		lua_pushnil(L);
@@ -7301,9 +7268,8 @@ int LuaScriptInterface::luaItemGetSpecialDescription(lua_State* L)
 int LuaScriptInterface::luaItemHasProperty(lua_State* L)
 {
 	// item:hasProperty(property)
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
-		ITEMPROPERTY property = getNumber<ITEMPROPERTY>(L, 2);
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
+		auto property = getNumber<ITEMPROPERTY>(L, 2);
 		pushBoolean(L, item->hasProperty(property));
 	} else {
 		lua_pushnil(L);
@@ -7314,8 +7280,7 @@ int LuaScriptInterface::luaItemHasProperty(lua_State* L)
 int LuaScriptInterface::luaItemIsLoadedFromMap(lua_State* L)
 {
 	// item:isLoadedFromMap()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		pushBoolean(L, item->isLoadedFromMap());
 	} else {
 		lua_pushnil(L);
@@ -7326,7 +7291,7 @@ int LuaScriptInterface::luaItemIsLoadedFromMap(lua_State* L)
 int LuaScriptInterface::luaItemSetStoreItem(lua_State* L)
 {
 	// item:setStoreItem(storeItem)
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7339,8 +7304,7 @@ int LuaScriptInterface::luaItemSetStoreItem(lua_State* L)
 int LuaScriptInterface::luaItemIsStoreItem(lua_State* L)
 {
 	// item:isStoreItem()
-	Item* item = getUserdata<Item>(L, 1);
-	if (item) {
+	if (const auto item = getSharedPtr<Item>(L, 1)) {
 		pushBoolean(L, item->isStoreItem());
 	} else {
 		lua_pushnil(L);
@@ -7351,8 +7315,7 @@ int LuaScriptInterface::luaItemIsStoreItem(lua_State* L)
 int LuaScriptInterface::luaItemGetImbuementSlots(lua_State* L)
 {
 	// item:getImbuementSlots() -- returns how many total slots
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
 		lua_pushinteger(L, item->getImbuementSlots());
 	} else {
@@ -7364,8 +7327,7 @@ int LuaScriptInterface::luaItemGetImbuementSlots(lua_State* L)
 int LuaScriptInterface::luaItemGetFreeImbuementSlots(lua_State* L)
 {
 	// item:getFreeImbuementSlots() -- returns how many slots are available for use
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
 		lua_pushinteger(L, item->getFreeImbuementSlots());
 	} else {
@@ -7377,8 +7339,7 @@ int LuaScriptInterface::luaItemGetFreeImbuementSlots(lua_State* L)
 int LuaScriptInterface::luaItemCanImbue(lua_State* L)
 {
 	// item:canImbue(amount) -- returns true if item has slots that are free
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
 		pushBoolean(L, item->canImbue());
 	} else {
@@ -7390,8 +7351,7 @@ int LuaScriptInterface::luaItemCanImbue(lua_State* L)
 int LuaScriptInterface::luaItemAddImbuementSlots(lua_State* L)
 {
 	// item:addImbuementSlots(amount) -- tries to add imbuement slot(s), returns true if successful
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
 		pushBoolean(L, item->addImbuementSlots(getNumber<uint32_t>(L, 2)));
 	} else {
@@ -7403,8 +7363,7 @@ int LuaScriptInterface::luaItemAddImbuementSlots(lua_State* L)
 int LuaScriptInterface::luaItemRemoveImbuementSlots(lua_State* L)
 {
 	// item:removeImbuementSlots(amount, destroy) -- tries to remove imbuement slot(s), returns true if successful
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
 		pushBoolean(L, item->removeImbuementSlots(getNumber<uint32_t>(L, 2), getBoolean(L, 5, false)));
 	} else {
@@ -7416,8 +7375,7 @@ int LuaScriptInterface::luaItemRemoveImbuementSlots(lua_State* L)
 int LuaScriptInterface::luaItemHasImbuementType(lua_State* L)
 {
 	// item:hasImbuementType(type)
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
 		pushBoolean(L, item->hasImbuementType(getNumber<ImbuementType>(L, 2, ImbuementType::IMBUEMENT_TYPE_NONE)));
 	} else {
@@ -7429,11 +7387,9 @@ int LuaScriptInterface::luaItemHasImbuementType(lua_State* L)
 int LuaScriptInterface::luaItemHasImbuement(lua_State* L)
 {
 	// item:hasImbuement(imbueType, amount, duration, realtime)
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
-		std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 2);
-		if (imbue) {
+		if (const std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 2)) {
 			pushBoolean(L, item->hasImbuement(imbue));
 		} else {
 			lua_pushnil(L);
@@ -7447,8 +7403,7 @@ int LuaScriptInterface::luaItemHasImbuement(lua_State* L)
 int LuaScriptInterface::luaItemHasImbuements(lua_State* L)
 {
 	// item:hasImbuements() -- returns true if item has any imbuements
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
 		pushBoolean(L, item->hasImbuements());
 	} else {
@@ -7460,11 +7415,9 @@ int LuaScriptInterface::luaItemHasImbuements(lua_State* L)
 int LuaScriptInterface::luaItemAddImbuement(lua_State* L)
 {
 	// item:addImbuement(imbuement) -- returns true if it successfully adds the imbuement
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
-		std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 2);
-		if (imbue) {
+		if (const std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 2)) {
 			pushBoolean(L, item->addImbuement(imbue, true));
 		}
 	} else {
@@ -7476,11 +7429,9 @@ int LuaScriptInterface::luaItemAddImbuement(lua_State* L)
 int LuaScriptInterface::luaItemRemoveImbuement(lua_State* L)
 {
 	// item:removeImbuement(imbuement)
-	Item* item = getUserdata<Item>(L, 1);
-	if (item)
+	if (const auto item = getSharedPtr<Item>(L, 1))
 	{
-		std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 2);
-		if (imbue) {
+		if (const std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 2)) {
 			pushBoolean(L, item->removeImbuement(imbue, false));
 		}
 	} else {
@@ -7493,17 +7444,17 @@ int LuaScriptInterface::luaItemRemoveImbuement(lua_State* L)
 int LuaScriptInterface::luaItemGetImbuements(lua_State* L)
 {
 	// item:getImbuements() -- returns a table that contains values that are imbuement userdata?
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	std::vector<std::shared_ptr<Imbuement>> imbuements = item->getImbuements();
+	const std::vector<std::shared_ptr<Imbuement>> imbuements = item->getImbuements();
 	lua_createtable(L, imbuements.size(), 0);
 
 	int index = 0;
-	for (std::shared_ptr<Imbuement> imbuement : imbuements) {
+	for (const auto imbuement : imbuements) {
 		pushSharedPtr(L, imbuement);
 		setMetatable(L, -1, "Imbuement");
 		lua_rawseti(L, -2, ++index);
@@ -7513,7 +7464,7 @@ int LuaScriptInterface::luaItemGetImbuements(lua_State* L)
 
 int LuaScriptInterface::luaItemAddAugment(lua_State* L)
 {
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7533,7 +7484,7 @@ int LuaScriptInterface::luaItemAddAugment(lua_State* L)
 			reportError(__FUNCTION__, "Item::addAugment() argument not found as any name in augments loaded on startup! \n");
 		}
 	} else if (isUserdata(L, 2)) {
-		if (std::shared_ptr augment = getSharedPtr<Augment>(L, 2)) {
+		if (auto augment = getSharedPtr<Augment>(L, 2)) {
 			lua_pushboolean(L, item->addAugment(augment));
 		} else {
 			lua_pushnil(L);
@@ -7548,17 +7499,17 @@ int LuaScriptInterface::luaItemAddAugment(lua_State* L)
 
 int LuaScriptInterface::luaItemRemoveAugment(lua_State* L)
 {
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	if (isString(L, 2)) {
-		auto name = getString(L, 2);
+		const auto name = getString(L, 2);
 		lua_pushboolean(L, item->removeAugment(name));
 	} else if (isUserdata(L, 2)) {
-		if (std::shared_ptr<Augment> augment = getSharedPtr<Augment>(L, 2)) {
+		if (auto augment = getSharedPtr<Augment>(L, 2)) {
 			lua_pushboolean(L, item->removeAugment(augment));
 		} else {
 			reportError(__FUNCTION__, "Item::removeAugment() invalid userdata type passed as argument! \n");
@@ -7573,7 +7524,7 @@ int LuaScriptInterface::luaItemRemoveAugment(lua_State* L)
 
 int LuaScriptInterface::luaItemIsAugmented(lua_State* L)
 {
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
@@ -7584,14 +7535,14 @@ int LuaScriptInterface::luaItemIsAugmented(lua_State* L)
 
 int LuaScriptInterface::luaItemHasAugment(lua_State* L)
 {
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 	
 	if (isString(L, 2)) {
-		auto name = getString(L, 2);
+		const auto name = getString(L, 2);
 		lua_pushboolean(L, item->hasAugment(name));
 	} else if (isUserdata(L, 2)) {
 		if (std::shared_ptr<Augment> augment = getSharedPtr<Augment>(L, 2)) {
@@ -7609,17 +7560,17 @@ int LuaScriptInterface::luaItemHasAugment(lua_State* L)
 
 int LuaScriptInterface::luaItemGetAugments(lua_State* L)
 {
-	Item* item = getUserdata<Item>(L, 1);
+	const auto item = getSharedPtr<Item>(L, 1);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	std::vector<std::shared_ptr<Augment>> augments = item->getAugments();
+	const auto augments = item->getAugments();
 	lua_createtable(L, augments.size(), 0);
 
 	int index = 0;
-	for (std::shared_ptr<Augment> augment : augments) {
+	for (const auto augment : augments) {
 		pushSharedPtr(L, augment);
 		setMetatable(L, -1, "Augment");
 		lua_rawseti(L, -2, ++index);
@@ -7644,8 +7595,7 @@ int LuaScriptInterface::luaImbuementCreate(lua_State* L)
 int LuaScriptInterface::luaImbuementGetType(lua_State* L)
 {
 	// imbuement:getType()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		lua_pushinteger(L, imbue->imbuetype);
 	} else {
 		lua_pushnil(L);
@@ -7656,8 +7606,7 @@ int LuaScriptInterface::luaImbuementGetType(lua_State* L)
 int LuaScriptInterface::luaImbuementGetValue(lua_State* L)
 {
 	// imbuement:getValue()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		lua_pushinteger(L, imbue->value);
 	} else {
 		lua_pushnil(L);
@@ -7669,8 +7618,7 @@ int LuaScriptInterface::luaImbuementGetValue(lua_State* L)
 int LuaScriptInterface::luaImbuementGetDuration(lua_State* L)
 {
 	// imbuement:getDuration()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		lua_pushinteger(L, imbue->duration);
 	} else {
 		lua_pushnil(L);
@@ -7681,8 +7629,7 @@ int LuaScriptInterface::luaImbuementGetDuration(lua_State* L)
 int LuaScriptInterface::luaImbuementIsSkill(lua_State* L)
 {
 	// imbuement:isSkill()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		lua_pushinteger(L, imbue->isSkill());
 	} else {
 		lua_pushnil(L);
@@ -7693,8 +7640,7 @@ int LuaScriptInterface::luaImbuementIsSkill(lua_State* L)
 int LuaScriptInterface::luaImbuementIsSpecialSkill(lua_State* L)
 {
 	// imbuement:isSpecialSkill()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		lua_pushinteger(L, imbue->isSpecialSkill());
 	} else {
 		lua_pushnil(L);
@@ -7705,8 +7651,7 @@ int LuaScriptInterface::luaImbuementIsSpecialSkill(lua_State* L)
 int LuaScriptInterface::luaImbuementIsDamage(lua_State* L)
 {
 	// imbuement:isDamage()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		lua_pushinteger(L, imbue->isDamage());
 	}
 	else {
@@ -7718,8 +7663,7 @@ int LuaScriptInterface::luaImbuementIsDamage(lua_State* L)
 int LuaScriptInterface::luaImbuementIsResist(lua_State* L)
 {
 	// imbuement:isResist()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		lua_pushinteger(L, imbue->isResist());
 	} else {
 		lua_pushnil(L);
@@ -7730,8 +7674,7 @@ int LuaScriptInterface::luaImbuementIsResist(lua_State* L)
 int LuaScriptInterface::luaImbuementIsStat(lua_State* L)
 {
 	// imbuement:isStat()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		lua_pushinteger(L, imbue->isStat());
 	} else {
 		lua_pushnil(L);
@@ -7742,8 +7685,7 @@ int LuaScriptInterface::luaImbuementIsStat(lua_State* L)
 int LuaScriptInterface::luaImbuementSetValue(lua_State* L)
 {
 	// imbuement:setAmount(amount)
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		imbue->value = getNumber<uint32_t>(L, 2);
 		pushBoolean(L, true);
 	} else {
@@ -7755,8 +7697,7 @@ int LuaScriptInterface::luaImbuementSetValue(lua_State* L)
 int LuaScriptInterface::luaImbuementSetDuration(lua_State* L)
 {
 	// imbuement:setDuration(duration)
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		imbue->duration = getNumber<uint32_t>(L, 2);
 		pushBoolean(L, true);
 	} else {
@@ -7768,8 +7709,7 @@ int LuaScriptInterface::luaImbuementSetDuration(lua_State* L)
 int LuaScriptInterface::luaImbuementSetEquipDecay(lua_State* L)
 {
 	// imbuement:makeEquipDecayed()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		imbue->decaytype = ImbuementDecayType::IMBUEMENT_DECAY_EQUIPPED;
 		pushBoolean(L, true);
 	} else {
@@ -7781,8 +7721,7 @@ int LuaScriptInterface::luaImbuementSetEquipDecay(lua_State* L)
 int LuaScriptInterface::luaImbuementSetInfightDecay(lua_State* L)
 {
 	// imbuement:makeInfightDecayed()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		imbue->decaytype = ImbuementDecayType::IMBUEMENT_DECAY_INFIGHT;
 		pushBoolean(L, true);
 	} else {
@@ -7794,8 +7733,7 @@ int LuaScriptInterface::luaImbuementSetInfightDecay(lua_State* L)
 int LuaScriptInterface::luaImbuementIsEquipDecay(lua_State* L)
 {
 	// imbuement:isEquipDecayed()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		pushBoolean(L, imbue->decaytype == ImbuementDecayType::IMBUEMENT_DECAY_EQUIPPED);
 	} else {
 		lua_pushnil(L);
@@ -7806,8 +7744,7 @@ int LuaScriptInterface::luaImbuementIsEquipDecay(lua_State* L)
 int LuaScriptInterface::luaImbuementIsInfightDecay(lua_State* L)
 {
 	// imbuement:isInfightDecayed()
-	std::shared_ptr<Imbuement> imbue = getSharedPtr<Imbuement>(L, 1);
-	if (imbue) {
+	if (const auto imbue = getSharedPtr<Imbuement>(L, 1)) {
 		pushBoolean(L, imbue->decaytype == ImbuementDecayType::IMBUEMENT_DECAY_INFIGHT);
 	} else {
 		lua_pushnil(L);
@@ -7822,7 +7759,7 @@ int LuaScriptInterface::luaDamageModifierCreate(lua_State* L)
 	auto modType = getNumber<uint8_t>(L, 3);
 	auto amount = getNumber<uint16_t>(L, 4);
 	auto factor = getNumber<ModFactor>(L, 5);
-	auto chance = getNumber<uint8_t>(L, 6);
+	auto chance = getNumber<uint8_t>(L, 6, 100);
 	auto combatType = getNumber<CombatType_t>(L, 7, COMBAT_NONE);
 	auto originType = getNumber<CombatOrigin>(L, 8, ORIGIN_NONE);
 	auto creatureType = getNumber<CreatureType_t>(L, 9, CREATURETYPE_ATTACKABLE);
@@ -7841,11 +7778,9 @@ int LuaScriptInterface::luaDamageModifierCreate(lua_State* L)
 
 int LuaScriptInterface::luaDamageModifierSetValue(lua_State* L)
 {
-	std::shared_ptr<DamageModifier> modifier = getSharedPtr<DamageModifier>(L, 1);
-	if (modifier) {
+	if (const auto modifier = getSharedPtr<DamageModifier>(L, 1)) {
 		// to-do: handle no param defaults and throw error
-		uint8_t amount = getNumber<uint8_t>(L, 2);
-		if (amount) {
+		if (const uint8_t amount = getNumber<uint8_t>(L, 2)) {
 			modifier->setValue(amount);
 		}
 	} else {
@@ -7856,11 +7791,9 @@ int LuaScriptInterface::luaDamageModifierSetValue(lua_State* L)
 
 int LuaScriptInterface::luaDamageModifierSetRateFactor(lua_State* L)
 {
-	std::shared_ptr<DamageModifier> modifier = getSharedPtr<DamageModifier>(L, 1);
-	if (modifier) {
+	if (const auto modifier = getSharedPtr<DamageModifier>(L, 1)) {
 		// to-do: handle no param defaults and throw error
-		uint8_t factor = getNumber<uint8_t>(L, 2);
-		if (factor >= 0) {
+		if (const uint8_t factor = getNumber<uint8_t>(L, 2)) {
 			modifier->setFactor(factor);
 		}
 	} else {
@@ -7871,8 +7804,7 @@ int LuaScriptInterface::luaDamageModifierSetRateFactor(lua_State* L)
 
 int LuaScriptInterface::luaDamageModifierSetCombatFilter(lua_State* L)
 {
-	std::shared_ptr<DamageModifier> modifier = getSharedPtr<DamageModifier>(L, 1);
-	if (modifier) {
+	if (const auto modifier = getSharedPtr<DamageModifier>(L, 1)) {
 		// to-do: handle no param defaults and throw error
 		CombatType_t combatType = getNumber<CombatType_t>(L, 2);
 		if (combatType >= 0) {
@@ -7886,11 +7818,9 @@ int LuaScriptInterface::luaDamageModifierSetCombatFilter(lua_State* L)
 
 int LuaScriptInterface::luaDamageModifierSetOriginFilter(lua_State* L)
 {
-	std::shared_ptr<DamageModifier> modifier = getSharedPtr<DamageModifier>(L, 1);
-	if (modifier) {
+	if (const auto modifier = getSharedPtr<DamageModifier>(L, 1)) {
 		// to-do: handle no param defaults and throw error
-		CombatOrigin origin = getNumber<CombatOrigin>(L, 2);
-		if (origin >= 0) {
+		if (const CombatOrigin origin = getNumber<CombatOrigin>(L, 2)) {
 			modifier->setOriginType(origin);
 		}
 	} else {
@@ -7904,10 +7834,9 @@ int LuaScriptInterface::luaAugmentCreate(lua_State* L)
 	// Augment(name, description, modifier or table_of_modifiers)
 
 	if (isString(L, 2)) {
-		auto name = getString(L, 2);
-		auto augment = Augments::GetAugment(name);
+		const auto name = getString(L, 2);
 
-		if (augment) {
+		if (const auto augment = Augments::GetAugment(name)) {
 			pushSharedPtr(L, augment);
 			setMetatable(L, -1, "Augment");
 			return 1; // return early here because we found a global augment with this name
@@ -7915,8 +7844,7 @@ int LuaScriptInterface::luaAugmentCreate(lua_State* L)
 
 		auto description = getString(L, 3);
 		if (isUserdata(L, 4)) {
-			auto modifier = getSharedPtr<DamageModifier>(L, 4);
-			if (modifier) {
+			if (auto modifier = getSharedPtr<DamageModifier>(L, 4)) {
 				auto augment = Augment::MakeAugment(name, description);
 				augment->addModifier(modifier);
 				pushSharedPtr(L, augment);
@@ -7934,8 +7862,7 @@ int LuaScriptInterface::luaAugmentCreate(lua_State* L)
 			while (lua_next(L, 4) != 0) {
 				// Check if the value is userdata and of type DamageModifier
 				if (isUserdata(L, -1)) {
-					auto modifier = getSharedPtr<DamageModifier>(L, -1);
-					if (modifier) {
+					if (auto modifier = getSharedPtr<DamageModifier>(L, -1)) {
 						list.emplace_back(modifier);
 					} else {
 						reportError(__FUNCTION__, "Invalid userdata in table element\n");
@@ -7949,7 +7876,7 @@ int LuaScriptInterface::luaAugmentCreate(lua_State* L)
 
 			// Create augment with all modifiers
 			// To-do : Add augments created this particular way to global table
-			auto augment = Augment::MakeAugment(name, description);
+			const auto augment = Augment::MakeAugment(name, description);
 			for (auto& modifier : list) {
 				augment->addModifier(modifier);
 			}
@@ -7969,7 +7896,7 @@ int LuaScriptInterface::luaAugmentCreate(lua_State* L)
 int LuaScriptInterface::luaAugmentSetName(lua_State* L)
 {
 	// Augment:setName(newName)
-	auto augment = getSharedPtr<Augment>(L, 1);
+	const auto augment = getSharedPtr<Augment>(L, 1);
 	if (!augment) {
 		reportError(__FUNCTION__, "Invalid Augment userdata\n");
 		return 0;
@@ -7983,41 +7910,41 @@ int LuaScriptInterface::luaAugmentSetName(lua_State* L)
 int LuaScriptInterface::luaAugmentSetDescription(lua_State* L)
 {
 	// Augment:getDescription(newDescription)
-	auto augment = getSharedPtr<Augment>(L, 1);
+	const auto augment = getSharedPtr<Augment>(L, 1);
 	if (!augment) {
 		reportError(__FUNCTION__, "Invalid Augment userdata\n");
 		return 0;
 	}
 
-	auto newDescription = getString(L, 2);
+	const auto newDescription = getString(L, 2);
 	augment->setDescription(newDescription);
 	return 0;
 }
 
 int LuaScriptInterface::luaAugmentGetName(lua_State* L) {
 	// Augment:getName()
-	auto augment = getSharedPtr<Augment>(L, 1); // Get augment object
+	const auto augment = getSharedPtr<Augment>(L, 1); // Get augment object
 	if (!augment) {
 		reportError(__FUNCTION__, "Invalid Augment userdata\n");
 		lua_pushnil(L);
 		return 1;
 	}
 
-	std::string name = augment->getName();
+	const std::string name = augment->getName();
 	pushString(L, name);
 	return 1;
 }
 
 int LuaScriptInterface::luaAugmentGetDescription(lua_State* L) {
 	// Augment:getDescription()
-	auto augment = getSharedPtr<Augment>(L, 1);
+	const auto augment = getSharedPtr<Augment>(L, 1);
 	if (!augment) {
 		reportError(__FUNCTION__, "Invalid Augment userdata\n");
 		lua_pushnil(L);
 		return 1;
 	}
 
-	std::string description = augment->getDescription();
+	const std::string description = augment->getDescription();
 	pushString(L, description);
 	return 1;
 }
@@ -8026,7 +7953,7 @@ int LuaScriptInterface::luaAugmentGetDescription(lua_State* L) {
 int LuaScriptInterface::luaAugmentAddDamageModifier(lua_State* L)
 {
 	// Augment:addDamageModifier(modifier)
-	auto augment = getSharedPtr<Augment>(L, 1);
+	const auto augment = getSharedPtr<Augment>(L, 1);
 	if (!augment) {
 		reportError(__FUNCTION__, "Invalid Augment userdata\n");
 		return 0;
@@ -8045,7 +7972,7 @@ int LuaScriptInterface::luaAugmentAddDamageModifier(lua_State* L)
 int LuaScriptInterface::luaAugmentRemoveDamageModifier(lua_State* L)
 {
 	// Augment:RemoveDamageModifier(modifier)
-	auto augment = getSharedPtr<Augment>(L, 1);
+	const auto augment = getSharedPtr<Augment>(L, 1);
 	if (!augment) {
 		reportError(__FUNCTION__, "Invalid Augment userdata\n");
 		return 0;
@@ -8063,7 +7990,7 @@ int LuaScriptInterface::luaAugmentRemoveDamageModifier(lua_State* L)
 
 int LuaScriptInterface::luaAugmentGetAttackModifiers(lua_State* L) {
 	// Augment:GetAttackModifiers([modType])
-	auto augment = getSharedPtr<Augment>(L, 1);
+	const auto augment = getSharedPtr<Augment>(L, 1);
 	if (!augment) {
 		reportError(__FUNCTION__, "Invalid Augment userdata\n");
 		lua_pushnil(L);
@@ -8073,7 +8000,7 @@ int LuaScriptInterface::luaAugmentGetAttackModifiers(lua_State* L) {
 	std::vector<std::shared_ptr<DamageModifier>> modifiers;
 
 	if (lua_gettop(L) > 1 && lua_isinteger(L, 2)) {
-		uint8_t modType = static_cast<uint8_t>(lua_tointeger(L, 2));
+		const uint8_t modType = static_cast<uint8_t>(lua_tointeger(L, 2));
 		modifiers = augment->getAttackModifiers(modType);
 	} else {
 		modifiers = augment->getAttackModifiers();
@@ -8092,7 +8019,7 @@ int LuaScriptInterface::luaAugmentGetAttackModifiers(lua_State* L) {
 
 int LuaScriptInterface::luaAugmentGetDefenseModifiers(lua_State* L) {
 	// Augment:GetDefenseModifiers([modType])
-	auto augment = getSharedPtr<Augment>(L, 1);
+	const auto augment = getSharedPtr<Augment>(L, 1);
 	if (!augment) {
 		reportError(__FUNCTION__, "Invalid Augment userdata\n");
 		lua_pushnil(L);
@@ -8124,11 +8051,10 @@ int LuaScriptInterface::luaAugmentGetDefenseModifiers(lua_State* L) {
 int LuaScriptInterface::luaContainerCreate(lua_State* L)
 {
 	// Container(uid)
-	uint32_t id = getNumber<uint32_t>(L, 2);
+	const uint32_t id = getNumber<uint32_t>(L, 2);
 
-	Container* container = getScriptEnv()->getContainerByUID(id);
-	if (container) {
-		pushUserdata(L, container);
+	if (const auto container = getScriptEnv()->getContainerByUID(id)) {
+		pushSharedPtr(L, container);
 		setMetatable(L, -1, "Container");
 	} else {
 		lua_pushnil(L);
@@ -8139,8 +8065,7 @@ int LuaScriptInterface::luaContainerCreate(lua_State* L)
 int LuaScriptInterface::luaContainerGetSize(lua_State* L)
 {
 	// container:getSize()
-	Container* container = getUserdata<Container>(L, 1);
-	if (container) {
+	if (const auto container = getSharedPtr<Container>(L, 1)) {
 		lua_pushinteger(L, container->size());
 	} else {
 		lua_pushnil(L);
@@ -8151,8 +8076,7 @@ int LuaScriptInterface::luaContainerGetSize(lua_State* L)
 int LuaScriptInterface::luaContainerGetCapacity(lua_State* L)
 {
 	// container:getCapacity()
-	Container* container = getUserdata<Container>(L, 1);
-	if (container) {
+	if (const auto container = getSharedPtr<Container>(L, 1)) {
 		lua_pushinteger(L, container->capacity());
 	} else {
 		lua_pushnil(L);
@@ -8163,17 +8087,16 @@ int LuaScriptInterface::luaContainerGetCapacity(lua_State* L)
 int LuaScriptInterface::luaContainerGetEmptySlots(lua_State* L)
 {
 	// container:getEmptySlots([recursive = false])
-	Container* container = getUserdata<Container>(L, 1);
+	const auto container = getSharedPtr<Container>(L, 1);
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	uint32_t slots = container->capacity() - container->size();
-	bool recursive = getBoolean(L, 2, false);
-	if (recursive) {
+	if (getBoolean(L, 2, false)) {
 		for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-			if (Container* tmpContainer = (*it)->getContainer()) {
+			if (const auto tmpContainer = (*it)->getContainer()) {
 				slots += tmpContainer->capacity() - tmpContainer->size();
 			}
 		}
@@ -8185,8 +8108,7 @@ int LuaScriptInterface::luaContainerGetEmptySlots(lua_State* L)
 int LuaScriptInterface::luaContainerGetItemHoldingCount(lua_State* L)
 {
 	// container:getItemHoldingCount()
-	Container* container = getUserdata<Container>(L, 1);
-	if (container) {
+	if (const auto container = getSharedPtr<Container>(L, 1)) {
 		lua_pushinteger(L, container->getItemHoldingCount());
 	} else {
 		lua_pushnil(L);
@@ -8197,16 +8119,15 @@ int LuaScriptInterface::luaContainerGetItemHoldingCount(lua_State* L)
 int LuaScriptInterface::luaContainerGetItem(lua_State* L)
 {
 	// container:getItem(index)
-	Container* container = getUserdata<Container>(L, 1);
+	const auto container = getSharedPtr<Container>(L, 1);
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	uint32_t index = getNumber<uint32_t>(L, 2);
-	Item* item = container->getItemByIndex(index);
-	if (item) {
-		pushUserdata<Item>(L, item);
+	if (const auto item = container->getItemByIndex(index)) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -8217,9 +8138,8 @@ int LuaScriptInterface::luaContainerGetItem(lua_State* L)
 int LuaScriptInterface::luaContainerHasItem(lua_State* L)
 {
 	// container:hasItem(item)
-	Item* item = getUserdata<Item>(L, 2);
-	Container* container = getUserdata<Container>(L, 1);
-	if (container) {
+	if (const auto container = getSharedPtr<Container>(L, 1);
+		const auto item = getSharedPtr<Item>(L, 2)) {
 		pushBoolean(L, container->isHoldingItem(item));
 	} else {
 		lua_pushnil(L);
@@ -8230,7 +8150,7 @@ int LuaScriptInterface::luaContainerHasItem(lua_State* L)
 int LuaScriptInterface::luaContainerAddItem(lua_State* L)
 {
 	// container:addItem(itemId[, count/subType = 1[, index = INDEX_WHEREEVER[, flags = 0]]])
-	Container* container = getUserdata<Container>(L, 1);
+	const auto container = getSharedPtr<Container>(L, 1);
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -8273,8 +8193,8 @@ int LuaScriptInterface::luaContainerAddItem(lua_State* L)
 	uint32_t flags = getNumber<uint32_t>(L, 5, 0);
 
 	for (int32_t i = 1; i <= itemCount; ++i) {
-		int32_t stackCount = std::min<int32_t>(subType, 100);
-		Item* item = Item::CreateItem(itemId, stackCount);
+		const int32_t stackCount = std::min<int32_t>(subType, 100);
+		auto item = Item::CreateItem(itemId, stackCount);
 		if (!item) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 			if (!hasTable) {
@@ -8286,10 +8206,10 @@ int LuaScriptInterface::luaContainerAddItem(lua_State* L)
 		if (it.stackable) {
 			subType -= stackCount;
 		}
-
-		ReturnValue ret = g_game.internalAddItem(container, item, index, flags);
+		CylinderPtr holder = container;
+		ReturnValue ret = g_game.internalAddItem(holder, item, index, flags);
 		if (ret != RETURNVALUE_NOERROR) {
-			delete item;
+			item.reset();
 			if (!hasTable) {
 				lua_pushnil(L);
 			}
@@ -8298,11 +8218,11 @@ int LuaScriptInterface::luaContainerAddItem(lua_State* L)
 
 		if (hasTable) {
 			lua_pushinteger(L, i);
-			pushUserdata<Item>(L, item);
+			pushSharedPtr(L, item);
 			setItemMetatable(L, -1, item);
 			lua_settable(L, -3);
 		} else {
-			pushUserdata<Item>(L, item);
+			pushSharedPtr(L, item);
 			setItemMetatable(L, -1, item);
 		}
 	}
@@ -8312,13 +8232,13 @@ int LuaScriptInterface::luaContainerAddItem(lua_State* L)
 int LuaScriptInterface::luaContainerAddItemEx(lua_State* L)
 {
 	// container:addItemEx(item[, index = INDEX_WHEREEVER[, flags = 0]])
-	Item* item = getUserdata<Item>(L, 2);
+	const auto item = getSharedPtr<Item>(L, 2);
 	if (!item) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Container* container = getUserdata<Container>(L, 1);
+	const auto container = getSharedPtr<Container>(L, 1);
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -8332,7 +8252,8 @@ int LuaScriptInterface::luaContainerAddItemEx(lua_State* L)
 
 	int32_t index = getNumber<int32_t>(L, 3, INDEX_WHEREEVER);
 	uint32_t flags = getNumber<uint32_t>(L, 4, 0);
-	ReturnValue ret = g_game.internalAddItem(container, item, index, flags);
+	CylinderPtr holder = container;
+	ReturnValue ret = g_game.internalAddItem(holder, item, index, flags);
 	if (ret == RETURNVALUE_NOERROR) {
 		ScriptEnvironment::removeTempItem(item);
 	}
@@ -8343,8 +8264,7 @@ int LuaScriptInterface::luaContainerAddItemEx(lua_State* L)
 int LuaScriptInterface::luaContainerGetCorpseOwner(lua_State* L)
 {
 	// container:getCorpseOwner()
-	Container* container = getUserdata<Container>(L, 1);
-	if (container) {
+	if (const auto container = getSharedPtr<Container>(L, 1)) {
 		lua_pushinteger(L, container->getCorpseOwner());
 	} else {
 		lua_pushnil(L);
@@ -8355,7 +8275,7 @@ int LuaScriptInterface::luaContainerGetCorpseOwner(lua_State* L)
 int LuaScriptInterface::luaContainerGetItemCountById(lua_State* L)
 {
 	// container:getItemCountById(itemId[, subType = -1])
-	Container* container = getUserdata<Container>(L, 1);
+	const auto container = getSharedPtr<Container>(L, 1);
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
@@ -8380,8 +8300,7 @@ int LuaScriptInterface::luaContainerGetItemCountById(lua_State* L)
 int LuaScriptInterface::luaContainerGetContentDescription(lua_State* L)
 {
 	// container:getContentDescription()
-	Container* container = getUserdata<Container>(L, 1);
-	if (container) {
+	if (const auto container = getSharedPtr<Container>(L, 1)) {
 		pushString(L, container->getContentDescription());
 	} else {
 		lua_pushnil(L);
@@ -8392,20 +8311,20 @@ int LuaScriptInterface::luaContainerGetContentDescription(lua_State* L)
 int LuaScriptInterface::luaContainerGetItems(lua_State* L)
 {
 	// container:getItems([recursive = false])
-	Container* container = getUserdata<Container>(L, 1);
+	const auto container = getSharedPtr<Container>(L, 1);
 	if (!container) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	bool recursive = getBoolean(L, 2, false);
-	std::vector<Item*> items = container->getItems(recursive);
+	const auto items = container->getItems(recursive);
 
 	lua_createtable(L, items.size(), 0);
 
 	int index = 0;
-	for (Item* item : items) {
-		pushUserdata(L, item);
+	for (const auto item : items) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -8416,11 +8335,10 @@ int LuaScriptInterface::luaContainerGetItems(lua_State* L)
 int LuaScriptInterface::luaTeleportCreate(lua_State* L)
 {
 	// Teleport(uid)
-	uint32_t id = getNumber<uint32_t>(L, 2);
+	const uint32_t id = getNumber<uint32_t>(L, 2);
 
-	Item* item = getScriptEnv()->getItemByUID(id);
-	if (item && item->getTeleport()) {
-		pushUserdata(L, item);
+	if (const auto item = getScriptEnv()->getItemByUID(id); item && item->getTeleport()) {
+		pushSharedPtr(L, item);
 		setMetatable(L, -1, "Teleport");
 	} else {
 		lua_pushnil(L);
@@ -8431,8 +8349,7 @@ int LuaScriptInterface::luaTeleportCreate(lua_State* L)
 int LuaScriptInterface::luaTeleportGetDestination(lua_State* L)
 {
 	// teleport:getDestination()
-	Teleport* teleport = getUserdata<Teleport>(L, 1);
-	if (teleport) {
+	if (const auto teleport = getSharedPtr<Teleport>(L, 1)) {
 		pushPosition(L, teleport->getDestPos());
 	} else {
 		lua_pushnil(L);
@@ -8443,8 +8360,7 @@ int LuaScriptInterface::luaTeleportGetDestination(lua_State* L)
 int LuaScriptInterface::luaTeleportSetDestination(lua_State* L)
 {
 	// teleport:setDestination(position)
-	Teleport* teleport = getUserdata<Teleport>(L, 1);
-	if (teleport) {
+	if (const auto teleport = getSharedPtr<Teleport>(L, 1)) {
 		teleport->setDestPos(getPosition(L, 2));
 		pushBoolean(L, true);
 	} else {
@@ -8457,24 +8373,23 @@ int LuaScriptInterface::luaTeleportSetDestination(lua_State* L)
 int LuaScriptInterface::luaCreatureCreate(lua_State* L)
 {
 	// Creature(id or name or userdata)
-	Creature* creature;
+	CreaturePtr creature;
 	if (isNumber(L, 2)) {
 		creature = g_game.getCreatureByID(getNumber<uint32_t>(L, 2));
 	} else if (isString(L, 2)) {
 		creature = g_game.getCreatureByName(getString(L, 2));
 	} else if (isUserdata(L, 2)) {
-		LuaDataType type = getUserdataType(L, 2);
-		if (type != LuaData_Player && type != LuaData_Monster && type != LuaData_Npc) {
+		if (const LuaDataType type = getUserdataType(L, 2); type != LuaData_Player && type != LuaData_Monster && type != LuaData_Npc) {
 			lua_pushnil(L);
 			return 1;
 		}
-		creature = getUserdata<Creature>(L, 2);
+		creature = getSharedPtr<Creature>(L, 2);
 	} else {
 		creature = nullptr;
 	}
 
 	if (creature) {
-		pushUserdata<Creature>(L, creature);
+		pushSharedPtr(L, creature);
 		setCreatureMetatable(L, -1, creature);
 	} else {
 		lua_pushnil(L);
@@ -8485,18 +8400,18 @@ int LuaScriptInterface::luaCreatureCreate(lua_State* L)
 int LuaScriptInterface::luaCreatureGetEvents(lua_State* L)
 {
 	// creature:getEvents(type)
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	CreatureEventType_t eventType = getNumber<CreatureEventType_t>(L, 2);
+	const CreatureEventType_t eventType = getNumber<CreatureEventType_t>(L, 2);
 	const auto& eventList = creature->getCreatureEvents(eventType);
 	lua_createtable(L, eventList.size(), 0);
 
 	int index = 0;
-	for (CreatureEvent* event : eventList) {
+	for (const auto event : eventList) {
 		pushString(L, event->getName());
 		lua_rawseti(L, -2, ++index);
 	}
@@ -8506,8 +8421,7 @@ int LuaScriptInterface::luaCreatureGetEvents(lua_State* L)
 int LuaScriptInterface::luaCreatureRegisterEvent(lua_State* L)
 {
 	// creature:registerEvent(name)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		const std::string& name = getString(L, 2);
 		pushBoolean(L, creature->registerCreatureEvent(name));
 	} else {
@@ -8520,8 +8434,7 @@ int LuaScriptInterface::luaCreatureUnregisterEvent(lua_State* L)
 {
 	// creature:unregisterEvent(name)
 	const std::string& name = getString(L, 2);
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		pushBoolean(L, creature->unregisterCreatureEvent(name));
 	} else {
 		lua_pushnil(L);
@@ -8532,8 +8445,7 @@ int LuaScriptInterface::luaCreatureUnregisterEvent(lua_State* L)
 int LuaScriptInterface::luaCreatureIsRemoved(lua_State* L)
 {
 	// creature:isRemoved()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		pushBoolean(L, creature->isRemoved());
 	} else {
 		lua_pushnil(L);
@@ -8544,15 +8456,14 @@ int LuaScriptInterface::luaCreatureIsRemoved(lua_State* L)
 int LuaScriptInterface::luaCreatureIsCreature(lua_State* L)
 {
 	// creature:isCreature()
-	pushBoolean(L, getUserdata<const Creature>(L, 1) != nullptr);
+	pushBoolean(L, getSharedPtr<const Creature>(L, 1) != nullptr);
 	return 1;
 }
 
 int LuaScriptInterface::luaCreatureIsInGhostMode(lua_State* L)
 {
 	// creature:isInGhostMode()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		pushBoolean(L, creature->isInGhostMode());
 	} else {
 		lua_pushnil(L);
@@ -8563,8 +8474,7 @@ int LuaScriptInterface::luaCreatureIsInGhostMode(lua_State* L)
 int LuaScriptInterface::luaCreatureIsHealthHidden(lua_State* L)
 {
 	// creature:isHealthHidden()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		pushBoolean(L, creature->isHealthHidden());
 	} else {
 		lua_pushnil(L);
@@ -8575,8 +8485,7 @@ int LuaScriptInterface::luaCreatureIsHealthHidden(lua_State* L)
 int LuaScriptInterface::luaCreatureIsMovementBlocked(lua_State* L)
 {
 	// creature:isMovementBlocked()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		pushBoolean(L, creature->isMovementBlocked());
 	} else {
 		lua_pushnil(L);
@@ -8587,8 +8496,7 @@ int LuaScriptInterface::luaCreatureIsMovementBlocked(lua_State* L)
 int LuaScriptInterface::luaCreatureCanSee(lua_State* L)
 {
 	// creature:canSee(position)
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		const Position& position = getPosition(L, 2);
 		pushBoolean(L, creature->canSee(position));
 	} else {
@@ -8600,16 +8508,15 @@ int LuaScriptInterface::luaCreatureCanSee(lua_State* L)
 int LuaScriptInterface::luaCreatureCanSeeCreature(lua_State* L)
 {
 	// creature:canSeeCreature(creature)
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
-		const Creature* otherCreature = getCreature(L, 2);
-		if (!otherCreature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
+		const auto other_creature = getCreature(L, 2);
+		if (!other_creature) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 			pushBoolean(L, false);
 			return 1;
 		}
 
-		pushBoolean(L, creature->canSeeCreature(otherCreature));
+		pushBoolean(L, creature->canSeeCreature(other_creature));
 	} else {
 		lua_pushnil(L);
 	}
@@ -8619,9 +8526,8 @@ int LuaScriptInterface::luaCreatureCanSeeCreature(lua_State* L)
 int LuaScriptInterface::luaCreatureCanSeeGhostMode(lua_State* L)
 {
 	// creature:canSeeGhostMode(creature)
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
-		const Creature* otherCreature = getCreature(L, 2);
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
+		const auto otherCreature = getCreature(L, 2);
 		if (!otherCreature) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 			pushBoolean(L, false);
@@ -8638,8 +8544,7 @@ int LuaScriptInterface::luaCreatureCanSeeGhostMode(lua_State* L)
 int LuaScriptInterface::luaCreatureCanSeeInvisibility(lua_State* L)
 {
 	// creature:canSeeInvisibility()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		pushBoolean(L, creature->canSeeInvisibility());
 	} else {
 		lua_pushnil(L);
@@ -8650,13 +8555,13 @@ int LuaScriptInterface::luaCreatureCanSeeInvisibility(lua_State* L)
 int LuaScriptInterface::luaCreatureGetParent(lua_State* L)
 {
 	// creature:getParent()
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Cylinder* parent = creature->getParent();
+	CylinderPtr parent = creature->getParent();
 	if (!parent) {
 		lua_pushnil(L);
 		return 1;
@@ -8669,8 +8574,7 @@ int LuaScriptInterface::luaCreatureGetParent(lua_State* L)
 int LuaScriptInterface::luaCreatureGetId(lua_State* L)
 {
 	// creature:getId()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		lua_pushinteger(L, creature->getID());
 	} else {
 		lua_pushnil(L);
@@ -8681,8 +8585,7 @@ int LuaScriptInterface::luaCreatureGetId(lua_State* L)
 int LuaScriptInterface::luaCreatureGetName(lua_State* L)
 {
 	// creature:getName()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		pushString(L, creature->getName());
 	} else {
 		lua_pushnil(L);
@@ -8693,15 +8596,14 @@ int LuaScriptInterface::luaCreatureGetName(lua_State* L)
 int LuaScriptInterface::luaCreatureGetTarget(lua_State* L)
 {
 	// creature:getTarget()
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* target = creature->getAttackedCreature();
-	if (target) {
-		pushUserdata<Creature>(L, target);
+	if (const auto target = creature->getAttackedCreature()) {
+		pushSharedPtr(L, target);
 		setCreatureMetatable(L, -1, target);
 	} else {
 		lua_pushnil(L);
@@ -8712,8 +8614,7 @@ int LuaScriptInterface::luaCreatureGetTarget(lua_State* L)
 int LuaScriptInterface::luaCreatureSetTarget(lua_State* L)
 {
 	// creature:setTarget(target)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		pushBoolean(L, creature->setAttackedCreature(getCreature(L, 2)));
 	} else {
 		lua_pushnil(L);
@@ -8724,15 +8625,14 @@ int LuaScriptInterface::luaCreatureSetTarget(lua_State* L)
 int LuaScriptInterface::luaCreatureGetFollowCreature(lua_State* L)
 {
 	// creature:getFollowCreature()
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* followCreature = creature->getFollowCreature();
-	if (followCreature) {
-		pushUserdata<Creature>(L, followCreature);
+	if (const auto followCreature = creature->getFollowCreature()) {
+		pushSharedPtr(L, followCreature);
 		setCreatureMetatable(L, -1, followCreature);
 	} else {
 		lua_pushnil(L);
@@ -8743,8 +8643,7 @@ int LuaScriptInterface::luaCreatureGetFollowCreature(lua_State* L)
 int LuaScriptInterface::luaCreatureSetFollowCreature(lua_State* L)
 {
 	// creature:setFollowCreature(followedCreature)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		pushBoolean(L, creature->setFollowCreature(getCreature(L, 2)));
 	} else {
 		lua_pushnil(L);
@@ -8755,19 +8654,19 @@ int LuaScriptInterface::luaCreatureSetFollowCreature(lua_State* L)
 int LuaScriptInterface::luaCreatureGetMaster(lua_State* L)
 {
 	// creature:getMaster()
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* master = creature->getMaster();
+	const auto master = creature->getMaster();
 	if (!master) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	pushUserdata<Creature>(L, master);
+	pushSharedPtr(L, master);
 	setCreatureMetatable(L, -1, master);
 	return 1;
 }
@@ -8775,7 +8674,7 @@ int LuaScriptInterface::luaCreatureGetMaster(lua_State* L)
 int LuaScriptInterface::luaCreatureSetMaster(lua_State* L)
 {
 	// creature:setMaster(master)
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -8791,13 +8690,13 @@ int LuaScriptInterface::luaCreatureSetMaster(lua_State* L)
 int LuaScriptInterface::luaCreatureGetLight(lua_State* L)
 {
 	// creature:getLight()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
+	const auto creature = getSharedPtr<const Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	LightInfo lightInfo = creature->getCreatureLight();
+	const LightInfo lightInfo = creature->getCreatureLight();
 	lua_pushinteger(L, lightInfo.level);
 	lua_pushinteger(L, lightInfo.color);
 	return 2;
@@ -8806,7 +8705,7 @@ int LuaScriptInterface::luaCreatureGetLight(lua_State* L)
 int LuaScriptInterface::luaCreatureSetLight(lua_State* L)
 {
 	// creature:setLight(color, level)
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -8824,8 +8723,7 @@ int LuaScriptInterface::luaCreatureSetLight(lua_State* L)
 int LuaScriptInterface::luaCreatureGetSpeed(lua_State* L)
 {
 	// creature:getSpeed()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getUserdata<const Creature>(L, 1)) {
 		lua_pushinteger(L, creature->getSpeed());
 	} else {
 		lua_pushnil(L);
@@ -8836,8 +8734,7 @@ int LuaScriptInterface::luaCreatureGetSpeed(lua_State* L)
 int LuaScriptInterface::luaCreatureGetBaseSpeed(lua_State* L)
 {
 	// creature:getBaseSpeed()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		lua_pushinteger(L, creature->getBaseSpeed());
 	} else {
 		lua_pushnil(L);
@@ -8848,7 +8745,7 @@ int LuaScriptInterface::luaCreatureGetBaseSpeed(lua_State* L)
 int LuaScriptInterface::luaCreatureChangeSpeed(lua_State* L)
 {
 	// creature:changeSpeed(delta)
-	Creature* creature = getCreature(L, 1);
+	const auto creature = getCreature(L, 1);
 	if (!creature) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -8864,8 +8761,7 @@ int LuaScriptInterface::luaCreatureChangeSpeed(lua_State* L)
 int LuaScriptInterface::luaCreatureSetDropLoot(lua_State* L)
 {
 	// creature:setDropLoot(doDrop)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		creature->setDropLoot(getBoolean(L, 2));
 		pushBoolean(L, true);
 	} else {
@@ -8877,8 +8773,7 @@ int LuaScriptInterface::luaCreatureSetDropLoot(lua_State* L)
 int LuaScriptInterface::luaCreatureSetSkillLoss(lua_State* L)
 {
 	// creature:setSkillLoss(skillLoss)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		creature->setSkillLoss(getBoolean(L, 2));
 		pushBoolean(L, true);
 	} else {
@@ -8890,8 +8785,7 @@ int LuaScriptInterface::luaCreatureSetSkillLoss(lua_State* L)
 int LuaScriptInterface::luaCreatureGetPosition(lua_State* L)
 {
 	// creature:getPosition()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		pushPosition(L, creature->getPosition());
 	} else {
 		lua_pushnil(L);
@@ -8902,15 +8796,14 @@ int LuaScriptInterface::luaCreatureGetPosition(lua_State* L)
 int LuaScriptInterface::luaCreatureGetTile(lua_State* L)
 {
 	// creature:getTile()
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Tile* tile = creature->getTile();
-	if (tile) {
-		pushUserdata<Tile>(L, tile);
+	if (const auto tile = creature->getTile()) {
+		pushSharedPtr(L, tile);
 		setMetatable(L, -1, "Tile");
 	} else {
 		lua_pushnil(L);
@@ -8921,8 +8814,7 @@ int LuaScriptInterface::luaCreatureGetTile(lua_State* L)
 int LuaScriptInterface::luaCreatureGetDirection(lua_State* L)
 {
 	// creature:getDirection()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		lua_pushinteger(L, creature->getDirection());
 	} else {
 		lua_pushnil(L);
@@ -8933,8 +8825,7 @@ int LuaScriptInterface::luaCreatureGetDirection(lua_State* L)
 int LuaScriptInterface::luaCreatureSetDirection(lua_State* L)
 {
 	// creature:setDirection(direction)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		pushBoolean(L, g_game.internalCreatureTurn(creature, getNumber<Direction>(L, 2)));
 	} else {
 		lua_pushnil(L);
@@ -8945,8 +8836,7 @@ int LuaScriptInterface::luaCreatureSetDirection(lua_State* L)
 int LuaScriptInterface::luaCreatureGetHealth(lua_State* L)
 {
 	// creature:getHealth()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		lua_pushinteger(L, creature->getHealth());
 	} else {
 		lua_pushnil(L);
@@ -8957,7 +8847,7 @@ int LuaScriptInterface::luaCreatureGetHealth(lua_State* L)
 int LuaScriptInterface::luaCreatureSetHealth(lua_State* L)
 {
 	// creature:setHealth(health)
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -8966,8 +8856,7 @@ int LuaScriptInterface::luaCreatureSetHealth(lua_State* L)
 	creature->health = std::min<int32_t>(getNumber<uint32_t>(L, 2), creature->healthMax);
 	g_game.addCreatureHealth(creature);
 
-	Player* player = creature->getPlayer();
-	if (player) {
+	if (const auto player = creature->getPlayer()) {
 		player->sendStats();
 	}
 	pushBoolean(L, true);
@@ -8977,7 +8866,7 @@ int LuaScriptInterface::luaCreatureSetHealth(lua_State* L)
 int LuaScriptInterface::luaCreatureAddHealth(lua_State* L)
 {
 	// creature:addHealth(healthChange)
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -8997,8 +8886,7 @@ int LuaScriptInterface::luaCreatureAddHealth(lua_State* L)
 int LuaScriptInterface::luaCreatureGetMaxHealth(lua_State* L)
 {
 	// creature:getMaxHealth()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		lua_pushinteger(L, creature->getMaxHealth());
 	} else {
 		lua_pushnil(L);
@@ -9009,7 +8897,7 @@ int LuaScriptInterface::luaCreatureGetMaxHealth(lua_State* L)
 int LuaScriptInterface::luaCreatureSetMaxHealth(lua_State* L)
 {
 	// creature:setMaxHealth(maxHealth)
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -9019,8 +8907,7 @@ int LuaScriptInterface::luaCreatureSetMaxHealth(lua_State* L)
 	creature->health = std::min<int32_t>(creature->health, creature->healthMax);
 	g_game.addCreatureHealth(creature);
 
-	Player* player = creature->getPlayer();
-	if (player) {
+	if (const auto player = creature->getPlayer()) {
 		player->sendStats();
 	}
 	pushBoolean(L, true);
@@ -9030,8 +8917,7 @@ int LuaScriptInterface::luaCreatureSetMaxHealth(lua_State* L)
 int LuaScriptInterface::luaCreatureSetHiddenHealth(lua_State* L)
 {
 	// creature:setHiddenHealth(hide)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		creature->setHiddenHealth(getBoolean(L, 2));
 		g_game.addCreatureHealth(creature);
 		pushBoolean(L, true);
@@ -9044,8 +8930,7 @@ int LuaScriptInterface::luaCreatureSetHiddenHealth(lua_State* L)
 int LuaScriptInterface::luaCreatureSetMovementBlocked(lua_State* L)
 {
 	// creature:setMovementBlocked(state)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		creature->setMovementBlocked(getBoolean(L, 2));
 		pushBoolean(L, true);
 	} else {
@@ -9057,8 +8942,7 @@ int LuaScriptInterface::luaCreatureSetMovementBlocked(lua_State* L)
 int LuaScriptInterface::luaCreatureGetSkull(lua_State* L)
 {
 	// creature:getSkull()
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		lua_pushinteger(L, creature->getSkull());
 	} else {
 		lua_pushnil(L);
@@ -9069,8 +8953,7 @@ int LuaScriptInterface::luaCreatureGetSkull(lua_State* L)
 int LuaScriptInterface::luaCreatureSetSkull(lua_State* L)
 {
 	// creature:setSkull(skull)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		creature->setSkull(getNumber<Skulls_t>(L, 2));
 		pushBoolean(L, true);
 	} else {
@@ -9082,8 +8965,7 @@ int LuaScriptInterface::luaCreatureSetSkull(lua_State* L)
 int LuaScriptInterface::luaCreatureGetOutfit(lua_State* L)
 {
 	// creature:getOutfit()
-	const Creature* creature = getUserdata<const Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<const Creature>(L, 1)) {
 		pushOutfit(L, creature->getCurrentOutfit());
 	} else {
 		lua_pushnil(L);
@@ -9094,8 +8976,7 @@ int LuaScriptInterface::luaCreatureGetOutfit(lua_State* L)
 int LuaScriptInterface::luaCreatureSetOutfit(lua_State* L)
 {
 	// creature:setOutfit(outfit)
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		creature->defaultOutfit = getOutfit(L, 2);
 		g_game.internalCreatureChangeOutfit(creature, creature->defaultOutfit);
 		pushBoolean(L, true);
@@ -9108,7 +8989,7 @@ int LuaScriptInterface::luaCreatureSetOutfit(lua_State* L)
 int LuaScriptInterface::luaCreatureGetCondition(lua_State* L)
 {
 	// creature:getCondition(conditionType[, conditionId = CONDITIONID_COMBAT[, subId = 0]])
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -9118,8 +8999,7 @@ int LuaScriptInterface::luaCreatureGetCondition(lua_State* L)
 	ConditionId_t conditionId = getNumber<ConditionId_t>(L, 3, CONDITIONID_COMBAT);
 	uint32_t subId = getNumber<uint32_t>(L, 4, 0);
 
-	Condition* condition = creature->getCondition(conditionType, conditionId, subId);
-	if (condition) {
+	if (const auto condition = creature->getCondition(conditionType, conditionId, subId)) {
 		pushUserdata<Condition>(L, condition);
 		setWeakMetatable(L, -1, "Condition");
 	} else {
@@ -9131,10 +9011,10 @@ int LuaScriptInterface::luaCreatureGetCondition(lua_State* L)
 int LuaScriptInterface::luaCreatureAddCondition(lua_State* L)
 {
 	// creature:addCondition(condition[, force = false])
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	Condition* condition = getUserdata<Condition>(L, 2);
 	if (creature && condition) {
-		bool force = getBoolean(L, 3, false);
+		const bool force = getBoolean(L, 3, false);
 		pushBoolean(L, creature->addCondition(condition->clone(), force));
 	} else {
 		lua_pushnil(L);
@@ -9146,7 +9026,7 @@ int LuaScriptInterface::luaCreatureRemoveCondition(lua_State* L)
 {
 	// creature:removeCondition(conditionType[, conditionId = CONDITIONID_COMBAT[, subId = 0[, force = false]]])
 	// creature:removeCondition(condition[, force = false])
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -9179,14 +9059,14 @@ int LuaScriptInterface::luaCreatureRemoveCondition(lua_State* L)
 int LuaScriptInterface::luaCreatureHasCondition(lua_State* L)
 {
 	// creature:hasCondition(conditionType[, subId = 0])
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	ConditionType_t conditionType = getNumber<ConditionType_t>(L, 2);
-	uint32_t subId = getNumber<uint32_t>(L, 3, 0);
+	const auto conditionType = getNumber<ConditionType_t>(L, 2);
+	const uint32_t subId = getNumber<uint32_t>(L, 3, 0);
 	pushBoolean(L, creature->hasCondition(conditionType, subId));
 	return 1;
 }
@@ -9194,7 +9074,7 @@ int LuaScriptInterface::luaCreatureHasCondition(lua_State* L)
 int LuaScriptInterface::luaCreatureIsImmune(lua_State* L)
 {
 	// creature:isImmune(condition or conditionType)
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -9213,26 +9093,25 @@ int LuaScriptInterface::luaCreatureIsImmune(lua_State* L)
 int LuaScriptInterface::luaCreatureRemove(lua_State* L)
 {
 	// creature:remove()
-	Creature** creaturePtr = getRawUserdata<Creature>(L, 1);
+	auto creaturePtr = getSharedPtr<Creature>(L, 1);
 	if (!creaturePtr) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* creature = *creaturePtr;
+	auto creature = creaturePtr;
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Player* player = creature->getPlayer();
-	if (player) {
+	if (auto player = creature->getPlayer()) {
 		player->kickPlayer(true);
 	} else {
 		g_game.removeCreature(creature);
 	}
 
-	*creaturePtr = nullptr;
+	creaturePtr = nullptr;
 	pushBoolean(L, true);
 	return 1;
 }
@@ -9243,7 +9122,7 @@ int LuaScriptInterface::luaCreatureTeleportTo(lua_State* L)
 	bool pushMovement = getBoolean(L, 3) || false ;
 
 	const Position& position = getPosition(L, 2);
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -9287,16 +9166,16 @@ int LuaScriptInterface::luaCreatureSay(lua_State* L)
 		}
 	}
 
-	Creature* target = nullptr;
+	CreaturePtr target = nullptr;
 	if (parameters >= 5) {
 		target = getCreature(L, 5);
 	}
 
-	bool ghost = getBoolean(L, 4, false);
+	const bool ghost = getBoolean(L, 4, false);
 
-	SpeakClasses type = getNumber<SpeakClasses>(L, 3, TALKTYPE_MONSTER_SAY);
+	const SpeakClasses type = getNumber<SpeakClasses>(L, 3, TALKTYPE_MONSTER_SAY);
 	const std::string& text = getString(L, 2);
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const CreaturePtr creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -9308,7 +9187,7 @@ int LuaScriptInterface::luaCreatureSay(lua_State* L)
 	}
 
 	// Prevent infinity echo on event onHear
-	bool echo = getScriptEnv()->getScriptId() == g_events->getScriptId(EventInfoId::CREATURE_ONHEAR);
+	const bool echo = getScriptEnv()->getScriptId() == g_events->getScriptId(EventInfoId::CREATURE_ONHEAR);
 
 	if (position.x != 0) {
 		pushBoolean(L, g_game.internalCreatureSay(creature, type, text, ghost, &spectators, &position, echo));
@@ -9321,18 +9200,18 @@ int LuaScriptInterface::luaCreatureSay(lua_State* L)
 int LuaScriptInterface::luaCreatureGetDamageMap(lua_State* L)
 {
 	// creature:getDamageMap()
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	lua_createtable(L, creature->damageMap.size(), 0);
-	for (const auto& damageEntry : creature->damageMap) {
+	for (const auto& [index, value] : creature->damageMap) {
 		lua_createtable(L, 0, 2);
-		setField(L, "total", damageEntry.second.total);
-		setField(L, "ticks", damageEntry.second.ticks);
-		lua_rawseti(L, -2, damageEntry.first);
+		setField(L, "total", value.total);
+		setField(L, "ticks", value.ticks);
+		lua_rawseti(L, -2, index);
 	}
 	return 1;
 }
@@ -9340,7 +9219,7 @@ int LuaScriptInterface::luaCreatureGetDamageMap(lua_State* L)
 int LuaScriptInterface::luaCreatureGetSummons(lua_State* L)
 {
 	// creature:getSummons()
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -9349,8 +9228,8 @@ int LuaScriptInterface::luaCreatureGetSummons(lua_State* L)
 	lua_createtable(L, creature->getSummonCount(), 0);
 
 	int index = 0;
-	for (Creature* summon : creature->getSummons()) {
-		pushUserdata<Creature>(L, summon);
+	for (const auto summon : creature->getSummons()) {
+		pushSharedPtr(L, summon);
 		setCreatureMetatable(L, -1, summon);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -9361,8 +9240,7 @@ int LuaScriptInterface::luaCreatureGetDescription(lua_State* L)
 {
 	// creature:getDescription(distance)
 	int32_t distance = getNumber<int32_t>(L, 2);
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		pushString(L, creature->getDescription(distance));
 	} else {
 		lua_pushnil(L);
@@ -9373,7 +9251,7 @@ int LuaScriptInterface::luaCreatureGetDescription(lua_State* L)
 int LuaScriptInterface::luaCreatureGetPathTo(lua_State* L)
 {
 	// creature:getPathTo(pos[, minTargetDist = 0[, maxTargetDist = 1[, fullPathSearch = true[, clearSight = true[, maxSearchDist = 0]]]]])
-	Creature* creature = getUserdata<Creature>(L, 1);
+	const auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
@@ -9388,8 +9266,7 @@ int LuaScriptInterface::luaCreatureGetPathTo(lua_State* L)
 	fpp.clearSight = getBoolean(L, 6, fpp.clearSight);
 	fpp.maxSearchDist = getNumber<int32_t>(L, 7, fpp.maxSearchDist);
 
-	std::vector<Direction> dirList;
-	if (creature->getPathTo(position, dirList, fpp)) {
+	if (std::vector<Direction> dirList; creature->getPathTo(position, dirList, fpp)) {
 		lua_newtable(L);
 
 		int index = 0;
@@ -9407,26 +9284,26 @@ int LuaScriptInterface::luaCreatureMove(lua_State* L)
 {
 	// creature:move(direction)
 	// creature:move(tile[, flags = 0])
-	Creature* creature = getUserdata<Creature>(L, 1);
+	auto creature = getSharedPtr<Creature>(L, 1);
 	if (!creature) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	if (isNumber(L, 2)) {
-		Direction direction = getNumber<Direction>(L, 2);
+		const Direction direction = getNumber<Direction>(L, 2);
 		if (direction > DIRECTION_LAST) {
 			lua_pushnil(L);
 			return 1;
 		}
 		lua_pushinteger(L, g_game.internalMoveCreature(creature, direction, FLAG_NOLIMIT));
 	} else {
-		Tile* tile = getUserdata<Tile>(L, 2);
+		const auto tile = getSharedPtr<Tile>(L, 2);
 		if (!tile) {
 			lua_pushnil(L);
 			return 1;
 		}
-		lua_pushinteger(L, g_game.internalMoveCreature(*creature, *tile, getNumber<uint32_t>(L, 3)));
+		lua_pushinteger(L, g_game.internalMoveCreature(creature, tile, getNumber<uint32_t>(L, 3)));
 	}
 	return 1;
 }
@@ -9434,8 +9311,7 @@ int LuaScriptInterface::luaCreatureMove(lua_State* L)
 int LuaScriptInterface::luaCreatureGetZone(lua_State* L)
 {
 	// creature:getZone()
-	Creature* creature = getUserdata<Creature>(L, 1);
-	if (creature) {
+	if (const auto creature = getSharedPtr<Creature>(L, 1)) {
 		lua_pushinteger(L, creature->getZone());
 	} else {
 		lua_pushnil(L);
@@ -9447,17 +9323,15 @@ int LuaScriptInterface::luaCreatureGetZone(lua_State* L)
 int LuaScriptInterface::luaPlayerCreate(lua_State* L)
 {
 	// Player(id or guid or name or userdata)
-	Player* player;
+	PlayerPtr player;
 	if (isNumber(L, 2)) {
-		uint32_t id = getNumber<uint32_t>(L, 2);
-		if (id >= 0x10000000 && id <= Player::playerAutoID) {
+		if (const uint32_t id = getNumber<uint32_t>(L, 2); id >= 0x10000000 && id <= Player::playerAutoID) {
 			player = g_game.getPlayerByID(id);
 		} else {
 			player = g_game.getPlayerByGUID(id);
 		}
 	} else if (isString(L, 2)) {
-		ReturnValue ret = g_game.getPlayerByNameWildcard(getString(L, 2), player);
-		if (ret != RETURNVALUE_NOERROR) {
+		if (const ReturnValue ret = g_game.getPlayerByNameWildcard(getString(L, 2)); ret != RETURNVALUE_NOERROR) {
 			lua_pushnil(L);
 			lua_pushinteger(L, ret);
 			return 2;
@@ -9467,13 +9341,13 @@ int LuaScriptInterface::luaPlayerCreate(lua_State* L)
 			lua_pushnil(L);
 			return 1;
 		}
-		player = getUserdata<Player>(L, 2);
+		player = getSharedPtr<Player>(L, 2);
 	} else {
 		player = nullptr;
 	}
 
 	if (player) {
-		pushUserdata<Player>(L, player);
+		pushSharedPtr(L, player);
 		setMetatable(L, -1, "Player");
 	} else {
 		lua_pushnil(L);
@@ -9484,15 +9358,14 @@ int LuaScriptInterface::luaPlayerCreate(lua_State* L)
 int LuaScriptInterface::luaPlayerIsPlayer(lua_State* L)
 {
 	// player:isPlayer()
-	pushBoolean(L, getUserdata<const Player>(L, 1) != nullptr);
+	pushBoolean(L, getSharedPtr<const Player>(L, 1) != nullptr);
 	return 1;
 }
 
 int LuaScriptInterface::luaPlayerGetGuid(lua_State* L)
 {
 	// player:getGuid()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getGUID());
 	} else {
 		lua_pushnil(L);
@@ -9503,8 +9376,7 @@ int LuaScriptInterface::luaPlayerGetGuid(lua_State* L)
 int LuaScriptInterface::luaPlayerGetIp(lua_State* L)
 {
 	// player:getIp()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getIP());
 	} else {
 		lua_pushnil(L);
@@ -9515,8 +9387,7 @@ int LuaScriptInterface::luaPlayerGetIp(lua_State* L)
 int LuaScriptInterface::luaPlayerGetAccountId(lua_State* L)
 {
 	// player:getAccountId()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getAccount());
 	} else {
 		lua_pushnil(L);
@@ -9527,8 +9398,7 @@ int LuaScriptInterface::luaPlayerGetAccountId(lua_State* L)
 int LuaScriptInterface::luaPlayerGetLastLoginSaved(lua_State* L)
 {
 	// player:getLastLoginSaved()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getLastLoginSaved());
 	} else {
 		lua_pushnil(L);
@@ -9539,8 +9409,7 @@ int LuaScriptInterface::luaPlayerGetLastLoginSaved(lua_State* L)
 int LuaScriptInterface::luaPlayerGetLastLogout(lua_State* L)
 {
 	// player:getLastLogout()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getLastLogout());
 	} else {
 		lua_pushnil(L);
@@ -9551,8 +9420,7 @@ int LuaScriptInterface::luaPlayerGetLastLogout(lua_State* L)
 int LuaScriptInterface::luaPlayerGetAccountType(lua_State* L)
 {
 	// player:getAccountType()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getAccountType());
 	} else {
 		lua_pushnil(L);
@@ -9563,8 +9431,7 @@ int LuaScriptInterface::luaPlayerGetAccountType(lua_State* L)
 int LuaScriptInterface::luaPlayerSetAccountType(lua_State* L)
 {
 	// player:setAccountType(accountType)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->accountType = getNumber<AccountType_t>(L, 2);
 		IOLoginData::setAccountType(player->getAccount(), player->accountType);
 		pushBoolean(L, true);
@@ -9577,8 +9444,7 @@ int LuaScriptInterface::luaPlayerSetAccountType(lua_State* L)
 int LuaScriptInterface::luaPlayerGetCapacity(lua_State* L)
 {
 	// player:getCapacity()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getCapacity());
 	} else {
 		lua_pushnil(L);
@@ -9589,8 +9455,7 @@ int LuaScriptInterface::luaPlayerGetCapacity(lua_State* L)
 int LuaScriptInterface::luaPlayerSetCapacity(lua_State* L)
 {
 	// player:setCapacity(capacity)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->capacity = getNumber<uint32_t>(L, 2);
 		player->sendStats();
 		pushBoolean(L, true);
@@ -9603,8 +9468,7 @@ int LuaScriptInterface::luaPlayerSetCapacity(lua_State* L)
 int LuaScriptInterface::luaPlayerGetFreeCapacity(lua_State* L)
 {
 	// player:getFreeCapacity()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getFreeCapacity());
 	} else {
 		lua_pushnil(L);
@@ -9615,8 +9479,7 @@ int LuaScriptInterface::luaPlayerGetFreeCapacity(lua_State* L)
 int LuaScriptInterface::luaPlayerGetDepotItemCount(lua_State* L)
 {
 	// player:getDepotItemCount()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getDepotItemCount());
 	}
 	else {
@@ -9628,18 +9491,17 @@ int LuaScriptInterface::luaPlayerGetDepotItemCount(lua_State* L)
 int LuaScriptInterface::luaPlayerGetDepotChest(lua_State* L)
 {
 	// player:getDepotChest(depotId[, autoCreate = false])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint32_t depotId = getNumber<uint32_t>(L, 2);
-	bool autoCreate = getBoolean(L, 3, true);
-	DepotChest* depotChest = player->getDepotChest(depotId, autoCreate);
-	
-	if (depotChest) {
-		pushUserdata<Item>(L, depotChest);
+	const uint32_t depotId = getNumber<uint32_t>(L, 2);
+	const bool autoCreate = getBoolean(L, 3, true);
+
+	if (const auto depotChest = player->getDepotChest(depotId, autoCreate)) {
+		pushSharedPtr(L, depotChest);
 		setItemMetatable(L, -1, depotChest);
 	} else {
 		pushBoolean(L, false);
@@ -9650,15 +9512,14 @@ int LuaScriptInterface::luaPlayerGetDepotChest(lua_State* L)
 int LuaScriptInterface::luaPlayerGetInbox(lua_State* L)
 {
 	// player:getInbox()
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Inbox* inbox = player->getInbox();
-	if (inbox) {
-		pushUserdata<Item>(L, inbox);
+	if (const auto inbox = player->getInbox()) {
+		pushSharedPtr(L, inbox);
 		setItemMetatable(L, -1, inbox);
 	} else {
 		pushBoolean(L, false);
@@ -9669,16 +9530,15 @@ int LuaScriptInterface::luaPlayerGetInbox(lua_State* L)
 int LuaScriptInterface::luaPlayerGetRewardChest(lua_State* L)
 {
 	// player:getRewardChest()
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	RewardChest& rewardChest = player->getRewardChest();
-	if (&rewardChest) {
-		pushUserdata<Item>(L, &rewardChest);
-		setItemMetatable(L, -1, &rewardChest);
+	if (const auto rewardChest = player->getRewardChest()) {
+		pushSharedPtr(L, rewardChest);
+		setItemMetatable(L, -1, rewardChest);
 	}
 	else {
 		pushBoolean(L, false);
@@ -9689,8 +9549,7 @@ int LuaScriptInterface::luaPlayerGetRewardChest(lua_State* L)
 int LuaScriptInterface::luaPlayerGetSkullTime(lua_State* L)
 {
 	// player:getSkullTime()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getSkullTicks());
 	} else {
 		lua_pushnil(L);
@@ -9701,8 +9560,7 @@ int LuaScriptInterface::luaPlayerGetSkullTime(lua_State* L)
 int LuaScriptInterface::luaPlayerSetSkullTime(lua_State* L)
 {
 	// player:setSkullTime(skullTime)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->setSkullTicks(getNumber<int64_t>(L, 2));
 		pushBoolean(L, true);
 	} else {
@@ -9714,8 +9572,7 @@ int LuaScriptInterface::luaPlayerSetSkullTime(lua_State* L)
 int LuaScriptInterface::luaPlayerGetDeathPenalty(lua_State* L)
 {
 	// player:getDeathPenalty()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushnumber(L, player->getLostPercent() * 100);
 	} else {
 		lua_pushnil(L);
@@ -9726,8 +9583,7 @@ int LuaScriptInterface::luaPlayerGetDeathPenalty(lua_State* L)
 int LuaScriptInterface::luaPlayerGetExperience(lua_State* L)
 {
 	// player:getExperience()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getExperience());
 	} else {
 		lua_pushnil(L);
@@ -9738,10 +9594,10 @@ int LuaScriptInterface::luaPlayerGetExperience(lua_State* L)
 int LuaScriptInterface::luaPlayerAddExperience(lua_State* L)
 {
 	// player:addExperience(experience[, sendText = false])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (player) {
-		uint64_t experience = getNumber<uint64_t>(L, 2);
-		bool sendText = getBoolean(L, 3, false);
+		const uint64_t experience = getNumber<uint64_t>(L, 2);
+		const bool sendText = getBoolean(L, 3, false);
 		player->addExperience(nullptr, experience, sendText);
 		pushBoolean(L, true);
 	} else {
@@ -9753,10 +9609,9 @@ int LuaScriptInterface::luaPlayerAddExperience(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveExperience(lua_State* L)
 {
 	// player:removeExperience(experience[, sendText = false])
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint64_t experience = getNumber<uint64_t>(L, 2);
-		bool sendText = getBoolean(L, 3, false);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const uint64_t experience = getNumber<uint64_t>(L, 2);
+		const bool sendText = getBoolean(L, 3, false);
 		player->removeExperience(experience, sendText);
 		pushBoolean(L, true);
 	} else {
@@ -9768,8 +9623,7 @@ int LuaScriptInterface::luaPlayerRemoveExperience(lua_State* L)
 int LuaScriptInterface::luaPlayerGetLevel(lua_State* L)
 {
 	// player:getLevel()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getLevel());
 	} else {
 		lua_pushnil(L);
@@ -9780,8 +9634,7 @@ int LuaScriptInterface::luaPlayerGetLevel(lua_State* L)
 int LuaScriptInterface::luaPlayerGetMagicLevel(lua_State* L)
 {
 	// player:getMagicLevel()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getMagicLevel());
 	} else {
 		lua_pushnil(L);
@@ -9792,8 +9645,7 @@ int LuaScriptInterface::luaPlayerGetMagicLevel(lua_State* L)
 int LuaScriptInterface::luaPlayerGetBaseMagicLevel(lua_State* L)
 {
 	// player:getBaseMagicLevel()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getBaseMagicLevel());
 	} else {
 		lua_pushnil(L);
@@ -9804,8 +9656,7 @@ int LuaScriptInterface::luaPlayerGetBaseMagicLevel(lua_State* L)
 int LuaScriptInterface::luaPlayerGetMana(lua_State* L)
 {
 	// player:getMana()
-	const Player* player = getUserdata<const Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<const Player>(L, 1)) {
 		lua_pushinteger(L, player->getMana());
 	} else {
 		lua_pushnil(L);
@@ -9816,14 +9667,14 @@ int LuaScriptInterface::luaPlayerGetMana(lua_State* L)
 int LuaScriptInterface::luaPlayerAddMana(lua_State* L)
 {
 	// player:addMana(manaChange[, animationOnLoss = false])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	int32_t manaChange = getNumber<int32_t>(L, 2);
-	bool animationOnLoss = getBoolean(L, 3, false);
+	const int32_t manaChange = getNumber<int32_t>(L, 2);
+	const bool animationOnLoss = getBoolean(L, 3, false);
 	if (!animationOnLoss && manaChange < 0) {
 		player->changeMana(manaChange);
 	} else {
@@ -9839,8 +9690,7 @@ int LuaScriptInterface::luaPlayerAddMana(lua_State* L)
 int LuaScriptInterface::luaPlayerGetMaxMana(lua_State* L)
 {
 	// player:getMaxMana()
-	const Player* player = getUserdata<const Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<const Player>(L, 1)) {
 		lua_pushinteger(L, player->getMaxMana());
 	} else {
 		lua_pushnil(L);
@@ -9851,8 +9701,7 @@ int LuaScriptInterface::luaPlayerGetMaxMana(lua_State* L)
 int LuaScriptInterface::luaPlayerSetMaxMana(lua_State* L)
 {
 	// player:setMaxMana(maxMana)
-	Player* player = getPlayer(L, 1);
-	if (player) {
+	if (const auto player = getPlayer(L, 1)) {
 		player->manaMax = getNumber<int32_t>(L, 2);
 		player->mana = std::min<int32_t>(player->mana, player->manaMax);
 		player->sendStats();
@@ -9866,8 +9715,7 @@ int LuaScriptInterface::luaPlayerSetMaxMana(lua_State* L)
 int LuaScriptInterface::luaPlayerGetManaSpent(lua_State* L)
 {
 	// player:getManaSpent()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getSpentMana());
 	} else {
 		lua_pushnil(L);
@@ -9878,8 +9726,7 @@ int LuaScriptInterface::luaPlayerGetManaSpent(lua_State* L)
 int LuaScriptInterface::luaPlayerAddManaSpent(lua_State* L)
 {
 	// player:addManaSpent(amount)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->addManaSpent(getNumber<uint64_t>(L, 2));
 		pushBoolean(L, true);
 	} else {
@@ -9891,8 +9738,7 @@ int LuaScriptInterface::luaPlayerAddManaSpent(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveManaSpent(lua_State* L)
 {
 	// player:removeManaSpent(amount[, notify = true])
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->removeManaSpent(getNumber<uint64_t>(L, 2), getBoolean(L, 3, true));
 		pushBoolean(L, true);
 	} else {
@@ -9904,8 +9750,7 @@ int LuaScriptInterface::luaPlayerRemoveManaSpent(lua_State* L)
 int LuaScriptInterface::luaPlayerGetBaseMaxHealth(lua_State* L)
 {
 	// player:getBaseMaxHealth()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->healthMax);
 	} else {
 		lua_pushnil(L);
@@ -9916,8 +9761,7 @@ int LuaScriptInterface::luaPlayerGetBaseMaxHealth(lua_State* L)
 int LuaScriptInterface::luaPlayerGetBaseMaxMana(lua_State* L)
 {
 	// player:getBaseMaxMana()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->manaMax);
 	} else {
 		lua_pushnil(L);
@@ -9928,8 +9772,8 @@ int LuaScriptInterface::luaPlayerGetBaseMaxMana(lua_State* L)
 int LuaScriptInterface::luaPlayerGetSkillLevel(lua_State* L)
 {
 	// player:getSkillLevel(skillType)
-	skills_t skillType = getNumber<skills_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
+	const auto skillType = getNumber<skills_t>(L, 2);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (player && skillType <= SKILL_LAST) {
 		lua_pushinteger(L, player->skills[skillType].level);
 	} else {
@@ -9941,8 +9785,8 @@ int LuaScriptInterface::luaPlayerGetSkillLevel(lua_State* L)
 int LuaScriptInterface::luaPlayerGetEffectiveSkillLevel(lua_State* L)
 {
 	// player:getEffectiveSkillLevel(skillType)
-	skills_t skillType = getNumber<skills_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
+	const auto skillType = getNumber<skills_t>(L, 2);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (player && skillType <= SKILL_LAST) {
 		lua_pushinteger(L, player->getSkillLevel(skillType));
 	} else {
@@ -9954,8 +9798,8 @@ int LuaScriptInterface::luaPlayerGetEffectiveSkillLevel(lua_State* L)
 int LuaScriptInterface::luaPlayerGetSkillPercent(lua_State* L)
 {
 	// player:getSkillPercent(skillType)
-	skills_t skillType = getNumber<skills_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
+	const auto skillType = getNumber<skills_t>(L, 2);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (player && skillType <= SKILL_LAST) {
 		lua_pushinteger(L, player->skills[skillType].percent);
 	} else {
@@ -9967,8 +9811,8 @@ int LuaScriptInterface::luaPlayerGetSkillPercent(lua_State* L)
 int LuaScriptInterface::luaPlayerGetSkillTries(lua_State* L)
 {
 	// player:getSkillTries(skillType)
-	skills_t skillType = getNumber<skills_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
+	const auto skillType = getNumber<skills_t>(L, 2);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (player && skillType <= SKILL_LAST) {
 		lua_pushinteger(L, player->skills[skillType].tries);
 	} else {
@@ -9980,10 +9824,9 @@ int LuaScriptInterface::luaPlayerGetSkillTries(lua_State* L)
 int LuaScriptInterface::luaPlayerAddSkillTries(lua_State* L)
 {
 	// player:addSkillTries(skillType, tries)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		skills_t skillType = getNumber<skills_t>(L, 2);
-		uint64_t tries = getNumber<uint64_t>(L, 3);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const auto skillType = getNumber<skills_t>(L, 2);
+		const auto tries = getNumber<uint64_t>(L, 3);
 		player->addSkillAdvance(skillType, tries);
 		pushBoolean(L, true);
 	} else {
@@ -9995,10 +9838,9 @@ int LuaScriptInterface::luaPlayerAddSkillTries(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveSkillTries(lua_State* L)
 {
 	// player:removeSkillTries(skillType, tries[, notify = true])
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		skills_t skillType = getNumber<skills_t>(L, 2);
-		uint64_t tries = getNumber<uint64_t>(L, 3);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const auto skillType = getNumber<skills_t>(L, 2);
+		const uint64_t tries = getNumber<uint64_t>(L, 3);
 		player->removeSkillTries(skillType, tries, getBoolean(L, 4, true));
 		pushBoolean(L, true);
 	} else {
@@ -10010,8 +9852,8 @@ int LuaScriptInterface::luaPlayerRemoveSkillTries(lua_State* L)
 int LuaScriptInterface::luaPlayerGetSpecialSkill(lua_State* L)
 {
 	// player:getSpecialSkill(specialSkillType)
-	SpecialSkills_t specialSkillType = getNumber<SpecialSkills_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
+	const auto specialSkillType = getNumber<SpecialSkills_t>(L, 2);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (player && specialSkillType <= SPECIALSKILL_LAST) {
 		lua_pushinteger(L, player->getSpecialSkill(specialSkillType));
 	} else {
@@ -10023,13 +9865,13 @@ int LuaScriptInterface::luaPlayerGetSpecialSkill(lua_State* L)
 int LuaScriptInterface::luaPlayerAddSpecialSkill(lua_State* L)
 {
 	// player:addSpecialSkill(specialSkillType, value)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	SpecialSkills_t specialSkillType = getNumber<SpecialSkills_t>(L, 2);
+	const auto specialSkillType = getNumber<SpecialSkills_t>(L, 2);
 	if (specialSkillType > SPECIALSKILL_LAST) {
 		lua_pushnil(L);
 		return 1;
@@ -10044,9 +9886,8 @@ int LuaScriptInterface::luaPlayerAddSpecialSkill(lua_State* L)
 int LuaScriptInterface::luaPlayerAddOfflineTrainingTime(lua_State* L)
 {
 	// player:addOfflineTrainingTime(time)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		int32_t time = getNumber<int32_t>(L, 2);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const int32_t time = getNumber<int32_t>(L, 2);
 		player->addOfflineTrainingTime(time);
 		player->sendStats();
 		pushBoolean(L, true);
@@ -10059,8 +9900,7 @@ int LuaScriptInterface::luaPlayerAddOfflineTrainingTime(lua_State* L)
 int LuaScriptInterface::luaPlayerGetOfflineTrainingTime(lua_State* L)
 {
 	// player:getOfflineTrainingTime()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getOfflineTrainingTime());
 	} else {
 		lua_pushnil(L);
@@ -10071,9 +9911,8 @@ int LuaScriptInterface::luaPlayerGetOfflineTrainingTime(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveOfflineTrainingTime(lua_State* L)
 {
 	// player:removeOfflineTrainingTime(time)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		int32_t time = getNumber<int32_t>(L, 2);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const int32_t time = getNumber<int32_t>(L, 2);
 		player->removeOfflineTrainingTime(time);
 		player->sendStats();
 		pushBoolean(L, true);
@@ -10086,10 +9925,9 @@ int LuaScriptInterface::luaPlayerRemoveOfflineTrainingTime(lua_State* L)
 int LuaScriptInterface::luaPlayerAddOfflineTrainingTries(lua_State* L)
 {
 	// player:addOfflineTrainingTries(skillType, tries)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		skills_t skillType = getNumber<skills_t>(L, 2);
-		uint64_t tries = getNumber<uint64_t>(L, 3);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const auto skillType = getNumber<skills_t>(L, 2);
+		const uint64_t tries = getNumber<uint64_t>(L, 3);
 		pushBoolean(L, player->addOfflineTrainingTries(skillType, tries));
 	} else {
 		lua_pushnil(L);
@@ -10100,8 +9938,7 @@ int LuaScriptInterface::luaPlayerAddOfflineTrainingTries(lua_State* L)
 int LuaScriptInterface::luaPlayerGetOfflineTrainingSkill(lua_State* L)
 {
 	// player:getOfflineTrainingSkill()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getOfflineTrainingSkill());
 	} else {
 		lua_pushnil(L);
@@ -10112,9 +9949,8 @@ int LuaScriptInterface::luaPlayerGetOfflineTrainingSkill(lua_State* L)
 int LuaScriptInterface::luaPlayerSetOfflineTrainingSkill(lua_State* L)
 {
 	// player:setOfflineTrainingSkill(skillId)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint32_t skillId = getNumber<uint32_t>(L, 2);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const uint32_t skillId = getNumber<uint32_t>(L, 2);
 		player->setOfflineTrainingSkill(skillId);
 		pushBoolean(L, true);
 	} else {
@@ -10126,7 +9962,7 @@ int LuaScriptInterface::luaPlayerSetOfflineTrainingSkill(lua_State* L)
 int LuaScriptInterface::luaPlayerGetItemCount(lua_State* L)
 {
 	// player:getItemCount(itemId[, subType = -1])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10151,7 +9987,7 @@ int LuaScriptInterface::luaPlayerGetItemCount(lua_State* L)
 int LuaScriptInterface::luaPlayerGetItemById(lua_State* L)
 {
 	// player:getItemById(itemId, deepSearch[, subType = -1])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10167,12 +10003,11 @@ int LuaScriptInterface::luaPlayerGetItemById(lua_State* L)
 			return 1;
 		}
 	}
-	bool deepSearch = getBoolean(L, 3);
-	int32_t subType = getNumber<int32_t>(L, 4, -1);
+	const bool deepSearch = getBoolean(L, 3);
+	const int32_t subType = getNumber<int32_t>(L, 4, -1);
 
-	Item* item = g_game.findItemOfType(player, itemId, deepSearch, subType);
-	if (item) {
-		pushUserdata<Item>(L, item);
+	if (const auto item = g_game.findItemOfType(player, itemId, deepSearch, subType)) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -10183,8 +10018,7 @@ int LuaScriptInterface::luaPlayerGetItemById(lua_State* L)
 int LuaScriptInterface::luaPlayerGetVocation(lua_State* L)
 {
 	// player:getVocation()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		pushUserdata<Vocation>(L, player->getVocation());
 		setMetatable(L, -1, "Vocation");
 	} else {
@@ -10196,7 +10030,7 @@ int LuaScriptInterface::luaPlayerGetVocation(lua_State* L)
 int LuaScriptInterface::luaPlayerSetVocation(lua_State* L)
 {
 	// player:setVocation(id or name or userdata)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10226,8 +10060,7 @@ int LuaScriptInterface::luaPlayerSetVocation(lua_State* L)
 int LuaScriptInterface::luaPlayerGetSex(lua_State* L)
 {
 	// player:getSex()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getSex());
 	} else {
 		lua_pushnil(L);
@@ -10238,9 +10071,8 @@ int LuaScriptInterface::luaPlayerGetSex(lua_State* L)
 int LuaScriptInterface::luaPlayerSetSex(lua_State* L)
 {
 	// player:setSex(newSex)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		PlayerSex_t newSex = getNumber<PlayerSex_t>(L, 2);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const PlayerSex_t newSex = getNumber<PlayerSex_t>(L, 2);
 		player->setSex(newSex);
 		pushBoolean(L, true);
 	} else {
@@ -10252,8 +10084,7 @@ int LuaScriptInterface::luaPlayerSetSex(lua_State* L)
 int LuaScriptInterface::luaPlayerGetTown(lua_State* L)
 {
 	// player:getTown()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		pushUserdata<Town>(L, player->getTown());
 		setMetatable(L, -1, "Town");
 	} else {
@@ -10265,14 +10096,13 @@ int LuaScriptInterface::luaPlayerGetTown(lua_State* L)
 int LuaScriptInterface::luaPlayerSetTown(lua_State* L)
 {
 	// player:setTown(town)
-	Town* town = getUserdata<Town>(L, 2);
+	const auto town = getUserdata<Town>(L, 2);
 	if (!town) {
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->setTown(town);
 		pushBoolean(L, true);
 	} else {
@@ -10284,13 +10114,13 @@ int LuaScriptInterface::luaPlayerSetTown(lua_State* L)
 int LuaScriptInterface::luaPlayerGetGuild(lua_State* L)
 {
 	// player:getGuild()
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Guild* guild = player->getGuild();
+	const auto guild = player->getGuild();
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -10304,7 +10134,7 @@ int LuaScriptInterface::luaPlayerGetGuild(lua_State* L)
 int LuaScriptInterface::luaPlayerSetGuild(lua_State* L)
 {
 	// player:setGuild(guild)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10318,8 +10148,7 @@ int LuaScriptInterface::luaPlayerSetGuild(lua_State* L)
 int LuaScriptInterface::luaPlayerGetGuildLevel(lua_State* L)
 {
 	// player:getGuildLevel()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player && player->getGuild()) {
+	if (const auto player = getSharedPtr<Player>(L, 1); player && player->getGuild()) {
 		lua_pushinteger(L, player->getGuildRank()->level);
 	} else {
 		lua_pushnil(L);
@@ -10330,14 +10159,14 @@ int LuaScriptInterface::luaPlayerGetGuildLevel(lua_State* L)
 int LuaScriptInterface::luaPlayerSetGuildLevel(lua_State* L)
 {
 	// player:setGuildLevel(level)
-	uint8_t level = getNumber<uint8_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
+	const auto level = getNumber<uint8_t>(L, 2);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player || !player->getGuild()) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	GuildRank_ptr rank = player->getGuild()->getRankByLevel(level);
+	const auto rank = player->getGuild()->getRankByLevel(level);
 	if (!rank) {
 		pushBoolean(L, false);
 	} else {
@@ -10351,8 +10180,7 @@ int LuaScriptInterface::luaPlayerSetGuildLevel(lua_State* L)
 int LuaScriptInterface::luaPlayerGetGuildNick(lua_State* L)
 {
 	// player:getGuildNick()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		pushString(L, player->getGuildNick());
 	} else {
 		lua_pushnil(L);
@@ -10364,8 +10192,7 @@ int LuaScriptInterface::luaPlayerSetGuildNick(lua_State* L)
 {
 	// player:setGuildNick(nick)
 	const std::string& nick = getString(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->setGuildNick(nick);
 		pushBoolean(L, true);
 	} else {
@@ -10377,8 +10204,7 @@ int LuaScriptInterface::luaPlayerSetGuildNick(lua_State* L)
 int LuaScriptInterface::luaPlayerGetGroup(lua_State* L)
 {
 	// player:getGroup()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		pushUserdata<Group>(L, player->getGroup());
 		setMetatable(L, -1, "Group");
 	} else {
@@ -10396,8 +10222,7 @@ int LuaScriptInterface::luaPlayerSetGroup(lua_State* L)
 		return 1;
 	}
 
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->setGroup(group);
 		pushBoolean(L, true);
 	} else {
@@ -10409,8 +10234,7 @@ int LuaScriptInterface::luaPlayerSetGroup(lua_State* L)
 int LuaScriptInterface::luaPlayerGetStamina(lua_State* L)
 {
 	// player:getStamina()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getStaminaMinutes());
 	} else {
 		lua_pushnil(L);
@@ -10421,9 +10245,8 @@ int LuaScriptInterface::luaPlayerGetStamina(lua_State* L)
 int LuaScriptInterface::luaPlayerSetStamina(lua_State* L)
 {
 	// player:setStamina(stamina)
-	uint16_t stamina = getNumber<uint16_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	const uint16_t stamina = getNumber<uint16_t>(L, 2);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->staminaMinutes = std::min<uint16_t>(2520, stamina);
 		player->sendStats();
 		pushBoolean(L, true);
@@ -10436,8 +10259,7 @@ int LuaScriptInterface::luaPlayerSetStamina(lua_State* L)
 int LuaScriptInterface::luaPlayerGetSoul(lua_State* L)
 {
 	// player:getSoul()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getSoul());
 	} else {
 		lua_pushnil(L);
@@ -10449,8 +10271,7 @@ int LuaScriptInterface::luaPlayerAddSoul(lua_State* L)
 {
 	// player:addSoul(soulChange)
 	int32_t soulChange = getNumber<int32_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->changeSoul(soulChange);
 		pushBoolean(L, true);
 	} else {
@@ -10462,8 +10283,7 @@ int LuaScriptInterface::luaPlayerAddSoul(lua_State* L)
 int LuaScriptInterface::luaPlayerGetMaxSoul(lua_State* L)
 {
 	// player:getMaxSoul()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player && player->vocation) {
+	if (const auto player = getSharedPtr<Player>(L, 1); player && player->vocation) {
 		lua_pushinteger(L, player->vocation->getSoulMax());
 	} else {
 		lua_pushnil(L);
@@ -10474,8 +10294,7 @@ int LuaScriptInterface::luaPlayerGetMaxSoul(lua_State* L)
 int LuaScriptInterface::luaPlayerGetBankBalance(lua_State* L)
 {
 	// player:getBankBalance()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getBankBalance());
 	} else {
 		lua_pushnil(L);
@@ -10486,7 +10305,7 @@ int LuaScriptInterface::luaPlayerGetBankBalance(lua_State* L)
 int LuaScriptInterface::luaPlayerSetBankBalance(lua_State* L)
 {
 	// player:setBankBalance(bankBalance)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10507,15 +10326,14 @@ int LuaScriptInterface::luaPlayerSetBankBalance(lua_State* L)
 int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 {
 	// player:getStorageValue(key)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint32_t key = getNumber<uint32_t>(L, 2);
-	int32_t value;
-	if (player->getStorageValue(key, value)) {
+	const uint32_t key = getNumber<uint32_t>(L, 2);
+	if (int32_t value; player->getStorageValue(key, value)) {
 		lua_pushinteger(L, value);
 	} else {
 		lua_pushinteger(L, -1);
@@ -10526,9 +10344,9 @@ int LuaScriptInterface::luaPlayerGetStorageValue(lua_State* L)
 int LuaScriptInterface::luaPlayerSetStorageValue(lua_State* L)
 {
 	// player:setStorageValue(key, value)
-	int32_t value = getNumber<int32_t>(L, 3);
-	uint32_t key = getNumber<uint32_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
+	const int32_t value = getNumber<int32_t>(L, 3);
+	const uint32_t key = getNumber<uint32_t>(L, 2);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (IS_IN_KEYRANGE(key, RESERVED_RANGE)) {
 		reportErrorFunc(L, fmt::format("Accessing reserved range: {:d}", key));
 		pushBoolean(L, false);
@@ -10547,7 +10365,7 @@ int LuaScriptInterface::luaPlayerSetStorageValue(lua_State* L)
 int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 {
 	// player:addItem(itemId[, count = 1[, canDropOnMap = true[, subType = 1[, slot = CONST_SLOT_WHEREEVER]]]])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		pushBoolean(L, false);
 		return 1;
@@ -10564,7 +10382,7 @@ int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 		}
 	}
 
-	int32_t count = getNumber<int32_t>(L, 3, 1);
+	const int32_t count = getNumber<int32_t>(L, 3, 1);
 	int32_t subType = getNumber<int32_t>(L, 5, 1);
 
 	const ItemType& it = Item::items[itemId];
@@ -10583,7 +10401,7 @@ int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 		itemCount = std::max<int32_t>(1, count);
 	}
 
-	bool hasTable = itemCount > 1;
+	const bool hasTable = itemCount > 1;
 	if (hasTable) {
 		lua_newtable(L);
 	} else if (itemCount == 0) {
@@ -10592,7 +10410,7 @@ int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 	}
 
 	bool canDropOnMap = getBoolean(L, 4, true);
-	slots_t slot = getNumber<slots_t>(L, 6, CONST_SLOT_WHEREEVER);
+	const auto slot = getNumber<slots_t>(L, 6, CONST_SLOT_WHEREEVER);
 	for (int32_t i = 1; i <= itemCount; ++i) {
 		int32_t stackCount = subType;
 		if (it.stackable) {
@@ -10600,7 +10418,7 @@ int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 			subType -= stackCount;
 		}
 
-		Item* item = Item::CreateItem(itemId, stackCount);
+		auto item = Item::CreateItem(itemId, stackCount);
 		if (!item) {
 			if (!hasTable) {
 				lua_pushnil(L);
@@ -10610,7 +10428,7 @@ int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 
 		ReturnValue ret = g_game.internalPlayerAddItem(player, item, canDropOnMap, slot);
 		if (ret != RETURNVALUE_NOERROR) {
-			delete item;
+			item.reset();
 			if (!hasTable) {
 				lua_pushnil(L);
 			}
@@ -10619,11 +10437,11 @@ int LuaScriptInterface::luaPlayerAddItem(lua_State* L)
 
 		if (hasTable) {
 			lua_pushinteger(L, i);
-			pushUserdata<Item>(L, item);
+			pushSharedPtr(L, item);
 			setItemMetatable(L, -1, item);
 			lua_settable(L, -3);
 		} else {
-			pushUserdata<Item>(L, item);
+			pushSharedPtr(L, item);
 			setItemMetatable(L, -1, item);
 		}
 	}
@@ -10634,14 +10452,14 @@ int LuaScriptInterface::luaPlayerAddItemEx(lua_State* L)
 {
 	// player:addItemEx(item[, canDropOnMap = false[, index = INDEX_WHEREEVER[, flags = 0]]])
 	// player:addItemEx(item[, canDropOnMap = true[, slot = CONST_SLOT_WHEREEVER]])
-	Item* item = getUserdata<Item>(L, 2);
+	const auto item = getSharedPtr<Item>(L, 2);
 	if (!item) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_ITEM_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10656,12 +10474,13 @@ int LuaScriptInterface::luaPlayerAddItemEx(lua_State* L)
 	bool canDropOnMap = getBoolean(L, 3, false);
 	ReturnValue returnValue;
 	if (canDropOnMap) {
-		slots_t slot = getNumber<slots_t>(L, 4, CONST_SLOT_WHEREEVER);
+		const auto slot = getNumber<slots_t>(L, 4, CONST_SLOT_WHEREEVER);
 		returnValue = g_game.internalPlayerAddItem(player, item, true, slot);
 	} else {
 		int32_t index = getNumber<int32_t>(L, 4, INDEX_WHEREEVER);
 		uint32_t flags = getNumber<uint32_t>(L, 5, 0);
-		returnValue = g_game.internalAddItem(player, item, index, flags);
+		CylinderPtr holder = player;
+		returnValue = g_game.internalAddItem(holder, item, index, flags);
 	}
 
 	if (returnValue == RETURNVALUE_NOERROR) {
@@ -10674,7 +10493,7 @@ int LuaScriptInterface::luaPlayerAddItemEx(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveItem(lua_State* L)
 {
 	// player:removeItem(itemId, count[, subType = -1[, ignoreEquipped = false]])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10691,9 +10510,9 @@ int LuaScriptInterface::luaPlayerRemoveItem(lua_State* L)
 		}
 	}
 
-	uint32_t count = getNumber<uint32_t>(L, 3);
-	int32_t subType = getNumber<int32_t>(L, 4, -1);
-	bool ignoreEquipped = getBoolean(L, 5, false);
+	const uint32_t count = getNumber<uint32_t>(L, 3);
+	const int32_t subType = getNumber<int32_t>(L, 4, -1);
+	const bool ignoreEquipped = getBoolean(L, 5, false);
 	pushBoolean(L, player->removeItemOfType(itemId, count, subType, ignoreEquipped));
 	return 1;
 }
@@ -10701,8 +10520,7 @@ int LuaScriptInterface::luaPlayerRemoveItem(lua_State* L)
 int LuaScriptInterface::luaPlayerGetMoney(lua_State* L)
 {
 	// player:getMoney()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getMoney());
 	} else {
 		lua_pushnil(L);
@@ -10714,9 +10532,9 @@ int LuaScriptInterface::luaPlayerAddMoney(lua_State* L)
 {
 	// player:addMoney(money)
 	uint64_t money = getNumber<uint64_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		g_game.addMoney(player, money);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		CylinderPtr holder = player;
+		g_game.addMoney(holder, money);
 		pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);
@@ -10727,10 +10545,10 @@ int LuaScriptInterface::luaPlayerAddMoney(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveMoney(lua_State* L)
 {
 	// player:removeMoney(money)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint64_t money = getNumber<uint64_t>(L, 2);
-		pushBoolean(L, g_game.removeMoney(player, money));
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const uint64_t money = getNumber<uint64_t>(L, 2);
+		CylinderPtr holder = player;
+		pushBoolean(L, g_game.removeMoney(holder, money));
 	} else {
 		lua_pushnil(L);
 	}
@@ -10740,7 +10558,7 @@ int LuaScriptInterface::luaPlayerRemoveMoney(lua_State* L)
 int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 {
 	// player:showTextDialog(id or name or userdata[, text[, canWrite[, length]]])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10755,7 +10573,7 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 		text = getString(L, 3);
 	}
 
-	Item* item;
+	ItemPtr item;
 	if (isNumber(L, 2)) {
 		item = Item::CreateItem(getNumber<uint16_t>(L, 2));
 	} else if (isString(L, 2)) {
@@ -10766,7 +10584,7 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 			return 1;
 		}
 
-		item = getUserdata<Item>(L, 2);
+		item = getSharedPtr<Item>(L, 2);
 	} else {
 		item = nullptr;
 	}
@@ -10785,7 +10603,6 @@ int LuaScriptInterface::luaPlayerShowTextDialog(lua_State* L)
 		item->setText(text);
 		length = std::max<int32_t>(text.size(), length);
 	}
-
 	item->setParent(player);
 	player->windowTextId++;
 	player->writeItem = item;
@@ -10800,7 +10617,7 @@ int LuaScriptInterface::luaPlayerSendTextMessage(lua_State* L)
 	// player:sendTextMessage(type, text[, position, primaryValue = 0, primaryColor = TEXTCOLOR_NONE[, secondaryValue = 0, secondaryColor = TEXTCOLOR_NONE]])
 	// player:sendTextMessage(type, text, channelId)
 
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -10810,9 +10627,9 @@ int LuaScriptInterface::luaPlayerSendTextMessage(lua_State* L)
 
 	TextMessage message(getNumber<MessageClasses>(L, 2), getString(L, 3));
 	if (parameters == 4) {
-		uint16_t channelId = getNumber<uint16_t>(L, 4);
-		ChatChannel* channel = g_chat->getChannel(*player, channelId);
-		if (!channel || !channel->hasUser(*player)) {
+		const uint16_t channelId = getNumber<uint16_t>(L, 4);
+		const auto channel = g_chat->getChannel(player, channelId);
+		if (!channel || !channel->hasUser(player)) {
 			pushBoolean(L, false);
 			return 1;
 		}
@@ -10839,14 +10656,14 @@ int LuaScriptInterface::luaPlayerSendTextMessage(lua_State* L)
 int LuaScriptInterface::luaPlayerSendChannelMessage(lua_State* L)
 {
 	// player:sendChannelMessage(author, text, type, channelId)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint16_t channelId = getNumber<uint16_t>(L, 5);
-	SpeakClasses type = getNumber<SpeakClasses>(L, 4);
+	const uint16_t channelId = getNumber<uint16_t>(L, 5);
+	const auto type = getNumber<SpeakClasses>(L, 4);
 	const std::string& text = getString(L, 3);
 	const std::string& author = getString(L, 2);
 	player->sendChannelMessage(author, text, type, channelId);
@@ -10857,15 +10674,15 @@ int LuaScriptInterface::luaPlayerSendChannelMessage(lua_State* L)
 int LuaScriptInterface::luaPlayerSendPrivateMessage(lua_State* L)
 {
 	// player:sendPrivateMessage(speaker, text[, type])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	const Player* speaker = getUserdata<const Player>(L, 2);
+	const auto speaker = getSharedPtr<const Player>(L, 2);
 	const std::string& text = getString(L, 3);
-	SpeakClasses type = getNumber<SpeakClasses>(L, 4, TALKTYPE_PRIVATE_FROM);
+	const auto type = getNumber<SpeakClasses>(L, 4, TALKTYPE_PRIVATE_FROM);
 	player->sendPrivateMessage(speaker, type, text);
 	pushBoolean(L, true);
 	return 1;
@@ -10874,16 +10691,16 @@ int LuaScriptInterface::luaPlayerSendPrivateMessage(lua_State* L)
 int LuaScriptInterface::luaPlayerChannelSay(lua_State* L)
 {
 	// player:channelSay(speaker, type, text, channelId)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* speaker = getCreature(L, 2);
-	SpeakClasses type = getNumber<SpeakClasses>(L, 3);
+	const auto speaker = getCreature(L, 2);
+	const auto type = getNumber<SpeakClasses>(L, 3);
 	const std::string& text = getString(L, 4);
-	uint16_t channelId = getNumber<uint16_t>(L, 5);
+	const uint16_t channelId = getNumber<uint16_t>(L, 5);
 	player->sendToChannel(speaker, type, text, channelId);
 	pushBoolean(L, true);
 	return 1;
@@ -10893,8 +10710,7 @@ int LuaScriptInterface::luaPlayerOpenChannel(lua_State* L)
 {
 	// player:openChannel(channelId)
 	uint16_t channelId = getNumber<uint16_t>(L, 2);
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		g_game.playerOpenChannel(player->getID(), channelId);
 		pushBoolean(L, true);
 	} else {
@@ -10906,22 +10722,21 @@ int LuaScriptInterface::luaPlayerOpenChannel(lua_State* L)
 int LuaScriptInterface::luaPlayerGetSlotItem(lua_State* L)
 {
 	// player:getSlotItem(slot)
-	const Player* player = getUserdata<const Player>(L, 1);
+	auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint32_t slot = getNumber<uint32_t>(L, 2);
-	Thing* thing = player->getThing(slot);
+	const uint32_t slot = getNumber<uint32_t>(L, 2);
+	auto thing = player->getThing(slot);
 	if (!thing) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Item* item = thing->getItem();
-	if (item) {
-		pushUserdata<Item>(L, item);
+	if (const auto item = thing->getItem()) {
+		pushSharedPtr(L, item);
 		setItemMetatable(L, -1, item);
 	} else {
 		lua_pushnil(L);
@@ -10932,14 +10747,13 @@ int LuaScriptInterface::luaPlayerGetSlotItem(lua_State* L)
 int LuaScriptInterface::luaPlayerGetParty(lua_State* L)
 {
 	// player:getParty()
-	const Player* player = getUserdata<const Player>(L, 1);
+	const auto player = getSharedPtr<const Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Party* party = player->getParty();
-	if (party) {
+	if (const auto party = player->getParty()) {
 		pushUserdata<Party>(L, party);
 		setMetatable(L, -1, "Party");
 	} else {
@@ -10951,8 +10765,7 @@ int LuaScriptInterface::luaPlayerGetParty(lua_State* L)
 int LuaScriptInterface::luaPlayerAddOutfit(lua_State* L)
 {
 	// player:addOutfit(lookType)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->addOutfit(getNumber<uint16_t>(L, 2), 0);
 		pushBoolean(L, true);
 	} else {
@@ -10964,10 +10777,9 @@ int LuaScriptInterface::luaPlayerAddOutfit(lua_State* L)
 int LuaScriptInterface::luaPlayerAddOutfitAddon(lua_State* L)
 {
 	// player:addOutfitAddon(lookType, addon)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint16_t lookType = getNumber<uint16_t>(L, 2);
-		uint8_t addon = getNumber<uint8_t>(L, 3);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const uint16_t lookType = getNumber<uint16_t>(L, 2);
+		const uint8_t addon = getNumber<uint8_t>(L, 3);
 		player->addOutfit(lookType, addon);
 		pushBoolean(L, true);
 	} else {
@@ -10979,9 +10791,8 @@ int LuaScriptInterface::luaPlayerAddOutfitAddon(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveOutfit(lua_State* L)
 {
 	// player:removeOutfit(lookType)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint16_t lookType = getNumber<uint16_t>(L, 2);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const uint16_t lookType = getNumber<uint16_t>(L, 2);
 		pushBoolean(L, player->removeOutfit(lookType));
 	} else {
 		lua_pushnil(L);
@@ -10992,10 +10803,9 @@ int LuaScriptInterface::luaPlayerRemoveOutfit(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveOutfitAddon(lua_State* L)
 {
 	// player:removeOutfitAddon(lookType, addon)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint16_t lookType = getNumber<uint16_t>(L, 2);
-		uint8_t addon = getNumber<uint8_t>(L, 3);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const uint16_t lookType = getNumber<uint16_t>(L, 2);
+		const uint8_t addon = getNumber<uint8_t>(L, 3);
 		pushBoolean(L, player->removeOutfitAddon(lookType, addon));
 	} else {
 		lua_pushnil(L);
@@ -11006,10 +10816,9 @@ int LuaScriptInterface::luaPlayerRemoveOutfitAddon(lua_State* L)
 int LuaScriptInterface::luaPlayerHasOutfit(lua_State* L)
 {
 	// player:hasOutfit(lookType[, addon = 0])
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint16_t lookType = getNumber<uint16_t>(L, 2);
-		uint8_t addon = getNumber<uint8_t>(L, 3, 0);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const uint16_t lookType = getNumber<uint16_t>(L, 2);
+		const uint8_t addon = getNumber<uint8_t>(L, 3, 0);
 		pushBoolean(L, player->hasOutfit(lookType, addon));
 	} else {
 		lua_pushnil(L);
@@ -11020,10 +10829,9 @@ int LuaScriptInterface::luaPlayerHasOutfit(lua_State* L)
 int LuaScriptInterface::luaPlayerCanWearOutfit(lua_State* L)
 {
 	// player:canWearOutfit(lookType[, addon = 0])
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint16_t lookType = getNumber<uint16_t>(L, 2);
-		uint8_t addon = getNumber<uint8_t>(L, 3, 0);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const uint16_t lookType = getNumber<uint16_t>(L, 2);
+		const uint8_t addon = getNumber<uint8_t>(L, 3, 0);
 		pushBoolean(L, player->canWear(lookType, addon));
 	} else {
 		lua_pushnil(L);
@@ -11034,8 +10842,7 @@ int LuaScriptInterface::luaPlayerCanWearOutfit(lua_State* L)
 int LuaScriptInterface::luaPlayerSendOutfitWindow(lua_State* L)
 {
 	// player:sendOutfitWindow()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->sendOutfitWindow();
 		pushBoolean(L, true);
 	} else {
@@ -11046,7 +10853,7 @@ int LuaScriptInterface::luaPlayerSendOutfitWindow(lua_State* L)
 
 int LuaScriptInterface::luaPlayerAddMount(lua_State* L) {
 	// player:addMount(mountId or mountName)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -11056,7 +10863,7 @@ int LuaScriptInterface::luaPlayerAddMount(lua_State* L) {
 	if (isNumber(L, 2)) {
 		mountId = getNumber<uint8_t>(L, 2);
 	} else {
-		Mount* mount = g_game.mounts.getMountByName(getString(L, 2));
+		const auto mount = g_game.mounts.getMountByName(getString(L, 2));
 		if (!mount) {
 			lua_pushnil(L);
 			return 1;
@@ -11069,7 +10876,7 @@ int LuaScriptInterface::luaPlayerAddMount(lua_State* L) {
 
 int LuaScriptInterface::luaPlayerRemoveMount(lua_State* L) {
 	// player:removeMount(mountId or mountName)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -11079,7 +10886,7 @@ int LuaScriptInterface::luaPlayerRemoveMount(lua_State* L) {
 	if (isNumber(L, 2)) {
 		mountId = getNumber<uint8_t>(L, 2);
 	} else {
-		Mount* mount = g_game.mounts.getMountByName(getString(L, 2));
+		const auto mount = g_game.mounts.getMountByName(getString(L, 2));
 		if (!mount) {
 			lua_pushnil(L);
 			return 1;
@@ -11092,7 +10899,7 @@ int LuaScriptInterface::luaPlayerRemoveMount(lua_State* L) {
 
 int LuaScriptInterface::luaPlayerHasMount(lua_State* L) {
 	// player:hasMount(mountId or mountName)
-	const Player* player = getUserdata<const Player>(L, 1);
+	const auto player = getSharedPtr<const Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -11116,8 +10923,7 @@ int LuaScriptInterface::luaPlayerHasMount(lua_State* L) {
 int LuaScriptInterface::luaPlayerGetPremiumEndsAt(lua_State* L)
 {
 	// player:getPremiumEndsAt()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->premiumEndsAt);
 	} else {
 		lua_pushnil(L);
@@ -11128,13 +10934,13 @@ int LuaScriptInterface::luaPlayerGetPremiumEndsAt(lua_State* L)
 int LuaScriptInterface::luaPlayerSetPremiumEndsAt(lua_State* L)
 {
 	// player:setPremiumEndsAt(timestamp)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	time_t timestamp = getNumber<time_t>(L, 2);
+	const time_t timestamp = getNumber<time_t>(L, 2);
 
 	player->setPremiumTime(timestamp);
 	IOLoginData::updatePremiumTime(player->getAccount(), timestamp);
@@ -11145,9 +10951,8 @@ int LuaScriptInterface::luaPlayerSetPremiumEndsAt(lua_State* L)
 int LuaScriptInterface::luaPlayerHasBlessing(lua_State* L)
 {
 	// player:hasBlessing(blessing)
-	uint8_t blessing = getNumber<uint8_t>(L, 2) - 1;
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	const uint8_t blessing = getNumber<uint8_t>(L, 2) - 1;
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		pushBoolean(L, player->hasBlessing(blessing));
 	} else {
 		lua_pushnil(L);
@@ -11158,13 +10963,13 @@ int LuaScriptInterface::luaPlayerHasBlessing(lua_State* L)
 int LuaScriptInterface::luaPlayerAddBlessing(lua_State* L)
 {
 	// player:addBlessing(blessing)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint8_t blessing = getNumber<uint8_t>(L, 2) - 1;
+	const auto blessing = getNumber<uint8_t>(L, 2) - 1;
 	if (player->hasBlessing(blessing)) {
 		pushBoolean(L, false);
 		return 1;
@@ -11178,13 +10983,13 @@ int LuaScriptInterface::luaPlayerAddBlessing(lua_State* L)
 int LuaScriptInterface::luaPlayerRemoveBlessing(lua_State* L)
 {
 	// player:removeBlessing(blessing)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint8_t blessing = getNumber<uint8_t>(L, 2) - 1;
+	const auto blessing = getNumber<uint8_t>(L, 2) - 1;
 	if (!player->hasBlessing(blessing)) {
 		pushBoolean(L, false);
 		return 1;
@@ -11198,14 +11003,14 @@ int LuaScriptInterface::luaPlayerRemoveBlessing(lua_State* L)
 int LuaScriptInterface::luaPlayerCanLearnSpell(lua_State* L)
 {
 	// player:canLearnSpell(spellName)
-	const Player* player = getUserdata<const Player>(L, 1);
+	const auto player = getSharedPtr<const Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	const std::string& spellName = getString(L, 2);
-	InstantSpell* spell = g_spells->getInstantSpellByName(spellName);
+	const auto spell = g_spells->getInstantSpellByName(spellName);
 	if (!spell) {
 		reportErrorFunc(L, "Spell \"" + spellName + "\" not found");
 		pushBoolean(L, false);
@@ -11218,7 +11023,7 @@ int LuaScriptInterface::luaPlayerCanLearnSpell(lua_State* L)
 	}
 
 	const auto& vocMap = spell->getVocMap();
-	if (vocMap.count(player->getVocationId()) == 0) {
+	if (!vocMap.contains(player->getVocationId())) {
 		pushBoolean(L, false);
 	} else if (player->getLevel() < spell->getLevel()) {
 		pushBoolean(L, false);
@@ -11233,8 +11038,7 @@ int LuaScriptInterface::luaPlayerCanLearnSpell(lua_State* L)
 int LuaScriptInterface::luaPlayerLearnSpell(lua_State* L)
 {
 	// player:learnSpell(spellName)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		const std::string& spellName = getString(L, 2);
 		player->learnInstantSpell(spellName);
 		pushBoolean(L, true);
@@ -11247,8 +11051,7 @@ int LuaScriptInterface::luaPlayerLearnSpell(lua_State* L)
 int LuaScriptInterface::luaPlayerForgetSpell(lua_State* L)
 {
 	// player:forgetSpell(spellName)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		const std::string& spellName = getString(L, 2);
 		player->forgetInstantSpell(spellName);
 		pushBoolean(L, true);
@@ -11261,8 +11064,7 @@ int LuaScriptInterface::luaPlayerForgetSpell(lua_State* L)
 int LuaScriptInterface::luaPlayerHasLearnedSpell(lua_State* L)
 {
 	// player:hasLearnedSpell(spellName)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		const std::string& spellName = getString(L, 2);
 		pushBoolean(L, player->hasLearnedInstantSpell(spellName));
 	} else {
@@ -11274,9 +11076,8 @@ int LuaScriptInterface::luaPlayerHasLearnedSpell(lua_State* L)
 int LuaScriptInterface::luaPlayerSendTutorial(lua_State* L)
 {
 	// player:sendTutorial(tutorialId)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		uint8_t tutorialId = getNumber<uint8_t>(L, 2);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const auto tutorialId = getNumber<uint8_t>(L, 2);
 		player->sendTutorial(tutorialId);
 		pushBoolean(L, true);
 	} else {
@@ -11288,11 +11089,10 @@ int LuaScriptInterface::luaPlayerSendTutorial(lua_State* L)
 int LuaScriptInterface::luaPlayerAddMapMark(lua_State* L)
 {
 	// player:addMapMark(position, type, description)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		const Position& position = getPosition(L, 2);
-		uint8_t type = getNumber<uint8_t>(L, 3);
-		const std::string& description = getString(L, 4);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const auto& position = getPosition(L, 2);
+		const auto type = getNumber<uint8_t>(L, 3);
+		const auto& description = getString(L, 4);
 		player->sendAddMarker(position, type, description);
 		pushBoolean(L, true);
 	} else {
@@ -11304,8 +11104,7 @@ int LuaScriptInterface::luaPlayerAddMapMark(lua_State* L)
 int LuaScriptInterface::luaPlayerSave(lua_State* L)
 {
 	// player:save()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		player->loginPosition = player->getPosition();
 		pushBoolean(L, IOLoginData::savePlayer(player));
 	} else {
@@ -11317,9 +11116,8 @@ int LuaScriptInterface::luaPlayerSave(lua_State* L)
 int LuaScriptInterface::luaPlayerPopupFYI(lua_State* L)
 {
 	// player:popupFYI(message)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
-		const std::string& message = getString(L, 2);
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
+		const auto& message = getString(L, 2);
 		player->sendFYIBox(message);
 		pushBoolean(L, true);
 	} else {
@@ -11331,8 +11129,7 @@ int LuaScriptInterface::luaPlayerPopupFYI(lua_State* L)
 int LuaScriptInterface::luaPlayerIsPzLocked(lua_State* L)
 {
 	// player:isPzLocked()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		pushBoolean(L, player->isPzLocked());
 	} else {
 		lua_pushnil(L);
@@ -11343,8 +11140,7 @@ int LuaScriptInterface::luaPlayerIsPzLocked(lua_State* L)
 int LuaScriptInterface::luaPlayerGetClient(lua_State* L)
 {
 	// player:getClient()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_createtable(L, 0, 2);
 		setField(L, "version", player->getProtocolVersion());
 		setField(L, "os", player->getOperatingSystem());
@@ -11357,14 +11153,13 @@ int LuaScriptInterface::luaPlayerGetClient(lua_State* L)
 int LuaScriptInterface::luaPlayerGetHouse(lua_State* L)
 {
 	// player:getHouse()
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	House* house = g_game.map.houses.getHouseByPlayerId(player->getGUID());
-	if (house) {
+	if (const auto house = g_game.map.houses.getHouseByPlayerId(player->getGUID())) {
 		pushUserdata<House>(L, house);
 		setMetatable(L, -1, "House");
 	} else {
@@ -11376,19 +11171,19 @@ int LuaScriptInterface::luaPlayerGetHouse(lua_State* L)
 int LuaScriptInterface::luaPlayerSendHouseWindow(lua_State* L)
 {
 	// player:sendHouseWindow(house, listId)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	House* house = getUserdata<House>(L, 2);
+	const auto house = getUserdata<House>(L, 2);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint32_t listId = getNumber<uint32_t>(L, 3);
+	const auto listId = getNumber<uint32_t>(L, 3);
 	player->sendHouseWindow(house, listId);
 	pushBoolean(L, true);
 	return 1;
@@ -11397,19 +11192,19 @@ int LuaScriptInterface::luaPlayerSendHouseWindow(lua_State* L)
 int LuaScriptInterface::luaPlayerSetEditHouse(lua_State* L)
 {
 	// player:setEditHouse(house, listId)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	House* house = getUserdata<House>(L, 2);
+	const auto house = getUserdata<House>(L, 2);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint32_t listId = getNumber<uint32_t>(L, 3);
+	const auto listId = getNumber<uint32_t>(L, 3);
 	player->setEditHouse(house, listId);
 	pushBoolean(L, true);
 	return 1;
@@ -11418,32 +11213,32 @@ int LuaScriptInterface::luaPlayerSetEditHouse(lua_State* L)
 int LuaScriptInterface::luaPlayerSetGhostMode(lua_State* L)
 {
 	// player:setGhostMode(enabled[, magicEffect = CONST_ME_TELEPORT])
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	bool enabled = getBoolean(L, 2);
+	const bool enabled = getBoolean(L, 2);
 	if (player->isInGhostMode() == enabled) {
 		pushBoolean(L, true);
 		return 1;
 	}
 
-	MagicEffectClasses magicEffect = getNumber<MagicEffectClasses>(L, 3, CONST_ME_TELEPORT);
+	const auto magicEffect = getNumber<MagicEffectClasses>(L, 3, CONST_ME_TELEPORT);
 
 	player->switchGhostMode();
 
-	Tile* tile = player->getTile();
+	const auto tile = player->getTile();
 	const Position& position = player->getPosition();
 	const bool isInvisible = player->isInvisible();
 
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, position, true, true);
-	for (Creature* spectator : spectators) {
-		assert(dynamic_cast<Player*>(spectator) != nullptr);
+	for (auto spectator : spectators) {
+		assert(std::dynamic_pointer_cast<Player>(spectator) != nullptr);
 
-		Player* spectatorPlayer = static_cast<Player*>(spectator);
+		PlayerPtr spectatorPlayer = std::static_pointer_cast<Player>(spectator);
 		if (spectatorPlayer != player && !spectatorPlayer->isAccessPlayer()) {
 			if (enabled) {
 				spectatorPlayer->sendRemoveTileCreature(player, position, tile->getClientIndexOfCreature(spectatorPlayer, player));
@@ -11460,16 +11255,16 @@ int LuaScriptInterface::luaPlayerSetGhostMode(lua_State* L)
 	}
 
 	if (player->isInGhostMode()) {
-		for (const auto& it : g_game.getPlayers()) {
-			if (!it.second->isAccessPlayer()) {
-				it.second->notifyStatusChange(player, VIPSTATUS_OFFLINE);
+		for (const auto& val : g_game.getPlayers() | std::views::values) {
+			if (!val->isAccessPlayer()) {
+				val->notifyStatusChange(player, VIPSTATUS_OFFLINE);
 			}
 		}
 		IOLoginData::updateOnlineStatus(player->getGUID(), false);
 	} else {
-		for (const auto& it : g_game.getPlayers()) {
-			if (!it.second->isAccessPlayer()) {
-				it.second->notifyStatusChange(player, VIPSTATUS_ONLINE);
+		for (const auto& val : g_game.getPlayers() | std::views::values) {
+			if (!val->isAccessPlayer()) {
+				val->notifyStatusChange(player, VIPSTATUS_ONLINE);
 			}
 		}
 		IOLoginData::updateOnlineStatus(player->getGUID(), true);
@@ -11481,14 +11276,13 @@ int LuaScriptInterface::luaPlayerSetGhostMode(lua_State* L)
 int LuaScriptInterface::luaPlayerGetContainerId(lua_State* L)
 {
 	// player:getContainerId(container)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Container* container = getUserdata<Container>(L, 2);
-	if (container) {
+	if (const auto container = getSharedPtr<Container>(L, 2)) {
 		lua_pushinteger(L, player->getContainerID(container));
 	} else {
 		lua_pushnil(L);
@@ -11499,15 +11293,14 @@ int LuaScriptInterface::luaPlayerGetContainerId(lua_State* L)
 int LuaScriptInterface::luaPlayerGetContainerById(lua_State* L)
 {
 	// player:getContainerById(id)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Container* container = player->getContainerByID(getNumber<uint8_t>(L, 2));
-	if (container) {
-		pushUserdata<Container>(L, container);
+	if (const auto container = player->getContainerByID(getNumber<uint8_t>(L, 2))) {
+		pushSharedPtr(L, container);
 		setMetatable(L, -1, "Container");
 	} else {
 		lua_pushnil(L);
@@ -11518,8 +11311,7 @@ int LuaScriptInterface::luaPlayerGetContainerById(lua_State* L)
 int LuaScriptInterface::luaPlayerGetContainerIndex(lua_State* L)
 {
 	// player:getContainerIndex(id)
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->getContainerIndex(getNumber<uint8_t>(L, 2)));
 	} else {
 		lua_pushnil(L);
@@ -11530,23 +11322,23 @@ int LuaScriptInterface::luaPlayerGetContainerIndex(lua_State* L)
 int LuaScriptInterface::luaPlayerGetInstantSpells(lua_State* L)
 {
 	// player:getInstantSpells()
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	std::vector<const InstantSpell*> spells;
-	for (auto& spell : g_spells->getInstantSpells()) {
-		if (spell.second.canCast(player)) {
-			spells.push_back(&spell.second);
+	for (const auto& val : g_spells->getInstantSpells() | std::views::values) {
+		if (val.canCast(player)) {
+			spells.push_back(&val);
 		}
 	}
 
 	lua_createtable(L, spells.size(), 0);
 
 	int index = 0;
-	for (auto spell : spells) {
+	for (const auto spell : spells) {
 		pushInstantSpell(L, *spell);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -11556,8 +11348,8 @@ int LuaScriptInterface::luaPlayerGetInstantSpells(lua_State* L)
 int LuaScriptInterface::luaPlayerCanCast(lua_State* L)
 {
 	// player:canCast(spell)
-	Player* player = getUserdata<Player>(L, 1);
-	InstantSpell* spell = getUserdata<InstantSpell>(L, 2);
+	const auto player = getSharedPtr<Player>(L, 1);
+	const auto spell = getUserdata<InstantSpell>(L, 2);
 	if (player && spell) {
 		pushBoolean(L, spell->canCast(player));
 	} else {
@@ -11569,8 +11361,7 @@ int LuaScriptInterface::luaPlayerCanCast(lua_State* L)
 int LuaScriptInterface::luaPlayerHasChaseMode(lua_State* L)
 {
 	// player:hasChaseMode()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		pushBoolean(L, player->chaseMode);
 	} else {
 		lua_pushnil(L);
@@ -11581,8 +11372,7 @@ int LuaScriptInterface::luaPlayerHasChaseMode(lua_State* L)
 int LuaScriptInterface::luaPlayerHasSecureMode(lua_State* L)
 {
 	// player:hasSecureMode()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		pushBoolean(L, player->secureMode);
 	} else {
 		lua_pushnil(L);
@@ -11593,8 +11383,7 @@ int LuaScriptInterface::luaPlayerHasSecureMode(lua_State* L)
 int LuaScriptInterface::luaPlayerGetFightMode(lua_State* L)
 {
 	// player:getFightMode()
-	Player* player = getUserdata<Player>(L, 1);
-	if (player) {
+	if (const auto player = getSharedPtr<Player>(L, 1)) {
 		lua_pushinteger(L, player->fightMode);
 	} else {
 		lua_pushnil(L);
@@ -11605,19 +11394,19 @@ int LuaScriptInterface::luaPlayerGetFightMode(lua_State* L)
 int LuaScriptInterface::luaPlayerGetStoreInbox(lua_State* L)
 {
 	// player:getStoreInbox()
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Container* storeInbox = player->getStoreInbox();
+	const auto storeInbox = player->getStoreInbox();
 	if (!storeInbox) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	pushUserdata<Container>(L, storeInbox);
+	pushSharedPtr(L, storeInbox);
 	setMetatable(L, -1, "Container");
 	return 1;
 }
@@ -11625,7 +11414,7 @@ int LuaScriptInterface::luaPlayerGetStoreInbox(lua_State* L)
 int LuaScriptInterface::luaPlayerIsNearDepotBox(lua_State* L)
 {
 	// player:isNearDepotBox()
-	const Player* const player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<const Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -11636,7 +11425,7 @@ int LuaScriptInterface::luaPlayerIsNearDepotBox(lua_State* L)
 int LuaScriptInterface::luaPlayerGetIdleTime(lua_State* L)
 {
 	// player:getIdleTime()
-	const Player* const player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<const Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -11648,7 +11437,7 @@ int LuaScriptInterface::luaPlayerGetIdleTime(lua_State* L)
 int LuaScriptInterface::luaPlayerResetIdleTime(lua_State* L)
 {
 	// player:resetIdleTime()
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -11662,12 +11451,12 @@ int LuaScriptInterface::luaPlayerResetIdleTime(lua_State* L)
 int LuaScriptInterface::luaPlayerSendCreatureSquare(lua_State* L)
 {
 	// player:sendCreatureSquare(creature, color)
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
-	auto creature = getCreature(L, 2);
+	const auto creature = getCreature(L, 2);
 	if (!creature) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -11680,7 +11469,7 @@ int LuaScriptInterface::luaPlayerSendCreatureSquare(lua_State* L)
 
 int LuaScriptInterface::luaPlayerAddAugment(lua_State* L)
 {
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -11709,14 +11498,14 @@ int LuaScriptInterface::luaPlayerAddAugment(lua_State* L)
 
 int LuaScriptInterface::luaPlayerRemoveAugment(lua_State* L)
 {
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	if (isString(L, 2)) {
-		auto name = getString(L, 2);
+		const auto name = getString(L, 2);
 		lua_pushboolean(L, player->removeAugment(name));
 	} else if (isUserdata(L, 2)) {
 		if (std::shared_ptr<Augment> augment = getSharedPtr<Augment>(L, 2)) {
@@ -11734,7 +11523,7 @@ int LuaScriptInterface::luaPlayerRemoveAugment(lua_State* L)
 
 int LuaScriptInterface::luaPlayerIsAugmented(lua_State* L)
 {
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
@@ -11745,20 +11534,20 @@ int LuaScriptInterface::luaPlayerIsAugmented(lua_State* L)
 
 int LuaScriptInterface::luaPlayerHasAugment(lua_State* L)
 {
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	if (isString(L, 2) && isBoolean(L, 3)) {
-		auto name = getString(L, 2);
-		auto checkItems = getBoolean(L, 3);
+		const auto name = getString(L, 2);
+		const auto checkItems = getBoolean(L, 3);
 		lua_pushboolean(L, player->hasAugment(name, checkItems));
 	} else if (isUserdata(L, 2)) {
 		if (std::shared_ptr<Augment>& augment = getSharedPtr<Augment>(L, 2)) {
 			if (isBoolean(L, 3)) {
-				auto checkItems = getBoolean(L, 3);
+				const auto checkItems = getBoolean(L, 3);
 				lua_pushboolean(L, player->hasAugment(augment, checkItems));
 			} else {
 				lua_pushboolean(L, player->hasAugment(augment, true));
@@ -11770,13 +11559,13 @@ int LuaScriptInterface::luaPlayerHasAugment(lua_State* L)
 
 int LuaScriptInterface::luaPlayerGetAugments(lua_State* L)
 {
-	Player* player = getUserdata<Player>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 1);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
-	
-	std::vector<std::shared_ptr<Augment>> augments;
+
+	const std::vector<std::shared_ptr<Augment>> augments;
 	
 	lua_newtable(L);
 	int index = 1;
@@ -11792,7 +11581,7 @@ int LuaScriptInterface::luaPlayerGetAugments(lua_State* L)
 int LuaScriptInterface::luaMonsterCreate(lua_State* L)
 {
 	// Monster(id or userdata)
-	Monster* monster;
+	MonsterPtr monster;
 	if (isNumber(L, 2)) {
 		monster = g_game.getMonsterByID(getNumber<uint32_t>(L, 2));
 	} else if (isUserdata(L, 2)) {
@@ -11800,13 +11589,13 @@ int LuaScriptInterface::luaMonsterCreate(lua_State* L)
 			lua_pushnil(L);
 			return 1;
 		}
-		monster = getUserdata<Monster>(L, 2);
+		monster = getSharedPtr<Monster>(L, 2);
 	} else {
 		monster = nullptr;
 	}
 
 	if (monster) {
-		pushUserdata<Monster>(L, monster);
+		pushSharedPtr(L, monster);
 		setMetatable(L, -1, "Monster");
 	} else {
 		lua_pushnil(L);
@@ -11817,8 +11606,7 @@ int LuaScriptInterface::luaMonsterCreate(lua_State* L)
 int LuaScriptInterface::luaMonsterGetId(lua_State* L)
 {
 	// monster:getId()
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
 		// Set monster id if it's not set yet (only for onSpawn event)
 		if (getScriptEnv()->getScriptId() == g_events->getScriptId(EventInfoId::MONSTER_ONSPAWN)) {
 			monster->setID();
@@ -11841,8 +11629,7 @@ int LuaScriptInterface::luaMonsterIsMonster(lua_State* L)
 int LuaScriptInterface::luaMonsterGetType(lua_State* L)
 {
 	// monster:getType()
-	const Monster* monster = getUserdata<const Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<const Monster>(L, 1)) {
 		pushUserdata<MonsterType>(L, monster->mType);
 		setMetatable(L, -1, "MonsterType");
 	} else {
@@ -11854,7 +11641,7 @@ int LuaScriptInterface::luaMonsterGetType(lua_State* L)
 int LuaScriptInterface::luaMonsterRename(lua_State* L)
 {
 	// monster:rename(name[, nameDescription])
-	Monster* monster = getUserdata<Monster>(L, 1);
+	const auto monster = getSharedPtr<Monster>(L, 1);
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -11872,8 +11659,7 @@ int LuaScriptInterface::luaMonsterRename(lua_State* L)
 int LuaScriptInterface::luaMonsterGetSpawnPosition(lua_State* L)
 {
 	// monster:getSpawnPosition()
-	const Monster* monster = getUserdata<const Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<const Monster>(L, 1)) {
 		pushPosition(L, monster->getMasterPos());
 	} else {
 		lua_pushnil(L);
@@ -11884,8 +11670,7 @@ int LuaScriptInterface::luaMonsterGetSpawnPosition(lua_State* L)
 int LuaScriptInterface::luaMonsterIsInSpawnRange(lua_State* L)
 {
 	// monster:isInSpawnRange([position])
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
 		pushBoolean(L, monster->isInSpawnRange(lua_gettop(L) >= 2 ? getPosition(L, 2) : monster->getPosition()));
 	} else {
 		lua_pushnil(L);
@@ -11896,8 +11681,7 @@ int LuaScriptInterface::luaMonsterIsInSpawnRange(lua_State* L)
 int LuaScriptInterface::luaMonsterIsIdle(lua_State* L)
 {
 	// monster:isIdle()
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
 		pushBoolean(L, monster->getIdleStatus());
 	} else {
 		lua_pushnil(L);
@@ -11908,7 +11692,7 @@ int LuaScriptInterface::luaMonsterIsIdle(lua_State* L)
 int LuaScriptInterface::luaMonsterSetIdle(lua_State* L)
 {
 	// monster:setIdle(idle)
-	Monster* monster = getUserdata<Monster>(L, 1);
+	const auto monster = getSharedPtr<Monster>(L, 1);
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -11922,9 +11706,8 @@ int LuaScriptInterface::luaMonsterSetIdle(lua_State* L)
 int LuaScriptInterface::luaMonsterIsTarget(lua_State* L)
 {
 	// monster:isTarget(creature)
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
-		const Creature* creature = getCreature(L, 2);
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
+		const auto creature = getCreature(L, 2);
 		if (!creature) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 			pushBoolean(L, false);
@@ -11941,9 +11724,8 @@ int LuaScriptInterface::luaMonsterIsTarget(lua_State* L)
 int LuaScriptInterface::luaMonsterIsOpponent(lua_State* L)
 {
 	// monster:isOpponent(creature)
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
-		const Creature* creature = getCreature(L, 2);
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
+		const auto creature = getCreature(L, 2);
 		if (!creature) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 			pushBoolean(L, false);
@@ -11960,9 +11742,8 @@ int LuaScriptInterface::luaMonsterIsOpponent(lua_State* L)
 int LuaScriptInterface::luaMonsterIsFriend(lua_State* L)
 {
 	// monster:isFriend(creature)
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
-		const Creature* creature = getCreature(L, 2);
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
+		const auto creature = getCreature(L, 2);
 		if (!creature) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 			pushBoolean(L, false);
@@ -11979,9 +11760,8 @@ int LuaScriptInterface::luaMonsterIsFriend(lua_State* L)
 int LuaScriptInterface::luaMonsterAddFriend(lua_State* L)
 {
 	// monster:addFriend(creature)
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
-		Creature* creature = getCreature(L, 2);
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
+		const auto creature = getCreature(L, 2);
 		if (!creature) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 			pushBoolean(L, false);
@@ -11999,9 +11779,8 @@ int LuaScriptInterface::luaMonsterAddFriend(lua_State* L)
 int LuaScriptInterface::luaMonsterRemoveFriend(lua_State* L)
 {
 	// monster:removeFriend(creature)
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
-		Creature* creature = getCreature(L, 2);
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
+		const auto creature = getCreature(L, 2);
 		if (!creature) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 			pushBoolean(L, false);
@@ -12019,7 +11798,7 @@ int LuaScriptInterface::luaMonsterRemoveFriend(lua_State* L)
 int LuaScriptInterface::luaMonsterGetFriendList(lua_State* L)
 {
 	// monster:getFriendList()
-	Monster* monster = getUserdata<Monster>(L, 1);
+	const auto monster = getSharedPtr<Monster>(L, 1);
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -12029,8 +11808,8 @@ int LuaScriptInterface::luaMonsterGetFriendList(lua_State* L)
 	lua_createtable(L, friendList.size(), 0);
 
 	int index = 0;
-	for (Creature* creature : friendList) {
-		pushUserdata<Creature>(L, creature);
+	for (const auto creature : friendList) {
+		pushSharedPtr(L, creature);
 		setCreatureMetatable(L, -1, creature);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -12040,8 +11819,7 @@ int LuaScriptInterface::luaMonsterGetFriendList(lua_State* L)
 int LuaScriptInterface::luaMonsterGetFriendCount(lua_State* L)
 {
 	// monster:getFriendCount()
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
 		lua_pushinteger(L, monster->getFriendList().size());
 	} else {
 		lua_pushnil(L);
@@ -12052,20 +11830,20 @@ int LuaScriptInterface::luaMonsterGetFriendCount(lua_State* L)
 int LuaScriptInterface::luaMonsterAddTarget(lua_State* L)
 {
 	// monster:addTarget(creature[, pushFront = false])
-	Monster* monster = getUserdata<Monster>(L, 1);
+	const auto monster = getSharedPtr<Monster>(L, 1);
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* creature = getCreature(L, 2);
+	const auto creature = getCreature(L, 2);
 	if (!creature) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	bool pushFront = getBoolean(L, 3, false);
+	const bool pushFront = getBoolean(L, 3, false);
 	monster->addTarget(creature, pushFront);
 	pushBoolean(L, true);
 	return 1;
@@ -12074,13 +11852,13 @@ int LuaScriptInterface::luaMonsterAddTarget(lua_State* L)
 int LuaScriptInterface::luaMonsterRemoveTarget(lua_State* L)
 {
 	// monster:removeTarget(creature)
-	Monster* monster = getUserdata<Monster>(L, 1);
+	const auto monster = getSharedPtr<Monster>(L, 1);
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Creature* creature = getCreature(L, 2);
+	const auto creature = getCreature(L, 2);
 	if (!creature) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -12095,7 +11873,7 @@ int LuaScriptInterface::luaMonsterRemoveTarget(lua_State* L)
 int LuaScriptInterface::luaMonsterGetTargetList(lua_State* L)
 {
 	// monster:getTargetList()
-	Monster* monster = getUserdata<Monster>(L, 1);
+	const auto monster = getUserdata<Monster>(L, 1);
 	if (!monster) {
 		lua_pushnil(L);
 		return 1;
@@ -12105,8 +11883,8 @@ int LuaScriptInterface::luaMonsterGetTargetList(lua_State* L)
 	lua_createtable(L, targetList.size(), 0);
 
 	int index = 0;
-	for (Creature* creature : targetList) {
-		pushUserdata<Creature>(L, creature);
+	for (const auto creature : targetList) {
+		pushSharedPtr(L, creature);
 		setCreatureMetatable(L, -1, creature);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -12116,8 +11894,7 @@ int LuaScriptInterface::luaMonsterGetTargetList(lua_State* L)
 int LuaScriptInterface::luaMonsterGetTargetCount(lua_State* L)
 {
 	// monster:getTargetCount()
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
 		lua_pushinteger(L, monster->getTargetList().size());
 	} else {
 		lua_pushnil(L);
@@ -12128,9 +11905,8 @@ int LuaScriptInterface::luaMonsterGetTargetCount(lua_State* L)
 int LuaScriptInterface::luaMonsterSelectTarget(lua_State* L)
 {
 	// monster:selectTarget(creature)
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
-		Creature* creature = getCreature(L, 2);
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
+		const auto creature = getCreature(L, 2);
 		if (!creature) {
 			reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 			pushBoolean(L, false);
@@ -12147,9 +11923,8 @@ int LuaScriptInterface::luaMonsterSelectTarget(lua_State* L)
 int LuaScriptInterface::luaMonsterSearchTarget(lua_State* L)
 {
 	// monster:searchTarget([searchType = TARGETSEARCH_DEFAULT])
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
-		TargetSearchType_t searchType = getNumber<TargetSearchType_t>(L, 2, TARGETSEARCH_DEFAULT);
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
+		const auto searchType = getNumber<TargetSearchType_t>(L, 2, TARGETSEARCH_DEFAULT);
 		pushBoolean(L, monster->searchTarget(searchType));
 	} else {
 		lua_pushnil(L);
@@ -12160,8 +11935,7 @@ int LuaScriptInterface::luaMonsterSearchTarget(lua_State* L)
 int LuaScriptInterface::luaMonsterIsWalkingToSpawn(lua_State* L)
 {
 	// monster:isWalkingToSpawn()
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
 		pushBoolean(L, monster->isWalkingToSpawn());
 	} else {
 		lua_pushnil(L);
@@ -12172,8 +11946,7 @@ int LuaScriptInterface::luaMonsterIsWalkingToSpawn(lua_State* L)
 int LuaScriptInterface::luaMonsterWalkToSpawn(lua_State* L)
 {
 	// monster:walkToSpawn()
-	Monster* monster = getUserdata<Monster>(L, 1);
-	if (monster) {
+	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
 		pushBoolean(L, monster->walkToSpawn());
 	} else {
 		lua_pushnil(L);
@@ -12185,7 +11958,7 @@ int LuaScriptInterface::luaMonsterWalkToSpawn(lua_State* L)
 int LuaScriptInterface::luaNpcCreate(lua_State* L)
 {
 	// Npc([id or name or userdata])
-	Npc* npc;
+	NpcPtr npc;
 	if (lua_gettop(L) >= 2) {
 		if (isNumber(L, 2)) {
 			npc = g_game.getNpcByID(getNumber<uint32_t>(L, 2));
@@ -12196,7 +11969,7 @@ int LuaScriptInterface::luaNpcCreate(lua_State* L)
 				lua_pushnil(L);
 				return 1;
 			}
-			npc = getUserdata<Npc>(L, 2);
+			npc = getSharedPtr<Npc>(L, 2);
 		} else {
 			npc = nullptr;
 		}
@@ -12205,7 +11978,7 @@ int LuaScriptInterface::luaNpcCreate(lua_State* L)
 	}
 
 	if (npc) {
-		pushUserdata<Npc>(L, npc);
+		pushSharedPtr(L, npc);
 		setMetatable(L, -1, "Npc");
 	} else {
 		lua_pushnil(L);
@@ -12216,21 +11989,21 @@ int LuaScriptInterface::luaNpcCreate(lua_State* L)
 int LuaScriptInterface::luaNpcIsNpc(lua_State* L)
 {
 	// npc:isNpc()
-	pushBoolean(L, getUserdata<const Npc>(L, 1) != nullptr);
+	pushBoolean(L, getSharedPtr<const Npc>(L, 1) != nullptr);
 	return 1;
 }
 
 int LuaScriptInterface::luaNpcSetMasterPos(lua_State* L)
 {
 	// npc:setMasterPos(pos[, radius])
-	Npc* npc = getUserdata<Npc>(L, 1);
+	const auto npc = getSharedPtr<Npc>(L, 1);
 	if (!npc) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	const Position& pos = getPosition(L, 2);
-	int32_t radius = getNumber<int32_t>(L, 3, 1);
+	const int32_t radius = getNumber<int32_t>(L, 3, 1);
 	npc->setMasterPos(pos, radius);
 	pushBoolean(L, true);
 	return 1;
@@ -12239,8 +12012,7 @@ int LuaScriptInterface::luaNpcSetMasterPos(lua_State* L)
 int LuaScriptInterface::luaNpcGetSpeechBubble(lua_State* L)
 {
 	// npc:getSpeechBubble()
-	Npc* npc = getUserdata<Npc>(L, 1);
-	if (npc) {
+	if (const auto npc = getSharedPtr<Npc>(L, 1)) {
 		lua_pushinteger(L, npc->getSpeechBubble());
 	} else {
 		lua_pushnil(L);
@@ -12251,7 +12023,7 @@ int LuaScriptInterface::luaNpcGetSpeechBubble(lua_State* L)
 int LuaScriptInterface::luaNpcSetSpeechBubble(lua_State* L)
 {
 	// npc:setSpeechBubble(speechBubble)
-	Npc* npc = getUserdata<Npc>(L, 1);
+	const auto npc = getSharedPtr<Npc>(L, 1);
 	if (!npc) {
 		lua_pushnil(L);
 		return 1;
@@ -12262,8 +12034,7 @@ int LuaScriptInterface::luaNpcSetSpeechBubble(lua_State* L)
 		return 1;
 	}
 
-	uint8_t speechBubble = getNumber<uint8_t>(L, 2);
-	if (speechBubble > SPEECHBUBBLE_LAST) {
+	if (const uint8_t speechBubble = getNumber<uint8_t>(L, 2); speechBubble > SPEECHBUBBLE_LAST) {
 		lua_pushnil(L);
 	} else {
 		npc->setSpeechBubble(speechBubble);
@@ -12277,7 +12048,7 @@ int LuaScriptInterface::luaNpcSetSpeechBubble(lua_State* L)
 int LuaScriptInterface::luaNpcGetSpectators(lua_State* L)
 {
 	// npc:getSpectators()
-	Npc* npc = getUserdata<Npc>(L, 1);
+	const auto npc = getSharedPtr<Npc>(L, 1);
 	if (!npc) {
 		lua_pushnil(L);
 		return 1;
@@ -12288,7 +12059,7 @@ int LuaScriptInterface::luaNpcGetSpectators(lua_State* L)
 	int index = 0;
 
 	for (const auto& spectatorPlayer : npc->getSpectators()) {
-		pushUserdata<const Player>(L, spectatorPlayer);
+		pushSharedPtr(L, spectatorPlayer);
 		setMetatable(L, -1, "Player");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -12299,10 +12070,9 @@ int LuaScriptInterface::luaNpcGetSpectators(lua_State* L)
 int LuaScriptInterface::luaGuildCreate(lua_State* L)
 {
 	// Guild(id)
-	uint32_t id = getNumber<uint32_t>(L, 2);
+	const uint32_t id = getNumber<uint32_t>(L, 2);
 
-	Guild* guild = g_game.getGuild(id);
-	if (guild) {
+	if (const auto guild = g_game.getGuild(id)) {
 		pushUserdata<Guild>(L, guild);
 		setMetatable(L, -1, "Guild");
 	} else {
@@ -12314,8 +12084,7 @@ int LuaScriptInterface::luaGuildCreate(lua_State* L)
 int LuaScriptInterface::luaGuildGetId(lua_State* L)
 {
 	// guild:getId()
-	Guild* guild = getUserdata<Guild>(L, 1);
-	if (guild) {
+	if (const auto guild = getUserdata<Guild>(L, 1)) {
 		lua_pushinteger(L, guild->getId());
 	} else {
 		lua_pushnil(L);
@@ -12326,8 +12095,7 @@ int LuaScriptInterface::luaGuildGetId(lua_State* L)
 int LuaScriptInterface::luaGuildGetName(lua_State* L)
 {
 	// guild:getName()
-	Guild* guild = getUserdata<Guild>(L, 1);
-	if (guild) {
+	if (const auto guild = getUserdata<Guild>(L, 1)) {
 		pushString(L, guild->getName());
 	} else {
 		lua_pushnil(L);
@@ -12338,7 +12106,7 @@ int LuaScriptInterface::luaGuildGetName(lua_State* L)
 int LuaScriptInterface::luaGuildGetMembersOnline(lua_State* L)
 {
 	// guild:getMembersOnline()
-	const Guild* guild = getUserdata<const Guild>(L, 1);
+	const auto guild = getUserdata<const Guild>(L, 1);
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
@@ -12348,8 +12116,8 @@ int LuaScriptInterface::luaGuildGetMembersOnline(lua_State* L)
 	lua_createtable(L, members.size(), 0);
 
 	int index = 0;
-	for (Player* player : members) {
-		pushUserdata<Player>(L, player);
+	for (const auto player : members) {
+		pushSharedPtr(L, player);
 		setMetatable(L, -1, "Player");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -12359,11 +12127,10 @@ int LuaScriptInterface::luaGuildGetMembersOnline(lua_State* L)
 int LuaScriptInterface::luaGuildAddRank(lua_State* L)
 {
 	// guild:addRank(id, name, level)
-	Guild* guild = getUserdata<Guild>(L, 1);
-	if (guild) {
-		uint32_t id = getNumber<uint32_t>(L, 2);
+	if (const auto guild = getSharedPtr<Guild>(L, 1)) {
+		const uint32_t id = getNumber<uint32_t>(L, 2);
 		const std::string& name = getString(L, 3);
-		uint8_t level = getNumber<uint8_t>(L, 4);
+		const uint8_t level = getNumber<uint8_t>(L, 4);
 		guild->addRank(id, name, level);
 		pushBoolean(L, true);
 	} else {
@@ -12375,15 +12142,14 @@ int LuaScriptInterface::luaGuildAddRank(lua_State* L)
 int LuaScriptInterface::luaGuildGetRankById(lua_State* L)
 {
 	// guild:getRankById(id)
-	Guild* guild = getUserdata<Guild>(L, 1);
+	const auto guild = getUserdata<Guild>(L, 1);
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint32_t id = getNumber<uint32_t>(L, 2);
-	GuildRank_ptr rank = guild->getRankById(id);
-	if (rank) {
+	const uint32_t id = getNumber<uint32_t>(L, 2);
+	if (const auto rank = guild->getRankById(id)) {
 		lua_createtable(L, 0, 3);
 		setField(L, "id", rank->id);
 		setField(L, "name", rank->name);
@@ -12397,15 +12163,14 @@ int LuaScriptInterface::luaGuildGetRankById(lua_State* L)
 int LuaScriptInterface::luaGuildGetRankByLevel(lua_State* L)
 {
 	// guild:getRankByLevel(level)
-	const Guild* guild = getUserdata<const Guild>(L, 1);
+	const auto guild = getUserdata<const Guild>(L, 1);
 	if (!guild) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint8_t level = getNumber<uint8_t>(L, 2);
-	GuildRank_ptr rank = guild->getRankByLevel(level);
-	if (rank) {
+	const uint8_t level = getNumber<uint8_t>(L, 2);
+	if (const auto rank = guild->getRankByLevel(level)) {
 		lua_createtable(L, 0, 3);
 		setField(L, "id", rank->id);
 		setField(L, "name", rank->name);
@@ -12419,8 +12184,7 @@ int LuaScriptInterface::luaGuildGetRankByLevel(lua_State* L)
 int LuaScriptInterface::luaGuildGetMotd(lua_State* L)
 {
 	// guild:getMotd()
-	Guild* guild = getUserdata<Guild>(L, 1);
-	if (guild) {
+	if (const auto guild = getUserdata<Guild>(L, 1)) {
 		pushString(L, guild->getMotd());
 	} else {
 		lua_pushnil(L);
@@ -12432,8 +12196,7 @@ int LuaScriptInterface::luaGuildSetMotd(lua_State* L)
 {
 	// guild:setMotd(motd)
 	const std::string& motd = getString(L, 2);
-	Guild* guild = getUserdata<Guild>(L, 1);
-	if (guild) {
+	if (const auto guild = getUserdata<Guild>(L, 1)) {
 		guild->setMotd(motd);
 		pushBoolean(L, true);
 	} else {
@@ -12446,10 +12209,9 @@ int LuaScriptInterface::luaGuildSetMotd(lua_State* L)
 int LuaScriptInterface::luaGroupCreate(lua_State* L)
 {
 	// Group(id)
-	uint32_t id = getNumber<uint32_t>(L, 2);
+	const uint32_t id = getNumber<uint32_t>(L, 2);
 
-	Group* group = g_game.groups.getGroup(id);
-	if (group) {
+	if (const auto group = g_game.groups.getGroup(id)) {
 		pushUserdata<Group>(L, group);
 		setMetatable(L, -1, "Group");
 	} else {
@@ -12461,8 +12223,7 @@ int LuaScriptInterface::luaGroupCreate(lua_State* L)
 int LuaScriptInterface::luaGroupGetId(lua_State* L)
 {
 	// group:getId()
-	Group* group = getUserdata<Group>(L, 1);
-	if (group) {
+	if (const auto group = getUserdata<Group>(L, 1)) {
 		lua_pushinteger(L, group->id);
 	} else {
 		lua_pushnil(L);
@@ -12473,8 +12234,7 @@ int LuaScriptInterface::luaGroupGetId(lua_State* L)
 int LuaScriptInterface::luaGroupGetName(lua_State* L)
 {
 	// group:getName()
-	Group* group = getUserdata<Group>(L, 1);
-	if (group) {
+	if (const auto group = getUserdata<Group>(L, 1)) {
 		pushString(L, group->name);
 	} else {
 		lua_pushnil(L);
@@ -12485,8 +12245,7 @@ int LuaScriptInterface::luaGroupGetName(lua_State* L)
 int LuaScriptInterface::luaGroupGetFlags(lua_State* L)
 {
 	// group:getFlags()
-	Group* group = getUserdata<Group>(L, 1);
-	if (group) {
+	if (const auto group = getUserdata<Group>(L, 1)) {
 		lua_pushinteger(L, group->flags);
 	} else {
 		lua_pushnil(L);
@@ -12497,8 +12256,7 @@ int LuaScriptInterface::luaGroupGetFlags(lua_State* L)
 int LuaScriptInterface::luaGroupGetAccess(lua_State* L)
 {
 	// group:getAccess()
-	Group* group = getUserdata<Group>(L, 1);
-	if (group) {
+	if (const auto group = getUserdata<Group>(L, 1)) {
 		pushBoolean(L, group->access);
 	} else {
 		lua_pushnil(L);
@@ -12509,8 +12267,7 @@ int LuaScriptInterface::luaGroupGetAccess(lua_State* L)
 int LuaScriptInterface::luaGroupGetMaxDepotItems(lua_State* L)
 {
 	// group:getMaxDepotItems()
-	Group* group = getUserdata<Group>(L, 1);
-	if (group) {
+	if (const auto group = getUserdata<Group>(L, 1)) {
 		lua_pushinteger(L, group->maxDepotItems);
 	} else {
 		lua_pushnil(L);
@@ -12521,8 +12278,7 @@ int LuaScriptInterface::luaGroupGetMaxDepotItems(lua_State* L)
 int LuaScriptInterface::luaGroupGetMaxVipEntries(lua_State* L)
 {
 	// group:getMaxVipEntries()
-	Group* group = getUserdata<Group>(L, 1);
-	if (group) {
+	if (const auto group = getUserdata<Group>(L, 1)) {
 		lua_pushinteger(L, group->maxVipEntries);
 	} else {
 		lua_pushnil(L);
@@ -12533,9 +12289,8 @@ int LuaScriptInterface::luaGroupGetMaxVipEntries(lua_State* L)
 int LuaScriptInterface::luaGroupHasFlag(lua_State* L)
 {
 	// group:hasFlag(flag)
-	Group* group = getUserdata<Group>(L, 1);
-	if (group) {
-		PlayerFlags flag = getNumber<PlayerFlags>(L, 2);
+	if (const auto group = getUserdata<Group>(L, 1)) {
+		const auto flag = getNumber<PlayerFlags>(L, 2);
 		pushBoolean(L, (group->flags & flag) != 0);
 	} else {
 		lua_pushnil(L);
@@ -12554,8 +12309,7 @@ int LuaScriptInterface::luaVocationCreate(lua_State* L)
 		id = g_vocations.getVocationId(getString(L, 2));
 	}
 
-	Vocation* vocation = g_vocations.getVocation(id);
-	if (vocation) {
+	if (const auto vocation = g_vocations.getVocation(id)) {
 		pushUserdata<Vocation>(L, vocation);
 		setMetatable(L, -1, "Vocation");
 	} else {
@@ -12567,8 +12321,7 @@ int LuaScriptInterface::luaVocationCreate(lua_State* L)
 int LuaScriptInterface::luaVocationGetId(lua_State* L)
 {
 	// vocation:getId()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getId());
 	} else {
 		lua_pushnil(L);
@@ -12579,8 +12332,7 @@ int LuaScriptInterface::luaVocationGetId(lua_State* L)
 int LuaScriptInterface::luaVocationGetClientId(lua_State* L)
 {
 	// vocation:getClientId()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getClientId());
 	} else {
 		lua_pushnil(L);
@@ -12591,8 +12343,7 @@ int LuaScriptInterface::luaVocationGetClientId(lua_State* L)
 int LuaScriptInterface::luaVocationGetName(lua_State* L)
 {
 	// vocation:getName()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		pushString(L, vocation->getVocName());
 	} else {
 		lua_pushnil(L);
@@ -12603,8 +12354,7 @@ int LuaScriptInterface::luaVocationGetName(lua_State* L)
 int LuaScriptInterface::luaVocationGetDescription(lua_State* L)
 {
 	// vocation:getDescription()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		pushString(L, vocation->getVocDescription());
 	} else {
 		lua_pushnil(L);
@@ -12615,10 +12365,9 @@ int LuaScriptInterface::luaVocationGetDescription(lua_State* L)
 int LuaScriptInterface::luaVocationGetRequiredSkillTries(lua_State* L)
 {
 	// vocation:getRequiredSkillTries(skillType, skillLevel)
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
-		skills_t skillType = getNumber<skills_t>(L, 2);
-		uint16_t skillLevel = getNumber<uint16_t>(L, 3);
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
+		const auto skillType = getNumber<skills_t>(L, 2);
+		const uint16_t skillLevel = getNumber<uint16_t>(L, 3);
 		lua_pushinteger(L, vocation->getReqSkillTries(skillType, skillLevel));
 	} else {
 		lua_pushnil(L);
@@ -12629,9 +12378,8 @@ int LuaScriptInterface::luaVocationGetRequiredSkillTries(lua_State* L)
 int LuaScriptInterface::luaVocationGetRequiredManaSpent(lua_State* L)
 {
 	// vocation:getRequiredManaSpent(magicLevel)
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
-		uint32_t magicLevel = getNumber<uint32_t>(L, 2);
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
+		const uint32_t magicLevel = getNumber<uint32_t>(L, 2);
 		lua_pushinteger(L, vocation->getReqMana(magicLevel));
 	} else {
 		lua_pushnil(L);
@@ -12642,8 +12390,7 @@ int LuaScriptInterface::luaVocationGetRequiredManaSpent(lua_State* L)
 int LuaScriptInterface::luaVocationGetCapacityGain(lua_State* L)
 {
 	// vocation:getCapacityGain()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getCapGain());
 	} else {
 		lua_pushnil(L);
@@ -12654,8 +12401,7 @@ int LuaScriptInterface::luaVocationGetCapacityGain(lua_State* L)
 int LuaScriptInterface::luaVocationGetHealthGain(lua_State* L)
 {
 	// vocation:getHealthGain()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getHPGain());
 	} else {
 		lua_pushnil(L);
@@ -12666,8 +12412,7 @@ int LuaScriptInterface::luaVocationGetHealthGain(lua_State* L)
 int LuaScriptInterface::luaVocationGetHealthGainTicks(lua_State* L)
 {
 	// vocation:getHealthGainTicks()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getHealthGainTicks());
 	} else {
 		lua_pushnil(L);
@@ -12678,8 +12423,7 @@ int LuaScriptInterface::luaVocationGetHealthGainTicks(lua_State* L)
 int LuaScriptInterface::luaVocationGetHealthGainAmount(lua_State* L)
 {
 	// vocation:getHealthGainAmount()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getHealthGainAmount());
 	} else {
 		lua_pushnil(L);
@@ -12690,8 +12434,7 @@ int LuaScriptInterface::luaVocationGetHealthGainAmount(lua_State* L)
 int LuaScriptInterface::luaVocationGetManaGain(lua_State* L)
 {
 	// vocation:getManaGain()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getManaGain());
 	} else {
 		lua_pushnil(L);
@@ -12702,8 +12445,7 @@ int LuaScriptInterface::luaVocationGetManaGain(lua_State* L)
 int LuaScriptInterface::luaVocationGetManaGainTicks(lua_State* L)
 {
 	// vocation:getManaGainTicks()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getManaGainTicks());
 	} else {
 		lua_pushnil(L);
@@ -12714,8 +12456,7 @@ int LuaScriptInterface::luaVocationGetManaGainTicks(lua_State* L)
 int LuaScriptInterface::luaVocationGetManaGainAmount(lua_State* L)
 {
 	// vocation:getManaGainAmount()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getManaGainAmount());
 	} else {
 		lua_pushnil(L);
@@ -12726,8 +12467,7 @@ int LuaScriptInterface::luaVocationGetManaGainAmount(lua_State* L)
 int LuaScriptInterface::luaVocationGetMaxSoul(lua_State* L)
 {
 	// vocation:getMaxSoul()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getSoulMax());
 	} else {
 		lua_pushnil(L);
@@ -12738,8 +12478,7 @@ int LuaScriptInterface::luaVocationGetMaxSoul(lua_State* L)
 int LuaScriptInterface::luaVocationGetSoulGainTicks(lua_State* L)
 {
 	// vocation:getSoulGainTicks()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getSoulGainTicks());
 	} else {
 		lua_pushnil(L);
@@ -12750,8 +12489,7 @@ int LuaScriptInterface::luaVocationGetSoulGainTicks(lua_State* L)
 int LuaScriptInterface::luaVocationGetAttackSpeed(lua_State* L)
 {
 	// vocation:getAttackSpeed()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getAttackSpeed());
 	} else {
 		lua_pushnil(L);
@@ -12762,8 +12500,7 @@ int LuaScriptInterface::luaVocationGetAttackSpeed(lua_State* L)
 int LuaScriptInterface::luaVocationGetBaseSpeed(lua_State* L)
 {
 	// vocation:getBaseSpeed()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		lua_pushinteger(L, vocation->getBaseSpeed());
 	} else {
 		lua_pushnil(L);
@@ -12774,21 +12511,21 @@ int LuaScriptInterface::luaVocationGetBaseSpeed(lua_State* L)
 int LuaScriptInterface::luaVocationGetDemotion(lua_State* L)
 {
 	// vocation:getDemotion()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
+	const auto vocation = getUserdata<Vocation>(L, 1);
 	if (!vocation) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint16_t fromId = vocation->getFromVocation();
+	const uint16_t fromId = vocation->getFromVocation();
 	if (fromId == VOCATION_NONE) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Vocation* demotedVocation = g_vocations.getVocation(fromId);
+	const auto demotedVocation = g_vocations.getVocation(fromId);
 	if (demotedVocation && demotedVocation != vocation) {
-		pushUserdata<Vocation>(L, demotedVocation);
+		pushSharedPtr(L, demotedVocation);
 		setMetatable(L, -1, "Vocation");
 	} else {
 		lua_pushnil(L);
@@ -12799,21 +12536,21 @@ int LuaScriptInterface::luaVocationGetDemotion(lua_State* L)
 int LuaScriptInterface::luaVocationGetPromotion(lua_State* L)
 {
 	// vocation:getPromotion()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
+	const auto vocation = getUserdata<Vocation>(L, 1);
 	if (!vocation) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint16_t promotedId = g_vocations.getPromotedVocation(vocation->getId());
+	const uint16_t promotedId = g_vocations.getPromotedVocation(vocation->getId());
 	if (promotedId == VOCATION_NONE) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Vocation* promotedVocation = g_vocations.getVocation(promotedId);
+	const auto promotedVocation = g_vocations.getVocation(promotedId);
 	if (promotedVocation && promotedVocation != vocation) {
-		pushUserdata<Vocation>(L, promotedVocation);
+		pushSharedPtr(L, promotedVocation);
 		setMetatable(L, -1, "Vocation");
 	} else {
 		lua_pushnil(L);
@@ -12824,8 +12561,7 @@ int LuaScriptInterface::luaVocationGetPromotion(lua_State* L)
 int LuaScriptInterface::luaVocationAllowsPvp(lua_State* L)
 {
 	// vocation:allowsPvp()
-	Vocation* vocation = getUserdata<Vocation>(L, 1);
-	if (vocation) {
+	if (const auto vocation = getUserdata<Vocation>(L, 1)) {
 		pushBoolean(L, vocation->allowsPvp());
 	} else {
 		lua_pushnil(L);
@@ -12858,8 +12594,7 @@ int LuaScriptInterface::luaTownCreate(lua_State* L)
 int LuaScriptInterface::luaTownGetId(lua_State* L)
 {
 	// town:getId()
-	Town* town = getUserdata<Town>(L, 1);
-	if (town) {
+	if (const auto town = getUserdata<Town>(L, 1)) {
 		lua_pushinteger(L, town->getID());
 	} else {
 		lua_pushnil(L);
@@ -12870,8 +12605,7 @@ int LuaScriptInterface::luaTownGetId(lua_State* L)
 int LuaScriptInterface::luaTownGetName(lua_State* L)
 {
 	// town:getName()
-	Town* town = getUserdata<Town>(L, 1);
-	if (town) {
+	if (const auto town = getUserdata<Town>(L, 1)) {
 		pushString(L, town->getName());
 	} else {
 		lua_pushnil(L);
@@ -12882,8 +12616,7 @@ int LuaScriptInterface::luaTownGetName(lua_State* L)
 int LuaScriptInterface::luaTownGetTemplePosition(lua_State* L)
 {
 	// town:getTemplePosition()
-	Town* town = getUserdata<Town>(L, 1);
-	if (town) {
+	if (const auto town = getUserdata<Town>(L, 1)) {
 		pushPosition(L, town->getTemplePosition());
 	} else {
 		lua_pushnil(L);
@@ -12895,8 +12628,7 @@ int LuaScriptInterface::luaTownGetTemplePosition(lua_State* L)
 int LuaScriptInterface::luaHouseCreate(lua_State* L)
 {
 	// House(id)
-	House* house = g_game.map.houses.getHouse(getNumber<uint32_t>(L, 2));
-	if (house) {
+	if (const auto house = g_game.map.houses.getHouse(getNumber<uint32_t>(L, 2))) {
 		pushUserdata<House>(L, house);
 		setMetatable(L, -1, "House");
 	} else {
@@ -12908,8 +12640,7 @@ int LuaScriptInterface::luaHouseCreate(lua_State* L)
 int LuaScriptInterface::luaHouseGetId(lua_State* L)
 {
 	// house:getId()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		lua_pushinteger(L, house->getId());
 	} else {
 		lua_pushnil(L);
@@ -12920,8 +12651,7 @@ int LuaScriptInterface::luaHouseGetId(lua_State* L)
 int LuaScriptInterface::luaHouseGetName(lua_State* L)
 {
 	// house:getName()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		pushString(L, house->getName());
 	} else {
 		lua_pushnil(L);
@@ -12932,14 +12662,13 @@ int LuaScriptInterface::luaHouseGetName(lua_State* L)
 int LuaScriptInterface::luaHouseGetTown(lua_State* L)
 {
 	// house:getTown()
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Town* town = g_game.map.towns.getTown(house->getTownId());
-	if (town) {
+	if (const auto town = g_game.map.towns.getTown(house->getTownId())) {
 		pushUserdata<Town>(L, town);
 		setMetatable(L, -1, "Town");
 	} else {
@@ -12951,8 +12680,7 @@ int LuaScriptInterface::luaHouseGetTown(lua_State* L)
 int LuaScriptInterface::luaHouseGetExitPosition(lua_State* L)
 {
 	// house:getExitPosition()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		pushPosition(L, house->getEntryPosition());
 	} else {
 		lua_pushnil(L);
@@ -12963,8 +12691,7 @@ int LuaScriptInterface::luaHouseGetExitPosition(lua_State* L)
 int LuaScriptInterface::luaHouseGetRent(lua_State* L)
 {
 	// house:getRent()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		lua_pushinteger(L, house->getRent());
 	} else {
 		lua_pushnil(L);
@@ -12975,9 +12702,8 @@ int LuaScriptInterface::luaHouseGetRent(lua_State* L)
 int LuaScriptInterface::luaHouseSetRent(lua_State* L)
 {
 	// house:setRent(rent)
-	uint32_t rent = getNumber<uint32_t>(L, 2);
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	const uint32_t rent = getNumber<uint32_t>(L, 2);
+	if (const auto house = getUserdata<House>(L, 1)) {
 		house->setRent(rent);
 		pushBoolean(L, true);
 	} else {
@@ -12989,8 +12715,7 @@ int LuaScriptInterface::luaHouseSetRent(lua_State* L)
 int LuaScriptInterface::luaHouseGetPaidUntil(lua_State* L)
 {
 	// house:getPaidUntil()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		lua_pushinteger(L, house->getPaidUntil());
 	} else {
 		lua_pushnil(L);
@@ -13001,9 +12726,8 @@ int LuaScriptInterface::luaHouseGetPaidUntil(lua_State* L)
 int LuaScriptInterface::luaHouseSetPaidUntil(lua_State* L)
 {
 	// house:setPaidUntil(timestamp)
-	time_t timestamp = getNumber<time_t>(L, 2);
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	const time_t timestamp = getNumber<time_t>(L, 2);
+	if (const auto house = getUserdata<House>(L, 1)) {
 		house->setPaidUntil(timestamp);
 		pushBoolean(L, true);
 	} else {
@@ -13015,8 +12739,7 @@ int LuaScriptInterface::luaHouseSetPaidUntil(lua_State* L)
 int LuaScriptInterface::luaHouseGetPayRentWarnings(lua_State* L)
 {
 	// house:getPayRentWarnings()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		lua_pushinteger(L, house->getPayRentWarnings());
 	} else {
 		lua_pushnil(L);
@@ -13027,9 +12750,8 @@ int LuaScriptInterface::luaHouseGetPayRentWarnings(lua_State* L)
 int LuaScriptInterface::luaHouseSetPayRentWarnings(lua_State* L)
 {
 	// house:setPayRentWarnings(warnings)
-	uint32_t warnings = getNumber<uint32_t>(L, 2);
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	const uint32_t warnings = getNumber<uint32_t>(L, 2);
+	if (const auto house = getUserdata<House>(L, 1)) {
 		house->setPayRentWarnings(warnings);
 		pushBoolean(L, true);
 	} else {
@@ -13041,8 +12763,7 @@ int LuaScriptInterface::luaHouseSetPayRentWarnings(lua_State* L)
 int LuaScriptInterface::luaHouseGetOwnerGuid(lua_State* L)
 {
 	// house:getOwnerGuid()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		lua_pushinteger(L, house->getOwner());
 	} else {
 		lua_pushnil(L);
@@ -13053,10 +12774,9 @@ int LuaScriptInterface::luaHouseGetOwnerGuid(lua_State* L)
 int LuaScriptInterface::luaHouseSetOwnerGuid(lua_State* L)
 {
 	// house:setOwnerGuid(guid[, updateDatabase = true])
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
-		uint32_t guid = getNumber<uint32_t>(L, 2);
-		bool updateDatabase = getBoolean(L, 3, true);
+	if (const auto house = getUserdata<House>(L, 1)) {
+		const uint32_t guid = getNumber<uint32_t>(L, 2);
+		const bool updateDatabase = getBoolean(L, 3, true);
 		house->setOwner(guid, updateDatabase);
 		pushBoolean(L, true);
 	} else {
@@ -13068,9 +12788,9 @@ int LuaScriptInterface::luaHouseSetOwnerGuid(lua_State* L)
 int LuaScriptInterface::luaHouseStartTrade(lua_State* L)
 {
 	// house:startTrade(player, tradePartner)
-	House* house = getUserdata<House>(L, 1);
-	Player* player = getUserdata<Player>(L, 2);
-	Player* tradePartner = getUserdata<Player>(L, 3);
+	const auto house = getUserdata<House>(L, 1);
+	const auto player = getSharedPtr<Player>(L, 2);
+	const auto tradePartner = getSharedPtr<Player>(L, 3);
 
 	if (!player || !tradePartner || !house) {
 		lua_pushnil(L);
@@ -13097,12 +12817,11 @@ int LuaScriptInterface::luaHouseStartTrade(lua_State* L)
 		return 1;
 	}
 
-	Item* transferItem = house->getTransferItem();
+	const auto transferItem = house->getTransferItem();
 	if (!transferItem) {
 		lua_pushinteger(L, RETURNVALUE_YOUCANNOTTRADETHISHOUSE);
 		return 1;
 	}
-
 	transferItem->getParent()->setParent(player);
 	if (!g_game.internalStartTrade(player, tradePartner, transferItem)) {
 		house->resetTransferItem();
@@ -13115,7 +12834,7 @@ int LuaScriptInterface::luaHouseStartTrade(lua_State* L)
 int LuaScriptInterface::luaHouseGetBeds(lua_State* L)
 {
 	// house:getBeds()
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -13125,8 +12844,8 @@ int LuaScriptInterface::luaHouseGetBeds(lua_State* L)
 	lua_createtable(L, beds.size(), 0);
 
 	int index = 0;
-	for (BedItem* bedItem : beds) {
-		pushUserdata<Item>(L, bedItem);
+	for (const auto bedItem : beds) {
+		pushSharedPtr(L, bedItem);
 		setItemMetatable(L, -1, bedItem);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -13136,8 +12855,7 @@ int LuaScriptInterface::luaHouseGetBeds(lua_State* L)
 int LuaScriptInterface::luaHouseGetBedCount(lua_State* L)
 {
 	// house:getBedCount()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		lua_pushinteger(L, house->getBedCount());
 	} else {
 		lua_pushnil(L);
@@ -13148,7 +12866,7 @@ int LuaScriptInterface::luaHouseGetBedCount(lua_State* L)
 int LuaScriptInterface::luaHouseGetDoors(lua_State* L)
 {
 	// house:getDoors()
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -13158,8 +12876,8 @@ int LuaScriptInterface::luaHouseGetDoors(lua_State* L)
 	lua_createtable(L, doors.size(), 0);
 
 	int index = 0;
-	for (Door* door : doors) {
-		pushUserdata<Item>(L, door);
+	for (const auto door : doors) {
+		pushSharedPtr(L, door);
 		setItemMetatable(L, -1, door);
 		lua_rawseti(L, -2, ++index);
 	}
@@ -13169,8 +12887,7 @@ int LuaScriptInterface::luaHouseGetDoors(lua_State* L)
 int LuaScriptInterface::luaHouseGetDoorCount(lua_State* L)
 {
 	// house:getDoorCount()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		lua_pushinteger(L, house->getDoors().size());
 	} else {
 		lua_pushnil(L);
@@ -13181,14 +12898,13 @@ int LuaScriptInterface::luaHouseGetDoorCount(lua_State* L)
 int LuaScriptInterface::luaHouseGetDoorIdByPosition(lua_State* L)
 {
 	// house:getDoorIdByPosition(position)
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Door* door = house->getDoorByPosition(getPosition(L, 2));
-	if (door) {
+	if (const auto door = house->getDoorByPosition(getPosition(L, 2))) {
 		lua_pushinteger(L, door->getDoorId());
 	} else {
 		lua_pushnil(L);
@@ -13199,7 +12915,7 @@ int LuaScriptInterface::luaHouseGetDoorIdByPosition(lua_State* L)
 int LuaScriptInterface::luaHouseGetTiles(lua_State* L)
 {
 	// house:getTiles()
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -13209,8 +12925,8 @@ int LuaScriptInterface::luaHouseGetTiles(lua_State* L)
 	lua_createtable(L, tiles.size(), 0);
 
 	int index = 0;
-	for (Tile* tile : tiles) {
-		pushUserdata<Tile>(L, tile);
+	for (const auto tile : tiles) {
+		pushSharedPtr(L, tile);
 		setMetatable(L, -1, "Tile");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -13220,7 +12936,7 @@ int LuaScriptInterface::luaHouseGetTiles(lua_State* L)
 int LuaScriptInterface::luaHouseGetItems(lua_State* L)
 {
 	// house:getItems()
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -13230,11 +12946,10 @@ int LuaScriptInterface::luaHouseGetItems(lua_State* L)
 	lua_newtable(L);
 
 	int index = 0;
-	for (Tile* tile : tiles) {
-		TileItemVector* itemVector = tile->getItemList();
-		if(itemVector) {
-			for(Item* item : *itemVector) {
-				pushUserdata<Item>(L, item);
+	for (const auto tile : tiles) {
+		if(const auto itemVector = tile->getItemList()) {
+			for(const auto item : *itemVector) {
+				pushSharedPtr(L, item);
 				setItemMetatable(L, -1, item);
 				lua_rawseti(L, -2, ++index);
 			}
@@ -13246,8 +12961,7 @@ int LuaScriptInterface::luaHouseGetItems(lua_State* L)
 int LuaScriptInterface::luaHouseGetTileCount(lua_State* L)
 {
 	// house:getTileCount()
-	House* house = getUserdata<House>(L, 1);
-	if (house) {
+	if (const auto house = getUserdata<House>(L, 1)) {
 		lua_pushinteger(L, house->getTiles().size());
 	} else {
 		lua_pushnil(L);
@@ -13258,14 +12972,14 @@ int LuaScriptInterface::luaHouseGetTileCount(lua_State* L)
 int LuaScriptInterface::luaHouseCanEditAccessList(lua_State* L)
 {
 	// house:canEditAccessList(listId, player)
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	uint32_t listId = getNumber<uint32_t>(L, 2);
-	Player* player = getPlayer(L, 3);
+	const auto player = getPlayer(L, 3);
 
 	pushBoolean(L, house->canEditAccessList(listId, player));
 	return 1;
@@ -13274,15 +12988,14 @@ int LuaScriptInterface::luaHouseCanEditAccessList(lua_State* L)
 int LuaScriptInterface::luaHouseGetAccessList(lua_State* L)
 {
 	// house:getAccessList(listId)
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
 	}
 
 	std::string list;
-	uint32_t listId = getNumber<uint32_t>(L, 2);
-	if (house->getAccessList(listId, list)) {
+	if (const uint32_t listId = getNumber<uint32_t>(L, 2); house->getAccessList(listId, list)) {
 		pushString(L, list);
 	} else {
 		pushBoolean(L, false);
@@ -13293,13 +13006,13 @@ int LuaScriptInterface::luaHouseGetAccessList(lua_State* L)
 int LuaScriptInterface::luaHouseSetAccessList(lua_State* L)
 {
 	// house:setAccessList(listId, list)
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint32_t listId = getNumber<uint32_t>(L, 2);
+	const uint32_t listId = getNumber<uint32_t>(L, 2);
 	const std::string& list = getString(L, 3);
 	house->setAccessList(listId, list);
 	pushBoolean(L, true);
@@ -13309,7 +13022,7 @@ int LuaScriptInterface::luaHouseSetAccessList(lua_State* L)
 int LuaScriptInterface::luaHouseKickPlayer(lua_State* L)
 {
 	// house:kickPlayer(player, targetPlayer)
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -13322,7 +13035,7 @@ int LuaScriptInterface::luaHouseKickPlayer(lua_State* L)
 int LuaScriptInterface::luaHouseSave(lua_State* L)
 {
 	// house:save()
-	House* house = getUserdata<House>(L, 1);
+	const auto house = getUserdata<House>(L, 1);
 	if (!house) {
 		lua_pushnil(L);
 		return 1;
@@ -13355,8 +13068,7 @@ int LuaScriptInterface::luaItemTypeCreate(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsCorpse(lua_State* L)
 {
 	// itemType:isCorpse()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->corpseType != RACE_NONE);
 	} else {
 		lua_pushnil(L);
@@ -13367,8 +13079,7 @@ int LuaScriptInterface::luaItemTypeIsCorpse(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsDoor(lua_State* L)
 {
 	// itemType:isDoor()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->isDoor());
 	} else {
 		lua_pushnil(L);
@@ -13379,8 +13090,7 @@ int LuaScriptInterface::luaItemTypeIsDoor(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsContainer(lua_State* L)
 {
 	// itemType:isContainer()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->isContainer());
 	} else {
 		lua_pushnil(L);
@@ -13391,8 +13101,7 @@ int LuaScriptInterface::luaItemTypeIsContainer(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsFluidContainer(lua_State* L)
 {
 	// itemType:isFluidContainer()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->isFluidContainer());
 	} else {
 		lua_pushnil(L);
@@ -13403,8 +13112,7 @@ int LuaScriptInterface::luaItemTypeIsFluidContainer(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsMovable(lua_State* L)
 {
 	// itemType:isMovable()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->moveable);
 	} else {
 		lua_pushnil(L);
@@ -13415,8 +13123,7 @@ int LuaScriptInterface::luaItemTypeIsMovable(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsRune(lua_State* L)
 {
 	// itemType:isRune()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->isRune());
 	} else {
 		lua_pushnil(L);
@@ -13427,8 +13134,7 @@ int LuaScriptInterface::luaItemTypeIsRune(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsStackable(lua_State* L)
 {
 	// itemType:isStackable()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->stackable);
 	} else {
 		lua_pushnil(L);
@@ -13439,8 +13145,7 @@ int LuaScriptInterface::luaItemTypeIsStackable(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsReadable(lua_State* L)
 {
 	// itemType:isReadable()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->canReadText);
 	} else {
 		lua_pushnil(L);
@@ -13451,8 +13156,7 @@ int LuaScriptInterface::luaItemTypeIsReadable(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsWritable(lua_State* L)
 {
 	// itemType:isWritable()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->canWriteText);
 	} else {
 		lua_pushnil(L);
@@ -13463,8 +13167,7 @@ int LuaScriptInterface::luaItemTypeIsWritable(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsBlocking(lua_State* L)
 {
 	// itemType:isBlocking()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->blockProjectile || itemType->blockSolid);
 	} else {
 		lua_pushnil(L);
@@ -13475,8 +13178,7 @@ int LuaScriptInterface::luaItemTypeIsBlocking(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsGroundTile(lua_State* L)
 {
 	// itemType:isGroundTile()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->isGroundTile());
 	} else {
 		lua_pushnil(L);
@@ -13487,8 +13189,7 @@ int LuaScriptInterface::luaItemTypeIsGroundTile(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsMagicField(lua_State* L)
 {
 	// itemType:isMagicField()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->isMagicField());
 	} else {
 		lua_pushnil(L);
@@ -13499,8 +13200,7 @@ int LuaScriptInterface::luaItemTypeIsMagicField(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsUseable(lua_State* L)
 {
 	// itemType:isUseable()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->isUseable());
 	} else {
 		lua_pushnil(L);
@@ -13511,8 +13211,7 @@ int LuaScriptInterface::luaItemTypeIsUseable(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsPickupable(lua_State* L)
 {
 	// itemType:isPickupable()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->isPickupable());
 	} else {
 		lua_pushnil(L);
@@ -13523,8 +13222,7 @@ int LuaScriptInterface::luaItemTypeIsPickupable(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsRotatable(lua_State* L)
 {
 	// itemType:isRotatable()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->rotatable);
 	} else {
 		lua_pushnil(L);
@@ -13535,8 +13233,7 @@ int LuaScriptInterface::luaItemTypeIsRotatable(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetType(lua_State* L)
 {
 	// itemType:getType()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->type);
 	} else {
 		lua_pushnil(L);
@@ -13547,8 +13244,7 @@ int LuaScriptInterface::luaItemTypeGetType(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetGroup(lua_State* L)
 {
 	// itemType:getGroup()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->group);
 	} else {
 		lua_pushnil(L);
@@ -13559,8 +13255,7 @@ int LuaScriptInterface::luaItemTypeGetGroup(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetId(lua_State* L)
 {
 	// itemType:getId()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->id);
 	} else {
 		lua_pushnil(L);
@@ -13571,8 +13266,7 @@ int LuaScriptInterface::luaItemTypeGetId(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetClientId(lua_State* L)
 {
 	// itemType:getClientId()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->clientId);
 	} else {
 		lua_pushnil(L);
@@ -13583,7 +13277,7 @@ int LuaScriptInterface::luaItemTypeGetClientId(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetName(lua_State* L)
 {
 	// itemType:getName()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		pushString(L, itemType->name);
 	} else {
@@ -13595,8 +13289,7 @@ int LuaScriptInterface::luaItemTypeGetName(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetPluralName(lua_State* L)
 {
 	// itemType:getPluralName()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushString(L, itemType->getPluralName());
 	} else {
 		lua_pushnil(L);
@@ -13607,8 +13300,7 @@ int LuaScriptInterface::luaItemTypeGetPluralName(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetRotateTo(lua_State* L)
 {
 	// itemType:getRotateTo()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->rotateTo);
 	} else {
 		lua_pushnil(L);
@@ -13619,7 +13311,7 @@ int LuaScriptInterface::luaItemTypeGetRotateTo(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetArticle(lua_State* L)
 {
 	// itemType:getArticle()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		pushString(L, itemType->article);
 	} else {
@@ -13631,7 +13323,7 @@ int LuaScriptInterface::luaItemTypeGetArticle(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetDescription(lua_State* L)
 {
 	// itemType:getDescription()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		pushString(L, itemType->description);
 	} else {
@@ -13643,7 +13335,7 @@ int LuaScriptInterface::luaItemTypeGetDescription(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetSlotPosition(lua_State *L)
 {
 	// itemType:getSlotPosition()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushinteger(L, itemType->slotPosition);
 	} else {
@@ -13655,7 +13347,7 @@ int LuaScriptInterface::luaItemTypeGetSlotPosition(lua_State *L)
 int LuaScriptInterface::luaItemTypeGetCharges(lua_State* L)
 {
 	// itemType:getCharges()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushinteger(L, itemType->charges);
 	} else {
@@ -13667,7 +13359,7 @@ int LuaScriptInterface::luaItemTypeGetCharges(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetFluidSource(lua_State* L)
 {
 	// itemType:getFluidSource()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushinteger(L, itemType->fluidSource);
 	} else {
@@ -13679,7 +13371,7 @@ int LuaScriptInterface::luaItemTypeGetFluidSource(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetCapacity(lua_State* L)
 {
 	// itemType:getCapacity()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushinteger(L, itemType->maxItems);
 	} else {
@@ -13691,15 +13383,15 @@ int LuaScriptInterface::luaItemTypeGetCapacity(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetWeight(lua_State* L)
 {
 	// itemType:getWeight([count = 1])
-	uint16_t count = getNumber<uint16_t>(L, 2, 1);
+	const uint16_t count = getNumber<uint16_t>(L, 2, 1);
 
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (!itemType) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint64_t weight = static_cast<uint64_t>(itemType->weight) * std::max<int32_t>(1, count);
+	const uint64_t weight = static_cast<uint64_t>(itemType->weight) * std::max<int32_t>(1, count);
 	lua_pushinteger(L, weight);
 	return 1;
 }
@@ -13707,7 +13399,7 @@ int LuaScriptInterface::luaItemTypeGetWeight(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetWorth(lua_State* L)
 {
 	// itemType:getWorth()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (!itemType) {
 		lua_pushnil(L);
 		return 1;
@@ -13720,8 +13412,7 @@ int LuaScriptInterface::luaItemTypeGetWorth(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetHitChance(lua_State* L)
 {
 	// itemType:getHitChance()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->hitChance);
 	} else {
 		lua_pushnil(L);
@@ -13732,8 +13423,7 @@ int LuaScriptInterface::luaItemTypeGetHitChance(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetShootRange(lua_State* L)
 {
 	// itemType:getShootRange()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->shootRange);
 	} else {
 		lua_pushnil(L);
@@ -13744,8 +13434,7 @@ int LuaScriptInterface::luaItemTypeGetShootRange(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetAttack(lua_State* L)
 {
 	// itemType:getAttack()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->attack);
 	} else {
 		lua_pushnil(L);
@@ -13756,8 +13445,7 @@ int LuaScriptInterface::luaItemTypeGetAttack(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetAttackSpeed(lua_State* L)
 {
 	// itemType:getAttackSpeed()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->attackSpeed);
 	} else {
 		lua_pushnil(L);
@@ -13768,7 +13456,7 @@ int LuaScriptInterface::luaItemTypeGetAttackSpeed(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetClassification(lua_State* L)
 {
 	// itemType:getClassification()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		pushString(L, itemType->classification);
 	} else {
@@ -13780,7 +13468,7 @@ int LuaScriptInterface::luaItemTypeGetClassification(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetTier(lua_State* L)
 {
 	// itemType:getTier()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		pushString(L, itemType->tier);
 	} else {
@@ -13792,7 +13480,7 @@ int LuaScriptInterface::luaItemTypeGetTier(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetDefense(lua_State* L)
 {
 	// itemType:getDefense()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushinteger(L, itemType->defense);
 	} else {
@@ -13804,7 +13492,7 @@ int LuaScriptInterface::luaItemTypeGetDefense(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetExtraDefense(lua_State* L)
 {
 	// itemType:getExtraDefense()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushinteger(L, itemType->extraDefense);
 	} else {
@@ -13816,7 +13504,7 @@ int LuaScriptInterface::luaItemTypeGetExtraDefense(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetArmor(lua_State* L)
 {
 	// itemType:getArmor()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushinteger(L, itemType->armor);
 	} else {
@@ -13828,7 +13516,7 @@ int LuaScriptInterface::luaItemTypeGetArmor(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetWeaponType(lua_State* L)
 {
 	// itemType:getWeaponType()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		lua_pushinteger(L, itemType->weaponType);
 	} else {
@@ -13840,8 +13528,7 @@ int LuaScriptInterface::luaItemTypeGetWeaponType(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetAmmoType(lua_State* L)
 {
 	// itemType:getAmmoType()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->ammoType);
 	} else {
 		lua_pushnil(L);
@@ -13852,8 +13539,7 @@ int LuaScriptInterface::luaItemTypeGetAmmoType(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetShootType(lua_State* L)
 {
 	// itemType:getShootType()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->shootType);
 	}
 	else {
@@ -13867,8 +13553,7 @@ int LuaScriptInterface::luaItemTypeGetShootType(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetCorpseType(lua_State* L)
 {
 	// itemType:getCorpseType()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->corpseType);
 	} else {
 		lua_pushnil(L);
@@ -13879,8 +13564,7 @@ int LuaScriptInterface::luaItemTypeGetCorpseType(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 {
 	// itemType:getAbilities()
-	ItemType* itemType = getUserdata<ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<ItemType>(L, 1)) {
 		Abilities& abilities = itemType->getAbilities();
 		lua_createtable(L, 10, 12);
 		setField(L, "healthGain", abilities.healthGain);
@@ -13938,8 +13622,7 @@ int LuaScriptInterface::luaItemTypeGetAbilities(lua_State* L)
 int LuaScriptInterface::luaItemTypeHasShowAttributes(lua_State* L)
 {
 	// itemType:hasShowAttributes()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->showAttributes);
 	} else {
 		lua_pushnil(L);
@@ -13950,8 +13633,7 @@ int LuaScriptInterface::luaItemTypeHasShowAttributes(lua_State* L)
 int LuaScriptInterface::luaItemTypeHasShowCount(lua_State* L)
 {
 	// itemType:hasShowCount()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->showCount);
 	} else {
 		lua_pushnil(L);
@@ -13962,8 +13644,7 @@ int LuaScriptInterface::luaItemTypeHasShowCount(lua_State* L)
 int LuaScriptInterface::luaItemTypeHasShowCharges(lua_State* L)
 {
 	// itemType:hasShowCharges()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->showCharges);
 	} else {
 		lua_pushnil(L);
@@ -13974,8 +13655,7 @@ int LuaScriptInterface::luaItemTypeHasShowCharges(lua_State* L)
 int LuaScriptInterface::luaItemTypeHasShowDuration(lua_State* L)
 {
 	// itemType:hasShowDuration()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->showDuration);
 	} else {
 		lua_pushnil(L);
@@ -13986,8 +13666,7 @@ int LuaScriptInterface::luaItemTypeHasShowDuration(lua_State* L)
 int LuaScriptInterface::luaItemTypeHasAllowDistRead(lua_State* L)
 {
 	// itemType:hasAllowDistRead()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->allowDistRead);
 	} else {
 		lua_pushnil(L);
@@ -13998,8 +13677,7 @@ int LuaScriptInterface::luaItemTypeHasAllowDistRead(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetWieldInfo(lua_State* L)
 {
 	// itemType:getWieldInfo()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->wieldInfo);
 	} else {
 		lua_pushnil(L);
@@ -14010,8 +13688,7 @@ int LuaScriptInterface::luaItemTypeGetWieldInfo(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetDuration(lua_State* L)
 {
 	// itemType:getDuration()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->decayTime);
 	} else {
 		lua_pushnil(L);
@@ -14022,8 +13699,7 @@ int LuaScriptInterface::luaItemTypeGetDuration(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetLevelDoor(lua_State* L)
 {
 	// itemType:getLevelDoor()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->levelDoor);
 	} else {
 		lua_pushnil(L);
@@ -14034,7 +13710,7 @@ int LuaScriptInterface::luaItemTypeGetLevelDoor(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetVocationString(lua_State* L)
 {
 	// itemType:getVocationString()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (itemType) {
 		pushString(L, itemType->vocationString);
 	} else {
@@ -14046,8 +13722,7 @@ int LuaScriptInterface::luaItemTypeGetVocationString(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetMinReqLevel(lua_State* L)
 {
 	// itemType:getMinReqLevel()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->minReqLevel);
 	} else {
 		lua_pushnil(L);
@@ -14058,8 +13733,7 @@ int LuaScriptInterface::luaItemTypeGetMinReqLevel(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetMinReqMagicLevel(lua_State* L)
 {
 	// itemType:getMinReqMagicLevel()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->minReqMagicLevel);
 	} else {
 		lua_pushnil(L);
@@ -14070,14 +13744,13 @@ int LuaScriptInterface::luaItemTypeGetMinReqMagicLevel(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetElementType(lua_State* L)
 {
 	// itemType:getElementType()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (!itemType) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	auto& abilities = itemType->abilities;
-	if (abilities) {
+	if (auto& abilities = itemType->abilities) {
 		lua_pushinteger(L, abilities->elementType);
 	} else {
 		lua_pushnil(L);
@@ -14088,14 +13761,13 @@ int LuaScriptInterface::luaItemTypeGetElementType(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetElementDamage(lua_State* L)
 {
 	// itemType:getElementDamage()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
+	const auto itemType = getUserdata<const ItemType>(L, 1);
 	if (!itemType) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	auto& abilities = itemType->abilities;
-	if (abilities) {
+	if (auto& abilities = itemType->abilities) {
 		lua_pushinteger(L, abilities->elementDamage);
 	} else {
 		lua_pushnil(L);
@@ -14106,8 +13778,7 @@ int LuaScriptInterface::luaItemTypeGetElementDamage(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetTransformEquipId(lua_State* L)
 {
 	// itemType:getTransformEquipId()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->transformEquipTo);
 	} else {
 		lua_pushnil(L);
@@ -14118,8 +13789,7 @@ int LuaScriptInterface::luaItemTypeGetTransformEquipId(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetTransformDeEquipId(lua_State* L)
 {
 	// itemType:getTransformDeEquipId()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->transformDeEquipTo);
 	} else {
 		lua_pushnil(L);
@@ -14130,8 +13800,7 @@ int LuaScriptInterface::luaItemTypeGetTransformDeEquipId(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetDestroyId(lua_State* L)
 {
 	// itemType:getDestroyId()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->destroyTo);
 	} else {
 		lua_pushnil(L);
@@ -14142,8 +13811,7 @@ int LuaScriptInterface::luaItemTypeGetDestroyId(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetDecayId(lua_State* L)
 {
 	// itemType:getDecayId()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->decayTo);
 	} else {
 		lua_pushnil(L);
@@ -14154,8 +13822,7 @@ int LuaScriptInterface::luaItemTypeGetDecayId(lua_State* L)
 int LuaScriptInterface::luaItemTypeGetRequiredLevel(lua_State* L)
 {
 	// itemType:getRequiredLevel()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		lua_pushinteger(L, itemType->minReqLevel);
 	} else {
 		lua_pushnil(L);
@@ -14166,8 +13833,7 @@ int LuaScriptInterface::luaItemTypeGetRequiredLevel(lua_State* L)
 int LuaScriptInterface::luaItemTypeHasSubType(lua_State* L)
 {
 	// itemType:hasSubType()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->hasSubType());
 	} else {
 		lua_pushnil(L);
@@ -14178,8 +13844,7 @@ int LuaScriptInterface::luaItemTypeHasSubType(lua_State* L)
 int LuaScriptInterface::luaItemTypeIsStoreItem(lua_State* L)
 {
 	// itemType:isStoreItem()
-	const ItemType* itemType = getUserdata<const ItemType>(L, 1);
-	if (itemType) {
+	if (const auto itemType = getUserdata<const ItemType>(L, 1)) {
 		pushBoolean(L, itemType->storeItem);
 	} else {
 		lua_pushnil(L);
@@ -14198,8 +13863,7 @@ int LuaScriptInterface::luaCombatCreate(lua_State* L)
 
 int LuaScriptInterface::luaCombatDelete(lua_State* L)
 {
-	Combat_ptr& combat = getSharedPtr<Combat>(L, 1);
-	if (combat) {
+	if (Combat_ptr& combat = getSharedPtr<Combat>(L, 1)) {
 		combat.reset();
 	}
 	return 0;
@@ -14390,12 +14054,12 @@ int LuaScriptInterface::luaCombatExecute(lua_State* L)
 		}
 	}
 
-	Creature* creature = getCreature(L, 2);
+	auto creature = getCreature(L, 2);
 
 	const LuaVariant& variant = getVariant(L, 3);
 	switch (variant.type()) {
 		case VARIANT_NUMBER: {
-			Creature* target = g_game.getCreatureByID(variant.getNumber());
+			const auto target = g_game.getCreatureByID(variant.getNumber());
 			if (!target) {
 				pushBoolean(L, false);
 				return 1;
@@ -14425,7 +14089,7 @@ int LuaScriptInterface::luaCombatExecute(lua_State* L)
 		}
 
 		case VARIANT_STRING: {
-			Player* target = g_game.getPlayerByName(variant.getString());
+			const auto target = g_game.getPlayerByName(variant.getString());
 			if (!target) {
 				pushBoolean(L, false);
 				return 1;
@@ -16268,13 +15932,13 @@ int LuaScriptInterface::luaMonsterSpellSetOutfit(lua_State* L)
 int32_t LuaScriptInterface::luaPartyCreate(lua_State* L)
 {
 	// Party(userdata)
-	Player* player = getUserdata<Player>(L, 2);
+	auto player = getSharedPtr<Player>(L, 2);
 	if (!player) {
 		lua_pushnil(L);
 		return 1;
 	}
 
-	Party* party = player->getParty();
+	auto party = player->getParty();
 	if (!party) {
 		party = new Party(player);
 		g_game.updatePlayerShield(player);
@@ -16311,9 +15975,8 @@ int LuaScriptInterface::luaPartyGetLeader(lua_State* L)
 		return 1;
 	}
 
-	Player* leader = party->getLeader();
-	if (leader) {
-		pushUserdata<Player>(L, leader);
+	if (const auto leader = party->getLeader()) {
+		pushSharedPtr(L, leader);
 		setMetatable(L, -1, "Player");
 	} else {
 		lua_pushnil(L);
@@ -16324,8 +15987,8 @@ int LuaScriptInterface::luaPartyGetLeader(lua_State* L)
 int LuaScriptInterface::luaPartySetLeader(lua_State* L)
 {
 	// party:setLeader(player)
-	Player* player = getPlayer(L, 2);
-	Party* party = getUserdata<Party>(L, 1);
+	const auto player = getPlayer(L, 2);
+	const auto party = getUserdata<Party>(L, 1);
 	if (party && player) {
 		pushBoolean(L, party->passPartyLeadership(player, true));
 	} else {
@@ -16345,8 +16008,8 @@ int LuaScriptInterface::luaPartyGetMembers(lua_State* L)
 
 	int index = 0;
 	lua_createtable(L, party->getMemberCount(), 0);
-	for (Player* player : party->getMembers()) {
-		pushUserdata<Player>(L, player);
+	for (const auto player : party->getMembers()) {
+		pushSharedPtr(L, player);
 		setMetatable(L, -1, "Player");
 		lua_rawseti(L, -2, ++index);
 	}
@@ -16368,13 +16031,12 @@ int LuaScriptInterface::luaPartyGetMemberCount(lua_State* L)
 int LuaScriptInterface::luaPartyGetInvitees(lua_State* L)
 {
 	// party:getInvitees()
-	Party* party = getUserdata<Party>(L, 1);
-	if (party) {
+	if (const auto party = getUserdata<Party>(L, 1)) {
 		lua_createtable(L, party->getInvitationCount(), 0);
 
 		int index = 0;
-		for (Player* player : party->getInvitees()) {
-			pushUserdata<Player>(L, player);
+		for (const auto player : party->getInvitees()) {
+			pushSharedPtr(L, player);
 			setMetatable(L, -1, "Player");
 			lua_rawseti(L, -2, ++index);
 		}
@@ -16387,7 +16049,7 @@ int LuaScriptInterface::luaPartyGetInvitees(lua_State* L)
 int LuaScriptInterface::luaPartyGetInviteeCount(lua_State* L)
 {
 	// party:getInviteeCount()
-	Party* party = getUserdata<Party>(L, 1);
+	const auto party = getUserdata<Party>(L, 1);
 	if (party) {
 		lua_pushinteger(L, party->getInvitationCount());
 	} else {
@@ -16399,10 +16061,10 @@ int LuaScriptInterface::luaPartyGetInviteeCount(lua_State* L)
 int LuaScriptInterface::luaPartyAddInvite(lua_State* L)
 {
 	// party:addInvite(player)
-	Player* player = getPlayer(L, 2);
-	Party* party = getUserdata<Party>(L, 1);
+	auto player = getPlayer(L, 2);
+	const auto party = getUserdata<Party>(L, 1);
 	if (party && player) {
-		pushBoolean(L, party->invitePlayer(*player));
+		pushBoolean(L, party->invitePlayer(player));
 	} else {
 		lua_pushnil(L);
 	}
@@ -16412,10 +16074,10 @@ int LuaScriptInterface::luaPartyAddInvite(lua_State* L)
 int LuaScriptInterface::luaPartyRemoveInvite(lua_State* L)
 {
 	// party:removeInvite(player)
-	Player* player = getPlayer(L, 2);
-	Party* party = getUserdata<Party>(L, 1);
+	auto player = getPlayer(L, 2);
+	const auto party = getUserdata<Party>(L, 1);
 	if (party && player) {
-		pushBoolean(L, party->removeInvite(*player));
+		pushBoolean(L, party->removeInvite(player));
 	} else {
 		lua_pushnil(L);
 	}
@@ -16425,10 +16087,10 @@ int LuaScriptInterface::luaPartyRemoveInvite(lua_State* L)
 int LuaScriptInterface::luaPartyAddMember(lua_State* L)
 {
 	// party:addMember(player)
-	Player* player = getPlayer(L, 2);
-	Party* party = getUserdata<Party>(L, 1);
+	auto player = getPlayer(L, 2);
+	const auto party = getUserdata<Party>(L, 1);
 	if (party && player) {
-		pushBoolean(L, party->joinParty(*player));
+		pushBoolean(L, party->joinParty(player));
 	} else {
 		lua_pushnil(L);
 	}
@@ -16438,8 +16100,8 @@ int LuaScriptInterface::luaPartyAddMember(lua_State* L)
 int LuaScriptInterface::luaPartyRemoveMember(lua_State* L)
 {
 	// party:removeMember(player)
-	Player* player = getPlayer(L, 2);
-	Party* party = getUserdata<Party>(L, 1);
+	const auto player = getPlayer(L, 2);
+	const auto party = getUserdata<Party>(L, 1);
 	if (party && player) {
 		pushBoolean(L, party->leaveParty(player));
 	} else {
@@ -16451,8 +16113,7 @@ int LuaScriptInterface::luaPartyRemoveMember(lua_State* L)
 int LuaScriptInterface::luaPartyIsSharedExperienceActive(lua_State* L)
 {
 	// party:isSharedExperienceActive()
-	Party* party = getUserdata<Party>(L, 1);
-	if (party) {
+	if (const auto party = getUserdata<Party>(L, 1)) {
 		pushBoolean(L, party->isSharedExperienceActive());
 	} else {
 		lua_pushnil(L);
@@ -16463,8 +16124,7 @@ int LuaScriptInterface::luaPartyIsSharedExperienceActive(lua_State* L)
 int LuaScriptInterface::luaPartyIsSharedExperienceEnabled(lua_State* L)
 {
 	// party:isSharedExperienceEnabled()
-	Party* party = getUserdata<Party>(L, 1);
-	if (party) {
+	if (const auto party = getUserdata<Party>(L, 1)) {
 		pushBoolean(L, party->isSharedExperienceEnabled());
 	} else {
 		lua_pushnil(L);
@@ -16476,8 +16136,7 @@ int LuaScriptInterface::luaPartyShareExperience(lua_State* L)
 {
 	// party:shareExperience(experience)
 	uint64_t experience = getNumber<uint64_t>(L, 2);
-	Party* party = getUserdata<Party>(L, 1);
-	if (party) {
+	if (const auto party = getUserdata<Party>(L, 1)) {
 		party->shareExperience(experience);
 		pushBoolean(L, true);
 	} else {
@@ -16489,9 +16148,8 @@ int LuaScriptInterface::luaPartyShareExperience(lua_State* L)
 int LuaScriptInterface::luaPartySetSharedExperience(lua_State* L)
 {
 	// party:setSharedExperience(active)
-	bool active = getBoolean(L, 2);
-	Party* party = getUserdata<Party>(L, 1);
-	if (party) {
+	const bool active = getBoolean(L, 2);
+	if (const auto party = getUserdata<Party>(L, 1)) {
 		pushBoolean(L, party->setSharedExperience(party->getLeader(), active));
 	} else {
 		lua_pushnil(L);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -288,7 +288,7 @@ int LuaScriptInterface::protectedCall(lua_State* L, int nargs, int nresults)
 	return ret;
 }
 
-int32_t LuaScriptInterface::loadFile(const std::string& file, std::optional<NpcPtr> npc /* = std::nullopt*/)
+int32_t LuaScriptInterface::loadFile(const std::string& file, NpcPtr npc /* = std::nullopt*/)
 {
 	//loads file as a chunk at stack top
 	int ret = luaL_loadfile(luaState, file.c_str());
@@ -312,11 +312,7 @@ int32_t LuaScriptInterface::loadFile(const std::string& file, std::optional<NpcP
 
 	ScriptEnvironment* env = getScriptEnv();
 	env->setScriptId(EVENT_ID_LOADING, this);
-	if (npc.has_value()) {
-		// probably need to use move here??
-		env->setNpc(npc.value());
-	}
-	
+	env->setNpc(npc);
 
 	//execute it
 	ret = protectedCall(luaState, 0, 0);

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -7172,7 +7172,7 @@ int LuaScriptInterface::luaItemMoveTo(lua_State* L)
 	} else {
 		ItemPtr moveItem = nullptr;
 		CylinderPtr i_parent = item->getParent();
-		ReturnValue ret = g_game.internalMoveItem(i_parent, toCylinder, INDEX_WHEREEVER, item, item->getItemCount(), &moveItem, flags);
+		ReturnValue ret = g_game.internalMoveItem(i_parent, toCylinder, INDEX_WHEREEVER, item, item->getItemCount(), std::ref(moveItem), flags);
 		if (moveItem) {
 			itemPtr = moveItem;
 		}

--- a/src/luascript.cpp
+++ b/src/luascript.cpp
@@ -2211,6 +2211,7 @@ void LuaScriptInterface::registerFunctions()
 	// Tile
 	registerClass("Tile", "", LuaScriptInterface::luaTileCreate);
 	registerMetaMethod("Tile", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Tile", "__gc", LuaScriptInterface::luaTileDelete);
 
 	registerMethod("Tile", "remove", LuaScriptInterface::luaTileRemove);
 
@@ -2316,6 +2317,7 @@ void LuaScriptInterface::registerFunctions()
 	// Item
 	registerClass("Item", "", LuaScriptInterface::luaItemCreate);
 	registerMetaMethod("Item", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Item", "__gc", LuaScriptInterface::luaItemDelete);
 
 	registerMethod("Item", "isItem", LuaScriptInterface::luaItemIsItem);
 
@@ -2426,6 +2428,7 @@ void LuaScriptInterface::registerFunctions()
 	// Container
 	registerClass("Container", "Item", LuaScriptInterface::luaContainerCreate);
 	registerMetaMethod("Container", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Container", "__gc", LuaScriptInterface::luaContainerDelete);
 
 	registerMethod("Container", "getSize", LuaScriptInterface::luaContainerGetSize);
 	registerMethod("Container", "getCapacity", LuaScriptInterface::luaContainerGetCapacity);
@@ -2444,6 +2447,7 @@ void LuaScriptInterface::registerFunctions()
 	// Teleport
 	registerClass("Teleport", "Item", LuaScriptInterface::luaTeleportCreate);
 	registerMetaMethod("Teleport", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Teleport", "__gc", LuaScriptInterface::luaTeleportDelete);
 
 	registerMethod("Teleport", "getDestination", LuaScriptInterface::luaTeleportGetDestination);
 	registerMethod("Teleport", "setDestination", LuaScriptInterface::luaTeleportSetDestination);
@@ -2451,6 +2455,7 @@ void LuaScriptInterface::registerFunctions()
 	// Creature
 	registerClass("Creature", "", LuaScriptInterface::luaCreatureCreate);
 	registerMetaMethod("Creature", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Creature", "__gc", LuaScriptInterface::luaCreatureDelete);
 
 	registerMethod("Creature", "getEvents", LuaScriptInterface::luaCreatureGetEvents);
 	registerMethod("Creature", "registerEvent", LuaScriptInterface::luaCreatureRegisterEvent);
@@ -2534,6 +2539,7 @@ void LuaScriptInterface::registerFunctions()
 	// Player
 	registerClass("Player", "Creature", LuaScriptInterface::luaPlayerCreate);
 	registerMetaMethod("Player", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Player", "__gc", LuaScriptInterface::luaPlayerDelete);
 
 	registerMethod("Player", "isPlayer", LuaScriptInterface::luaPlayerIsPlayer);
 
@@ -2721,6 +2727,7 @@ void LuaScriptInterface::registerFunctions()
 	// Monster
 	registerClass("Monster", "Creature", LuaScriptInterface::luaMonsterCreate);
 	registerMetaMethod("Monster", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Monster", "__gc", LuaScriptInterface::luaMonsterDelete);
 
 	registerMethod("Monster", "getId", LuaScriptInterface::luaMonsterGetId);
 	registerMethod("Monster", "isMonster", LuaScriptInterface::luaMonsterIsMonster);
@@ -2758,6 +2765,7 @@ void LuaScriptInterface::registerFunctions()
 	// Npc
 	registerClass("Npc", "Creature", LuaScriptInterface::luaNpcCreate);
 	registerMetaMethod("Npc", "__eq", LuaScriptInterface::luaUserdataCompare);
+	registerMetaMethod("Npc", "__gc", LuaScriptInterface::luaNpcDelete);
 
 	registerMethod("Npc", "isNpc", LuaScriptInterface::luaNpcIsNpc);
 
@@ -5351,6 +5359,14 @@ int LuaScriptInterface::luaTileCreate(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaTileDelete(lua_State* L) 
+{
+	if (auto& tile = getSharedPtr<Tile>(L, 1)) {
+		tile.reset();
+	}
+	return 0;
+}
+
 int LuaScriptInterface::luaTileRemove(lua_State* L)
 {
 	// tile:remove()
@@ -6589,6 +6605,14 @@ int LuaScriptInterface::luaItemCreate(lua_State* L)
 		lua_pushnil(L);
 	}
 	return 1;
+}
+
+int LuaScriptInterface::luaItemDelete(lua_State* L)
+{
+	if (auto& item = getSharedPtr<Item>(L, 1)) {
+		item.reset();
+	}
+	return 0;
 }
 
 int LuaScriptInterface::luaItemIsItem(lua_State* L)
@@ -8058,6 +8082,14 @@ int LuaScriptInterface::luaContainerCreate(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaContainerDelete(lua_State* L)
+{
+	if (auto& container = getSharedPtr<Container>(L, 1)) {
+		container.reset();
+	}
+	return 0;
+}
+
 int LuaScriptInterface::luaContainerGetSize(lua_State* L)
 {
 	// container:getSize()
@@ -8342,6 +8374,14 @@ int LuaScriptInterface::luaTeleportCreate(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaTeleportDelete(lua_State* L)
+{
+	if (auto& teleport = getSharedPtr<Teleport>(L, 1)) {
+		teleport.reset();
+	}
+	return 0;
+}
+
 int LuaScriptInterface::luaTeleportGetDestination(lua_State* L)
 {
 	// teleport:getDestination()
@@ -8391,6 +8431,14 @@ int LuaScriptInterface::luaCreatureCreate(lua_State* L)
 		lua_pushnil(L);
 	}
 	return 1;
+}
+
+int LuaScriptInterface::luaCreatureDelete(lua_State* L)
+{
+	if (auto& creature = getSharedPtr<Creature>(L, 1)) {
+		creature.reset();
+	}
+	return 0;
 }
 
 int LuaScriptInterface::luaCreatureGetEvents(lua_State* L)
@@ -9349,6 +9397,14 @@ int LuaScriptInterface::luaPlayerCreate(lua_State* L)
 		lua_pushnil(L);
 	}
 	return 1;
+}
+
+int LuaScriptInterface::luaPlayerDelete(lua_State* L)
+{
+	if (auto& player = getSharedPtr<Player>(L, 1)) {
+		player.reset();
+	}
+	return 0;
 }
 
 int LuaScriptInterface::luaPlayerIsPlayer(lua_State* L)
@@ -11599,10 +11655,18 @@ int LuaScriptInterface::luaMonsterCreate(lua_State* L)
 	return 1;
 }
 
+int LuaScriptInterface::luaMonsterDelete(lua_State* L)
+{
+	if (auto& monster = getSharedPtr<Monster>(L, 1)) {
+		monster.reset();
+	}
+	return 0;
+}
+
 int LuaScriptInterface::luaMonsterGetId(lua_State* L)
 {
 	// monster:getId()
-	if (const auto monster = getSharedPtr<Monster>(L, 1)) {
+	if (auto& monster = getSharedPtr<Monster>(L, 1)) {
 		// Set monster id if it's not set yet (only for onSpawn event)
 		if (getScriptEnv()->getScriptId() == g_events->getScriptId(EventInfoId::MONSTER_ONSPAWN)) {
 			monster->setID();
@@ -11980,6 +12044,14 @@ int LuaScriptInterface::luaNpcCreate(lua_State* L)
 		lua_pushnil(L);
 	}
 	return 1;
+}
+
+int LuaScriptInterface::luaNpcDelete(lua_State* L)
+{
+	if (auto& npc = getSharedPtr<Npc>(L, 1)) {
+		npc.reset();
+	}
+	return 0;
 }
 
 int LuaScriptInterface::luaNpcIsNpc(lua_State* L)

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -129,7 +129,7 @@ class ScriptEnvironment
 		static uint32_t addResult(const DBResult_ptr& res);
 		static bool removeResult(uint32_t id);
 
-		void setNpc(const NpcPtr& npc) {
+		void setNpc(NpcPtr npc) {
 			curNpc = npc;
 		}
 	
@@ -200,7 +200,7 @@ class LuaScriptInterface
 		virtual bool initState();
 		bool reInitState();
 
-		int32_t loadFile(const std::string& file, std::optional<NpcPtr> npc = std::nullopt);
+		int32_t loadFile(const std::string& file, NpcPtr npc = nullptr);
 
 		const std::string& getFileById(int32_t scriptId);
 		int32_t getEvent(std::string_view eventName);

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -27,20 +27,17 @@
 #include "mounts.h"
 #include "luavariant.h"
 #include <fmt/format.h>
+#include "declarations.h"
 
-class Thing;
-class Creature;
-class Player;
-class Item;
-class Container;
 class AreaCombat;
 class Combat;
 using Combat_ptr = std::shared_ptr<Combat>;
 class Condition;
-class Npc;
-class Monster;
 class InstantSpell;
 class Spell;
+class LuaScriptInterface;
+class Game;
+struct LootBlock;
 
 template<typename T>
 concept EnumType = std::is_enum_v<T> && !std::is_same_v<T, bool>;
@@ -89,62 +86,6 @@ struct LuaTimerEventDesc {
 	LuaTimerEventDesc() = default;
 	LuaTimerEventDesc(LuaTimerEventDesc&& other) = default;
 };
-
-class LuaScriptInterface;
-class Cylinder;
-class Game;
-
-using PlayerPtr = std::shared_ptr<Player>;
-using PlayerConstPtr = std::shared_ptr<const Player>;
-
-using MonsterPtr = std::shared_ptr<Monster>;
-using MonsterConstPtr = std::shared_ptr<const Monster>;
-
-using NpcPtr = std::shared_ptr<Npc>;
-using NpcConstPtr = std::shared_ptr<const Npc>;
-class Depot;
-using DepotPtr = std::shared_ptr<Depot>;
-using DepotConstPtr = std::shared_ptr<const Depot>;
-class Teleport;
-using TeleportPtr = std::shared_ptr<Teleport>;
-using TeleportConstPtr = std::shared_ptr<const Teleport>;
-class TrashHolder;
-using TrashHolderPtr = std::shared_ptr<TrashHolder>;
-using TrashHolderConstPtr = std::shared_ptr<const TrashHolder>;
-class Mailbox;
-using MailboxPtr = std::shared_ptr<Mailbox>;
-using MailboxConstPtr = std::shared_ptr<const Mailbox>;
-class Door;
-using DoorPtr = std::shared_ptr<Door>;
-using DoorConstPtr = std::shared_ptr<const Door>;
-class MagicField;
-using MagicFieldPtr = std::shared_ptr<MagicField>;
-using MagicFieldConstPtr = std::shared_ptr<const MagicField>;
-class BedItem;
-using BedItemPtr = std::shared_ptr<BedItem>;
-using BedItemConstPtr = std::shared_ptr<const BedItem>;
-
-using ThingPtr = std::shared_ptr<class Thing>;
-using ThingConstPtr = std::shared_ptr<const class Thing>;
-class Tile;
-using TilePtr = std::shared_ptr<Tile>;
-using TileConstPtr = std::shared_ptr<const Tile>;
-using TileWeakPtr = std::weak_ptr<Tile>;
-
-using CylinderPtr = std::shared_ptr<Cylinder>;
-using CylinderConstPtr = std::shared_ptr<const Cylinder>;
-using CylinderWeakPtr = std::weak_ptr<Cylinder>;
-
-using ItemPtr = std::shared_ptr<Item>;
-using ItemConstPtr = std::shared_ptr<const Item>;
-class Container;
-using ContainerPtr = std::shared_ptr<Container>;
-using ContainerConstPtr = std::shared_ptr<const Container>;
-class Creature;
-using CreaturePtr = std::shared_ptr<Creature>;
-using CreatureConstPtr = std::shared_ptr<const Creature>;
-
-struct LootBlock;
 
 class ScriptEnvironment
 {

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -94,6 +94,56 @@ class LuaScriptInterface;
 class Cylinder;
 class Game;
 
+using PlayerPtr = std::shared_ptr<Player>;
+using PlayerConstPtr = std::shared_ptr<const Player>;
+
+using MonsterPtr = std::shared_ptr<Monster>;
+using MonsterConstPtr = std::shared_ptr<const Monster>;
+
+using NpcPtr = std::shared_ptr<Npc>;
+using NpcConstPtr = std::shared_ptr<const Npc>;
+class Depot;
+using DepotPtr = std::shared_ptr<Depot>;
+using DepotConstPtr = std::shared_ptr<const Depot>;
+class Teleport;
+using TeleportPtr = std::shared_ptr<Teleport>;
+using TeleportConstPtr = std::shared_ptr<const Teleport>;
+class TrashHolder;
+using TrashHolderPtr = std::shared_ptr<TrashHolder>;
+using TrashHolderConstPtr = std::shared_ptr<const TrashHolder>;
+class Mailbox;
+using MailboxPtr = std::shared_ptr<Mailbox>;
+using MailboxConstPtr = std::shared_ptr<const Mailbox>;
+class Door;
+using DoorPtr = std::shared_ptr<Door>;
+using DoorConstPtr = std::shared_ptr<const Door>;
+class MagicField;
+using MagicFieldPtr = std::shared_ptr<MagicField>;
+using MagicFieldConstPtr = std::shared_ptr<const MagicField>;
+class BedItem;
+using BedItemPtr = std::shared_ptr<BedItem>;
+using BedItemConstPtr = std::shared_ptr<const BedItem>;
+
+using ThingPtr = std::shared_ptr<class Thing>;
+using ThingConstPtr = std::shared_ptr<const class Thing>;
+class Tile;
+using TilePtr = std::shared_ptr<Tile>;
+using TileConstPtr = std::shared_ptr<const Tile>;
+using TileWeakPtr = std::weak_ptr<Tile>;
+
+using CylinderPtr = std::shared_ptr<Cylinder>;
+using CylinderConstPtr = std::shared_ptr<const Cylinder>;
+using CylinderWeakPtr = std::weak_ptr<Cylinder>;
+
+using ItemPtr = std::shared_ptr<Item>;
+using ItemConstPtr = std::shared_ptr<const Item>;
+class Container;
+using ContainerPtr = std::shared_ptr<Container>;
+using ContainerConstPtr = std::shared_ptr<const Container>;
+class Creature;
+using CreaturePtr = std::shared_ptr<Creature>;
+using CreatureConstPtr = std::shared_ptr<const Creature>;
+
 struct LootBlock;
 
 class ScriptEnvironment
@@ -112,12 +162,14 @@ class ScriptEnvironment
 			this->scriptId = scriptId;
 			interface = scriptInterface;
 		}
+	
 		bool setCallbackId(int32_t callbackId, LuaScriptInterface* scriptInterface);
 
 		int32_t getScriptId() const {
 			return scriptId;
 		}
-		LuaScriptInterface* getScriptInterface() {
+	
+		LuaScriptInterface* getScriptInterface() const {
 			return interface;
 		}
 
@@ -127,25 +179,26 @@ class ScriptEnvironment
 
 		void getEventInfo(int32_t& scriptId, LuaScriptInterface*& scriptInterface, int32_t& callbackId, bool& timerEvent) const;
 
-		void addTempItem(Item* item);
-		static void removeTempItem(Item* item);
-		uint32_t addThing(Thing* thing);
-		void insertItem(uint32_t uid, Item* item);
+		void addTempItem(const ItemPtr& item);
+		static void removeTempItem(const ItemPtr& item);
+		uint32_t addThing(const ThingPtr& thing);
+		void insertItem(uint32_t uid, const ItemPtr& item);
 
 		static DBResult_ptr getResultByID(uint32_t id);
-		static uint32_t addResult(DBResult_ptr res);
+		static uint32_t addResult(const DBResult_ptr& res);
 		static bool removeResult(uint32_t id);
 
-		void setNpc(Npc* npc) {
+		void setNpc(const NpcPtr& npc) {
 			curNpc = npc;
 		}
-		Npc* getNpc() const {
+	
+		NpcPtr getNpc() const {
 			return curNpc;
 		}
 
-		Thing* getThingByUID(uint32_t uid);
-		Item* getItemByUID(uint32_t uid);
-		Container* getContainerByUID(uint32_t uid);
+		ThingPtr getThingByUID(uint32_t uid);
+		ItemPtr getItemByUID(uint32_t uid);
+		ContainerPtr getContainerByUID(uint32_t uid);
 		void removeItemByUID(uint32_t uid);
 
 	private:
@@ -156,13 +209,13 @@ class ScriptEnvironment
 		LuaScriptInterface* interface;
 
 		//for npc scripts
-		Npc* curNpc = nullptr;
+		NpcPtr curNpc = nullptr;
 
 		//temporary item list
-		static std::multimap<ScriptEnvironment*, Item*> tempItems;
+		static std::multimap<ScriptEnvironment*, ItemPtr> tempItems;
 
 		//local item map
-		std::unordered_map<uint32_t, Item*> localMap;
+		std::unordered_map<uint32_t, ItemPtr> localMap;
 		uint32_t lastUID = std::numeric_limits<uint16_t>::max();
 
 		//script file id
@@ -206,7 +259,7 @@ class LuaScriptInterface
 		virtual bool initState();
 		bool reInitState();
 
-		int32_t loadFile(const std::string& file, Npc* npc = nullptr);
+		int32_t loadFile(const std::string& file, std::optional<NpcPtr> npc = std::nullopt);
 
 		const std::string& getFileById(int32_t scriptId);
 		int32_t getEvent(std::string_view eventName);
@@ -232,6 +285,7 @@ class LuaScriptInterface
 		const std::string& getInterfaceName() const {
 			return interfaceName;
 		}
+	
 		const std::string& getLastLuaError() const {
 			return lastLuaError;
 		}
@@ -240,18 +294,18 @@ class LuaScriptInterface
 			return luaState;
 		}
 
-		bool pushFunction(int32_t functionId);
+		bool pushFunction(int32_t functionId) const;
 
 		static int luaErrorHandler(lua_State* L);
-		bool callFunction(int params);
-		void callVoidFunction(int params);
+		bool callFunction(int params) const;
+		void callVoidFunction(int params) const;
 
 		//push/pop common structures
-		static void pushThing(lua_State* L, Thing* thing);
+		static void pushThing(lua_State* L, const ThingPtr& thing);
 		static void pushVariant(lua_State* L, const LuaVariant& var);
 		static void pushString(lua_State* L, std::string_view value);
 		static void pushCallback(lua_State* L, int32_t callback);
-		static void pushCylinder(lua_State* L, Cylinder* cylinder);
+		static void pushCylinder(lua_State* L, const CylinderPtr& cylinder);
 
 		static std::string popString(lua_State* L);
 		static int32_t popCallback(lua_State* L);
@@ -275,8 +329,8 @@ class LuaScriptInterface
 		static void setMetatable(lua_State* L, int32_t index, const std::string& name);
 		static void setWeakMetatable(lua_State* L, int32_t index, const std::string& name);
 
-		static void setItemMetatable(lua_State* L, int32_t index, const Item* item);
-		static void setCreatureMetatable(lua_State* L, int32_t index, const Creature* creature);
+		static void setItemMetatable(lua_State* L, int32_t index, const ItemConstPtr& item);
+		static void setCreatureMetatable(lua_State* L, int32_t index, const CreatureConstPtr& creature);
 
 		// Get
 		template<typename T>
@@ -319,6 +373,7 @@ class LuaScriptInterface
 			}
 			return getNumber<T>(L, arg);
 		}
+	
 		template<class T>
 		static T* getUserdata(lua_State* L, int32_t arg)
 		{
@@ -328,11 +383,13 @@ class LuaScriptInterface
 			}
 			return *userdata;
 		}
+	
 		template<class T>
 		static T** getRawUserdata(lua_State* L, int32_t arg)
 		{
 			return static_cast<T**>(lua_touserdata(L, arg));
 		}
+	
 		template<class T>
 		static std::shared_ptr<T>& getSharedPtr(lua_State* L, int32_t arg)
 		{
@@ -343,6 +400,7 @@ class LuaScriptInterface
 		{
 			return lua_toboolean(L, arg) != 0;
 		}
+	
 		static bool getBoolean(lua_State* L, int32_t arg, bool defaultValue)
 		{
 			const auto parameters = lua_gettop(L);
@@ -360,9 +418,9 @@ class LuaScriptInterface
 	
 		static InstantSpell* getInstantSpell(lua_State* L, int32_t arg);
 
-		static Thing* getThing(lua_State* L, int32_t arg);
-		static Creature* getCreature(lua_State* L, int32_t arg);
-		static Player* getPlayer(lua_State* L, int32_t arg);
+		static ThingPtr getThing(lua_State* L, int32_t arg);
+		static CreaturePtr getCreature(lua_State* L, int32_t arg);
+		static PlayerPtr getPlayer(lua_State* L, int32_t arg);
 
 		template<typename T>
 		static T getField(lua_State* L, int32_t arg, const std::string& key)
@@ -387,22 +445,27 @@ class LuaScriptInterface
 		{
 			return lua_type(L, arg) == LUA_TNUMBER;
 		}
+	
 		static bool isString(lua_State* L, int32_t arg)
 		{
 			return lua_isstring(L, arg) != 0;
 		}
+	
 		static bool isBoolean(lua_State* L, int32_t arg)
 		{
 			return lua_isboolean(L, arg);
 		}
+	
 		static bool isTable(lua_State* L, int32_t arg)
 		{
 			return lua_istable(L, arg);
 		}
+	
 		static bool isFunction(lua_State* L, int32_t arg)
 		{
 			return lua_isfunction(L, arg);
 		}
+	
 		static bool isUserdata(lua_State* L, int32_t arg)
 		{
 			return lua_isuserdata(L, arg) != 0;
@@ -459,7 +522,7 @@ class LuaScriptInterface
 
 		void registerFunctions();
 
-		void registerMethod(const std::string& globalName, const std::string& methodName, lua_CFunction func);
+		void registerMethod(const std::string& globalName, const std::string& methodName, lua_CFunction func) const;
 
 		static std::string getErrorDesc(ErrorCode_t code);
 
@@ -472,13 +535,13 @@ class LuaScriptInterface
 		std::map<int32_t, std::string> cacheFiles;
 
 	private:
-		void registerClass(const std::string& className, const std::string& baseClass, lua_CFunction newFunction = nullptr);
-		void registerTable(const std::string& tableName);
-		void registerMetaMethod(const std::string& className, const std::string& methodName, lua_CFunction func);
-		void registerGlobalMethod(const std::string& functionName, lua_CFunction func);
-		void registerVariable(const std::string& tableName, const std::string& name, lua_Number value);
-		void registerGlobalVariable(const std::string& name, lua_Number value);
-		void registerGlobalBoolean(const std::string& name, bool value);
+		void registerClass(const std::string& className, const std::string& baseClass, lua_CFunction newFunction = nullptr) const;
+		void registerTable(const std::string& tableName) const;
+		void registerMetaMethod(const std::string& className, const std::string& methodName, lua_CFunction func) const;
+		void registerGlobalMethod(const std::string& functionName, lua_CFunction func) const;
+		void registerVariable(const std::string& tableName, const std::string& name, lua_Number value) const;
+		void registerGlobalVariable(const std::string& name, lua_Number value) const;
+		void registerGlobalBoolean(const std::string& name, bool value) const;
 
 		static std::string getStackTrace(lua_State* L, const std::string& error_desc);
 
@@ -1715,7 +1778,7 @@ class LuaEnvironment : public LuaScriptInterface
 {
 	public:
 		LuaEnvironment();
-		~LuaEnvironment();
+		~LuaEnvironment() override;
 
 		// non-copyable
 		LuaEnvironment(const LuaEnvironment&) = delete;

--- a/src/luascript.h
+++ b/src/luascript.h
@@ -654,7 +654,7 @@ class LuaScriptInterface
 
 		// Tile
 		static int luaTileCreate(lua_State* L);
-
+		static int luaTileDelete(lua_State* L);
 		static int luaTileRemove(lua_State* L);
 
 		static int luaTileGetPosition(lua_State* L);
@@ -754,6 +754,7 @@ class LuaScriptInterface
 
 		// Item
 		static int luaItemCreate(lua_State* L);
+		static int luaItemDelete(lua_State* L);
 
 		static int luaItemIsItem(lua_State* L);
 
@@ -863,6 +864,7 @@ class LuaScriptInterface
 
 		// Container
 		static int luaContainerCreate(lua_State* L);
+		static int luaContainerDelete(lua_State* L);
 
 		static int luaContainerGetSize(lua_State* L);
 		static int luaContainerGetCapacity(lua_State* L);
@@ -880,12 +882,14 @@ class LuaScriptInterface
 
 		// Teleport
 		static int luaTeleportCreate(lua_State* L);
+		static int luaTeleportDelete(lua_State* L);
 
 		static int luaTeleportGetDestination(lua_State* L);
 		static int luaTeleportSetDestination(lua_State* L);
 
 		// Creature
 		static int luaCreatureCreate(lua_State* L);
+		static int luaCreatureDelete(lua_State* L);
 
 		static int luaCreatureGetEvents(lua_State* L);
 		static int luaCreatureRegisterEvent(lua_State* L);
@@ -968,6 +972,7 @@ class LuaScriptInterface
 
 		// Player
 		static int luaPlayerCreate(lua_State* L);
+		static int luaPlayerDelete(lua_State* L);
 
 		static int luaPlayerIsPlayer(lua_State* L);
 
@@ -1155,6 +1160,7 @@ class LuaScriptInterface
 
 		// Monster
 		static int luaMonsterCreate(lua_State* L);
+		static int luaMonsterDelete(lua_State* L);
 
 		static int luaMonsterIsMonster(lua_State* L);
 		static int luaMonsterGetId(lua_State* L);
@@ -1191,6 +1197,7 @@ class LuaScriptInterface
 
 		// Npc
 		static int luaNpcCreate(lua_State* L);
+		static int luaNpcDelete(lua_State* L);
 
 		static int luaNpcIsNpc(lua_State* L);
 

--- a/src/mailbox.cpp
+++ b/src/mailbox.cpp
@@ -28,7 +28,7 @@ ReturnValue Mailbox::queryRemove(const ThingPtr&, uint32_t, uint32_t, CreaturePt
 	return RETURNVALUE_NOTPOSSIBLE;
 }
 
-CylinderPtr Mailbox::queryDestination(int32_t&, const ThingPtr&, ItemPtr*, uint32_t&)
+CylinderPtr Mailbox::queryDestination(int32_t&, const ThingPtr&, ItemPtr&, uint32_t&)
 {
 	return CylinderPtr(this);
 }
@@ -87,7 +87,7 @@ bool Mailbox::sendItem(const ItemPtr& item) const
 		CylinderPtr newParent = CylinderPtr(item->getParent());
 		CylinderPtr inbox = CylinderPtr(player->getInbox());
 		if (g_game.internalMoveItem(newParent, inbox, INDEX_WHEREEVER,
-		                            item, item->getItemCount(), nullptr, FLAG_NOLIMIT) == RETURNVALUE_NOERROR) {
+		                            item, item->getItemCount(), std::nullopt, FLAG_NOLIMIT) == RETURNVALUE_NOERROR) {
 			g_game.transformItem(item, item->getID() + 1);
 			player->onReceiveMail();
 			return true;
@@ -100,7 +100,7 @@ bool Mailbox::sendItem(const ItemPtr& item) const
 		CylinderPtr newParent = CylinderPtr(item->getParent());
 		CylinderPtr inbox = CylinderPtr(tmpPlayer->getInbox());
 		if (g_game.internalMoveItem(newParent, inbox, INDEX_WHEREEVER,
-		                            item, item->getItemCount(), nullptr, FLAG_NOLIMIT) == RETURNVALUE_NOERROR) {
+		                            item, item->getItemCount(), std::nullopt, FLAG_NOLIMIT) == RETURNVALUE_NOERROR) {
 			g_game.transformItem(item, item->getID() + 1);
 			IOLoginData::savePlayer(tmpPlayer);
 			return true;

--- a/src/mailbox.h
+++ b/src/mailbox.h
@@ -26,7 +26,7 @@ class Mailbox final : public Item, public Cylinder
 		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count,
 				uint32_t& maxQueryCount, uint32_t flags) override;
 		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
-		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 				uint32_t& flags) override; // another optional ref wrapper
 
 		void addThing(ThingPtr thing) override;

--- a/src/mailbox.h
+++ b/src/mailbox.h
@@ -6,45 +6,45 @@
 
 #include "item.h"
 #include "cylinder.h"
-#include "const.h"
 
 class Mailbox final : public Item, public Cylinder
 {
 	public:
-		explicit Mailbox(uint16_t itemId) : Item(itemId) {}
+		explicit Mailbox(const uint16_t itemId) : Item(itemId) {}
 
-		Mailbox* getMailbox() override {
-			return this;
+		MailboxPtr getMailbox() override {
+			return dynamic_shared_this<Mailbox>();
 		}
-		const Mailbox* getMailbox() const override {
-			return this;
+	
+		MailboxConstPtr getMailbox() const override {
+			return dynamic_shared_this<Mailbox>();
 		}
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const override;
-		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t& maxQueryCount, uint32_t flags) const override;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
-		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
-				uint32_t& flags) override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                     uint32_t flags, CreaturePtr actor = nullptr) override;
+		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count,
+				uint32_t& maxQueryCount, uint32_t flags) override;
+		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+				uint32_t& flags) override; // another optional ref wrapper
 
-		void addThing(Thing* thing) override;
-		void addThing(int32_t index, Thing* thing) override;
+		void addThing(ThingPtr thing) override;
+		void addThing(int32_t index, ThingPtr thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
-		void replaceThing(uint32_t index, Thing* thing) override;
+		void updateThing(ThingPtr thing, uint16_t itemId, uint32_t count) override;
+		void replaceThing(uint32_t index, ThingPtr thing) override;
 
-		void removeThing(Thing* thing, uint32_t count) override;
+		void removeThing(ThingPtr thing, uint32_t count) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 	private:
-		bool getReceiver(Item* item, std::string& name) const;
-		bool sendItem(Item* item) const;
+		bool getReceiver(const ItemPtr& item, std::string& name) const;
+		bool sendItem(const ItemPtr& item) const;
 
-		static bool canSend(const Item* item);
+		static bool canSend(const ItemConstPtr& item);
 };
 
 #endif

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -233,7 +233,7 @@ bool Map::placeCreature(const Position& centerPos, CreaturePtr creature, bool ex
 	int32_t index = 0;
 	uint32_t flags = 0;
 	ItemPtr toItem = nullptr;
-	auto toCylinder = tile->queryDestination(index, creature, &toItem, flags);
+	auto toCylinder = tile->queryDestination(index, creature, toItem, flags);
 	toCylinder->internalAddThing(creature);
 
 	const Position& dest = toCylinder->getPosition();

--- a/src/map.h
+++ b/src/map.h
@@ -44,7 +44,9 @@ struct alignas(16) ChunkKey {
 		return std::memcmp(this, &other, sizeof(ChunkKey)) == 0;
 	}
 };
+
 static ChunkKey chunkKey;
+
 struct ChunkKeyHash {
 	std::size_t operator()(const ChunkKey& key) const noexcept {
 		std::size_t hash = 0;
@@ -80,13 +82,13 @@ class AStarNodes
 
 		AStarNode* createOpenNode(AStarNode* parent, uint32_t x, uint32_t y, int_fast32_t f);
 		AStarNode* getBestNode();
-		void closeNode(AStarNode* node);
-		void openNode(AStarNode* node);
+		void closeNode(const AStarNode* node);
+		void openNode(const AStarNode* node);
 		int_fast32_t getClosedNodes() const;
 		AStarNode* getNodeByPosition(uint32_t x, uint32_t y);
 
-		static int_fast32_t getMapWalkCost(AStarNode* node, const Position& neighborPos);
-		static int_fast32_t getTileWalkCost(const Creature& creature, const Tile* tile);
+		static int_fast32_t getMapWalkCost(const AStarNode* node, const Position& neighborPos);
+		static int_fast32_t getTileWalkCost(const CreaturePtr creature, const TileConstPtr& tile);
 
 	private:
 		AStarNode nodes[MAX_NODES];
@@ -110,7 +112,7 @@ struct Floor {
 	Floor(const Floor&) = delete;
 	Floor& operator=(const Floor&) = delete;
 
-	Tile* tiles[FLOOR_SIZE][FLOOR_SIZE] = {};
+	TilePtr tiles[FLOOR_SIZE][FLOOR_SIZE] = {};
 };
 
 class FrozenPathingConditionCall;
@@ -162,19 +164,20 @@ class QTreeLeafNode final : public QTreeNode
 {
 	public:
 		QTreeLeafNode() { leaf = true; newLeaf = true; }
-		~QTreeLeafNode();
+		~QTreeLeafNode() override;
 
 		// non-copyable
 		QTreeLeafNode(const QTreeLeafNode&) = delete;
 		QTreeLeafNode& operator=(const QTreeLeafNode&) = delete;
 
 		Floor* createFloor(uint32_t z);
+	
 		Floor* getFloor(uint8_t z) const {
 			return array[z];
 		}
 
-		void addCreature(Creature* c);
-		void removeCreature(Creature* c);
+		void addCreature(const CreaturePtr& c);
+		void removeCreature(const CreaturePtr& c);
 
 	private:
 		static bool newLeaf;
@@ -201,13 +204,14 @@ class Map
 		static constexpr int32_t maxClientViewportX = 8;
 		static constexpr int32_t maxClientViewportY = 6;
 
-		uint32_t clean() const;
+		static uint32_t clean();
 
 		/**
 		  * Load a map.
 		  * \returns true if the map was loaded successfully
 		  */
 		bool loadMap(const std::string& identifier, bool loadHouses);
+	
 		void clearChunkSpectatorCache()	{
 			playersSpectatorCache.clear();
 			chunksSpectatorCache.clear();
@@ -223,23 +227,26 @@ class Map
 		  * Get a single tile.
 		  * \returns A pointer to that tile.
 		  */
-		Tile* getTile(uint16_t x, uint16_t y, uint8_t z) const;
-		Tile* getTile(const Position& pos) const {
+		TilePtr getTile(uint16_t x, uint16_t y, uint8_t z);
+	
+		TilePtr getTile(const Position& pos) {
 			return getTile(pos.x, pos.y, pos.z);
 		}
 
 		/**
 		  * Set a single tile.
 		  */
-		void setTile(uint16_t x, uint16_t y, uint8_t z, Tile* newTile);
-		void setTile(const Position& pos, Tile* newTile) {
+		void setTile(uint16_t x, uint16_t y, uint8_t z, TilePtr& newTile);
+	
+		void setTile(const Position& pos, TilePtr& newTile) {
 			setTile(pos.x, pos.y, pos.z, newTile);
 		}
 
 		/**
 		  * Removes a single tile.
 		  */
-		void removeTile(uint16_t x, uint16_t y, uint8_t z);
+		void removeTile(uint16_t x, uint16_t y, uint8_t z) const;
+	
 		void removeTile(const Position& pos) {
 			removeTile(pos.x, pos.y, pos.z);
 		}
@@ -251,9 +258,9 @@ class Map
 		  * \param extendedPos If true, the creature will in first-hand be placed 2 tiles away
 		  * \param forceLogin If true, placing the creature will not fail because of obstacles (creatures/chests)
 		  */
-		bool placeCreature(const Position& centerPos, Creature* creature, bool extendedPos = false, bool forceLogin = false);
+		bool placeCreature(const Position& centerPos, CreaturePtr creature, bool extendedPos = false, bool forceLogin = false);
 
-		void moveCreature(Creature& creature, Tile& newTile, bool forceTeleport = false);
+		void moveCreature(CreaturePtr& creature, const TilePtr& newTile, bool forceTeleport = false);
 
 		void getSpectators(SpectatorVec& spectators, const Position& centerPos, bool multifloor = false, bool onlyPlayers = false,
 		                   int32_t minRangeX = 0, int32_t maxRangeX = 0,
@@ -273,14 +280,14 @@ class Map
 		  *	\returns The result if you can throw there or not
 		  */
 		bool canThrowObjectTo(const Position& fromPos, const Position& toPos, bool checkLineOfSight = true, bool sameFloor = false,
-		                      int32_t rangex = Map::maxClientViewportX, int32_t rangey = Map::maxClientViewportY) const;
+		                      int32_t rangex = Map::maxClientViewportX, int32_t rangey = Map::maxClientViewportY);
 
 		/**
 		  * Checks if there are no obstacles on that position
 		  *	\param blockFloor counts the ground tile as an obstacle
 		  *	\returns The result if there is an obstacle or not
 		  */
-		bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false) const;
+		bool isTileClear(uint16_t x, uint16_t y, uint8_t z, bool blockFloor = false);
 
 		/**
 		  * Checks if path is clear from fromPos to toPos
@@ -290,13 +297,13 @@ class Map
 		  *	\param sameFloor checks if the destination is on same floor
 		  *	\returns The result if there is no obstacles
 		  */
-		bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false) const;
-		bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z) const;
+		bool isSightClear(const Position& fromPos, const Position& toPos, bool sameFloor = false);
+		static bool checkSightLine(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1, uint8_t z);
 
-		const Tile* canWalkTo(const Creature& creature, const Position& pos) const;
+		TilePtr canWalkTo(CreaturePtr& creature, const Position& pos);
 
-		bool getPathMatching(const Creature& creature, std::vector<Direction>& dirList,
-		                     const FrozenPathingConditionCall& pathCondition, const FindPathParams& fpp) const;
+		bool getPathMatching(CreaturePtr& creature, std::vector<Direction>& dirList,
+		                     const FrozenPathingConditionCall& pathCondition, const FindPathParams& fpp);
 
 		std::map<std::string, Position> waypoints;
 

--- a/src/map.h
+++ b/src/map.h
@@ -137,8 +137,12 @@ class QTreeNode
 		template<typename Leaf, typename Node>
 		static Leaf getLeafStatic(Node node, uint32_t x, uint32_t y)
 		{
+
+			uint32_t mask = 0x8000;
+
 			do {
-				node = node->child[((x & 0x8000) >> 15) | ((y & 0x8000) >> 14)];
+
+				node = node->child[((x & mask) >> 15) | ((y & mask) >> 14)];
 				if (!node) {
 					return nullptr;
 				}

--- a/src/matrixarea.cpp
+++ b/src/matrixarea.cpp
@@ -16,7 +16,7 @@ MatrixArea MatrixArea::rotate90() const
 MatrixArea MatrixArea::rotate180() const
 {
 	Container newArr(arr.size());
-	std::reverse_copy(std::begin(arr), std::end(arr), std::begin(newArr));
+	std::ranges::reverse_copy(arr, std::begin(newArr));
 	auto &&[centerX, centerY] = center;
 	return {{cols - centerX - 1, rows - centerY - 1}, rows, cols, std::move(newArr)};
 }
@@ -32,7 +32,7 @@ MatrixArea MatrixArea::rotate270() const
 	return {{centerY, cols - centerX - 1}, cols, rows, std::move(newArr)};
 }
 
-MatrixArea createArea(const std::vector<uint32_t> &vec, uint32_t rows)
+MatrixArea createArea(const std::vector<uint32_t> &vec, const uint32_t rows)
 {
 	uint32_t cols;
 	if (rows == 0) {
@@ -46,7 +46,7 @@ MatrixArea createArea(const std::vector<uint32_t> &vec, uint32_t rows)
 	uint32_t x = 0;
 	uint32_t y = 0;
 
-	for (uint32_t value : vec) {
+	for (const uint32_t& value : vec) {
 		if (value == 1 || value == 3) {
 			area(y, x) = true;
 		}

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1059,7 +1059,7 @@ bool Monster::pushItem(const ItemPtr& item)
 		if (tile && g_game.canThrowObjectTo(centerPos, tryPos, true, true)) {
 			CylinderPtr n_parent = item->getParent();
 			CylinderPtr t_parent = tile;
-			if (g_game.internalMoveItem(n_parent, t_parent, INDEX_WHEREEVER, item, item->getItemCount(), nullptr) == RETURNVALUE_NOERROR) {
+			if (g_game.internalMoveItem(n_parent, t_parent, INDEX_WHEREEVER, item, item->getItemCount(), std::nullopt) == RETURNVALUE_NOERROR) {
 				return true;
 			}
 		}

--- a/src/monster.h
+++ b/src/monster.h
@@ -11,8 +11,8 @@ class Creature;
 class Game;
 class Spawn;
 
-using CreatureHashSet = std::unordered_set<Creature*>;
-using CreatureList = std::list<Creature*>;
+using CreatureHashSet = std::unordered_set<CreaturePtr>;
+using CreatureList = std::list<CreaturePtr>;
 
 enum TargetSearchType_t {
 	TARGETSEARCH_DEFAULT,
@@ -24,22 +24,23 @@ enum TargetSearchType_t {
 class Monster final : public Creature
 {
 	public:
-		static Monster* createMonster(const std::string& name);
+		static MonsterPtr createMonster(const std::string& name);
 		static int32_t despawnRange;
 		static int32_t despawnRadius;
 
 		explicit Monster(MonsterType* mType);
-		~Monster();
+		~Monster() override;
 
 		// non-copyable
 		Monster(const Monster&) = delete;
 		Monster& operator=(const Monster&) = delete;
 
-		Monster* getMonster() override {
-			return this;
+		MonsterPtr getMonster() override {
+			return dynamic_shared_this<Monster>();
 		}
-		const Monster* getMonster() const override {
-			return this;
+	
+		MonsterConstPtr getMonster() const override {
+			return dynamic_shared_this<const Monster>();
 		}
 
 		void setID() override {
@@ -55,6 +56,7 @@ class Monster final : public Creature
 		void setName(const std::string& name);
 
 		const std::string& getNameDescription() const override;
+	
 		void setNameDescription(const std::string& nameDescription) {
 			this->nameDescription = nameDescription;
 		};
@@ -71,6 +73,7 @@ class Monster final : public Creature
 		const Position& getMasterPos() const {
 			return masterPos;
 		}
+	
 		void setMasterPos(Position pos) {
 			masterPos = pos;
 		}
@@ -78,99 +81,118 @@ class Monster final : public Creature
 		RaceType_t getRace() const override {
 			return mType->info.race;
 		}
+	
 		int32_t getArmor() const override {
 			return mType->info.armor;
 		}
+	
 		int32_t getDefense() const override {
 			return mType->info.defense;
 		}
+	
 		bool isPushable() const override {
 			return mType->info.pushable && baseSpeed != 0;
 		}
+	
 		bool isAttackable() const override {
 			return mType->info.isAttackable;
 		}
 
 		bool canPushItems() const;
+	
 		bool canPushCreatures() const {
 			return mType->info.canPushCreatures;
 		}
+	
 		bool isHostile() const {
 			return mType->info.isHostile;
 		}
+	
 		bool isRewardBoss() const {
 			return mType->info.isRewardBoss;
 		}
+	
 		bool canSee(const Position& pos) const override;
+	
 		bool canSeeInvisibility() const override {
 			return isImmune(CONDITION_INVISIBLE);
 		}
+	
 		uint32_t getManaCost() const {
 			return mType->info.manaCost;
 		}
+	
 		void setSpawn(Spawn* spawn) {
 			this->spawn = spawn;
 		}
+	
 		bool canWalkOnFieldType(CombatType_t combatType) const;
 
 		void onAttackedCreatureDisappear(bool isLogout) override;
 
-		void onCreatureAppear(Creature* creature, bool isLogin) override;
-		void onRemoveCreature(Creature* creature, bool isLogout) override;
-		void onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos, const Tile* oldTile, const Position& oldPos, bool teleport) override;
-		void onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text) override;
+		void onCreatureAppear(const CreaturePtr& creature, bool isLogin) override;
+		void onRemoveCreature(const CreaturePtr& creature, bool isLogout) override;
+		void onCreatureMove(const CreaturePtr& creature, const TilePtr& newTile, const Position& newPos, const TilePtr& oldTile, const Position& oldPos, bool teleport) override;
+		void onCreatureSay(const CreaturePtr& creature, SpeakClasses type, const std::string& text) override;
 
-		void drainHealth(Creature* attacker, int32_t damage) override;
+		void drainHealth(const CreaturePtr& attacker, int32_t damage) override;
 		void changeHealth(int32_t healthChange, bool sendHealthChange = true) override;
 
 		bool isWalkingToSpawn() const {
 			return walkingToSpawn;
 		}
+	
 		bool walkToSpawn();
 		void onWalk() override;
 		void onWalkComplete() override;
 		bool getNextStep(Direction& direction, uint32_t& flags) override;
-		void onFollowCreatureComplete(const Creature* creature) override;
+		void onFollowCreatureComplete(const CreatureConstPtr& creature) override;
 
 		void onThink(uint32_t interval) override;
 
-		bool challengeCreature(Creature* creature, bool force = false) override;
+		bool challengeCreature(const CreaturePtr& creature, bool force = false) override;
 
 		void setNormalCreatureLight() override;
 		bool getCombatValues(int32_t& min, int32_t& max) override;
 
 		void doAttacking(uint32_t interval) override;
+	
 		bool hasExtraSwing() override {
 			return lastMeleeAttack == 0;
 		}
 
 		bool searchTarget(TargetSearchType_t searchType = TARGETSEARCH_DEFAULT);
-		bool selectTarget(Creature* creature);
+		bool selectTarget(const CreaturePtr& creature);
 
 		const CreatureList& getTargetList() const {
 			return targetList;
 		}
+	
 		const CreatureHashSet& getFriendList() const {
 			return friendList;
 		}
+	
 		CreatureHashSet& getFriendList() {
 			return friendList;
 		}
 
-		bool isTarget(const Creature* creature) const;
+		bool isTarget(const CreatureConstPtr& creature) const;
+	
 		bool isFleeing() const {
 			return !isSummon() && getHealth() <= mType->info.runAwayHealth && challengeFocusDuration <= 0;
 		}
 
 		bool getDistanceStep(const Position& targetPos, Direction& direction, bool flee = false);
+	
 		bool isTargetNearby() const {
 			return stepDuration >= 1;
 		}
+	
 		bool isIgnoringFieldDamage() const {
 			return ignoreFieldDamage;
 		}
 
-		BlockType_t blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
+		BlockType_t blockHit(const CreaturePtr& attacker, CombatType_t combatType, int32_t& damage,
 		                     bool checkDefense = false, bool checkArmor = false, bool field = false, bool ignoreResistances = false) override;
 
 		static uint32_t monsterAutoID;
@@ -206,26 +228,27 @@ class Monster final : public Creature
 		bool randomStepping = false;
 		bool walkingToSpawn = false;
 
-		void onCreatureEnter(Creature* creature);
-		void onCreatureLeave(Creature* creature);
-		void onCreatureFound(Creature* creature, bool pushFront = false);
+		void onCreatureEnter(const CreaturePtr& creature);
+		void onCreatureLeave(const CreaturePtr& creature);
+		void onCreatureFound(const CreaturePtr& creature, bool pushFront = false);
 
 		void updateLookDirection();
 
-		void addFriend(Creature* creature);
-		void removeFriend(Creature* creature);
-		void addTarget(Creature* creature, bool pushFront = false);
-		void removeTarget(Creature* creature);
+		void addFriend(const CreaturePtr& creature);
+		void removeFriend(const CreaturePtr& creature);
+		void addTarget(const CreaturePtr& creature, bool pushFront = false);
+		void removeTarget(const CreaturePtr& creature);
 
 		void updateTargetList();
 		void clearTargetList();
 		void clearFriendList();
 
-		void death(Creature* lastHitCreature) override;
-		Item* getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature) override;
+		void death(const CreaturePtr& lastHitCreature) override;
+		ItemPtr getCorpse(const CreaturePtr& lastHitCreature, const CreaturePtr& mostDamageCreature) override;
 
 		void setIdle(bool idle);
 		void updateIdleStatus();
+	
 		bool getIdleStatus() const {
 			return isIdle;
 		}
@@ -233,41 +256,47 @@ class Monster final : public Creature
 		void onAddCondition(ConditionType_t type) override;
 		void onEndCondition(ConditionType_t type) override;
 
-		bool canUseAttack(const Position& pos, const Creature* target) const;
+		bool canUseAttack(const Position& pos, const CreatureConstPtr& target) const;
 		bool canUseSpell(const Position& pos, const Position& targetPos,
-		                 const spellBlock_t& sb, uint32_t interval, bool& inRange, bool& resetTicks);
-		bool getRandomStep(const Position& creaturePos, Direction& direction) const;
+		                 const spellBlock_t& sb, uint32_t interval, bool& inRange, bool& resetTicks) const;
+		bool getRandomStep(const Position& creaturePos, Direction& direction);
 		bool getDanceStep(const Position& creaturePos, Direction& direction,
 		                  bool keepAttack = true, bool keepDistance = true);
 		bool isInSpawnRange(const Position& pos) const;
-		bool canWalkTo(Position pos, Direction direction) const;
+		bool canWalkTo(Position pos, Direction direction);
 
-		static bool pushItem(Item* item);
-		static void pushItems(Tile* tile);
-		static bool pushCreature(Creature* creature);
-		static void pushCreatures(Tile* tile);
+		static bool pushItem(const ItemPtr& item);
+		static void pushItems(const TilePtr& tile);
+		static bool pushCreature(const CreaturePtr& creature);
+		static void pushCreatures(const TilePtr& tile);
 
 		void onThinkTarget(uint32_t interval);
 		void onThinkYell(uint32_t interval);
 		void onThinkDefense(uint32_t interval);
 
-		bool isFriend(const Creature* creature) const;
-		bool isOpponent(const Creature* creature) const;
+		bool isFriend(const CreatureConstPtr& creature) const;
+		bool isOpponent(const CreatureConstPtr& creature) const;
 
 		uint64_t getLostExperience() const override {
 			return skillLoss ? mType->info.experience : 0;
 		}
+	
 		uint16_t getLookCorpse() const override {
 			return mType->info.lookcorpse;
 		}
-		void dropLoot(Container* corpse, Creature* lastHitCreature) override;
+	
+		void dropLoot(const ContainerPtr& corpse, const CreaturePtr& lastHitCreature) override;
+	
 		uint32_t getDamageImmunities() const override {
 			return mType->info.damageImmunities;
 		}
+	
 		uint32_t getConditionImmunities() const override {
 			return mType->info.conditionImmunities;
 		}
-		void getPathSearchParams(const Creature* creature, FindPathParams& fpp) const override;
+	
+		void getPathSearchParams(const CreatureConstPtr& creature, FindPathParams& fpp) const override;
+	
 		bool useCacheMap() const override {
 			return !randomStepping;
 		}

--- a/src/movement.h
+++ b/src/movement.h
@@ -1,8 +1,8 @@
 // Copyright 2024 Black Tek Server Authors. All rights reserved.
 // Use of this source code is governed by the GPL-2.0 License that can be found in the LICENSE file.
 
-#ifndef FS_MOVEMENT_H_5E0D2626D4634ACA83AC6509518E5F49
-#define FS_MOVEMENT_H_5E0D2626D4634ACA83AC6509518E5F49
+#ifndef FS_MOVEMENT_H_
+#define FS_MOVEMENT_H_
 
 #include "baseevents.h"
 #include "item.h"
@@ -38,18 +38,18 @@ class MoveEvents final : public BaseEvents
 {
 	public:
 		MoveEvents();
-		~MoveEvents();
+		~MoveEvents() override;
 
 		// non-copyable
 		MoveEvents(const MoveEvents&) = delete;
 		MoveEvents& operator=(const MoveEvents&) = delete;
 
-		uint32_t onCreatureMove(Creature* creature, const Tile* tile, MoveEvent_t eventType);
-		ReturnValue onPlayerEquip(Player* player, Item* item, slots_t slot, bool isCheck);
-		ReturnValue onPlayerDeEquip(Player* player, Item* item, slots_t slot);
-		uint32_t onItemMove(Item* item, Tile* tile, bool isAdd);
+		uint32_t onCreatureMove(const CreaturePtr& creature, const TilePtr& tile, MoveEvent_t eventType);
+		ReturnValue onPlayerEquip(const PlayerPtr& player, const ItemPtr& item, slots_t slot, bool isCheck);
+		ReturnValue onPlayerDeEquip(const PlayerPtr& player, const ItemPtr& item, slots_t slot);
+		uint32_t onItemMove(const ItemPtr& item, const TilePtr& tile, bool isAdd);
 
-		MoveEvent* getEvent(Item* item, MoveEvent_t eventType);
+		MoveEvent* getEvent(const ItemPtr& item, MoveEvent_t eventType);
 
 		bool registerLuaEvent(MoveEvent* event);
 		bool registerLuaFunction(MoveEvent* event);
@@ -69,9 +69,9 @@ class MoveEvents final : public BaseEvents
 		void addEvent(MoveEvent moveEvent, int32_t id, MoveListMap& map);
 
 		void addEvent(MoveEvent moveEvent, const Position& pos, MovePosListMap& map);
-		MoveEvent* getEvent(const Tile* tile, MoveEvent_t eventType);
+		MoveEvent* getEvent(const TileConstPtr& tile, MoveEvent_t eventType);
 
-		MoveEvent* getEvent(Item* item, MoveEvent_t eventType, slots_t slot);
+		MoveEvent* getEvent(const ItemPtr& item, MoveEvent_t eventType, slots_t slot);
 
 		MoveListMap uniqueIdMap;
 		MoveListMap actionIdMap;
@@ -81,9 +81,9 @@ class MoveEvents final : public BaseEvents
 		LuaScriptInterface scriptInterface;
 };
 
-using StepFunction = std::function<uint32_t(Creature* creature, Item* item, const Position& pos)>;
-using MoveFunction = std::function<uint32_t(Item* item, Item* tileItem, const Position& pos)>;
-using EquipFunction = std::function<ReturnValue(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool boolean)>;
+using StepFunction = std::function<uint32_t(const CreaturePtr& creature, const ItemPtr& item, const Position& pos)>;
+using MoveFunction = std::function<uint32_t(const ItemPtr& item, const ItemPtr& tileItem, const Position& pos)>;
+using EquipFunction = std::function<ReturnValue(MoveEvent* moveEvent, const PlayerPtr& player, const ItemPtr& item, slots_t slot, bool boolean)>;
 
 class MoveEvent final : public Event
 {
@@ -96,126 +96,159 @@ class MoveEvent final : public Event
 		bool configureEvent(const pugi::xml_node& node) override;
 		bool loadFunction(const pugi::xml_attribute& attr, bool isScripted) override;
 
-		uint32_t fireStepEvent(Creature* creature, Item* item, const Position& pos);
-		uint32_t fireAddRemItem(Item* item, Item* tileItem, const Position& pos);
-		ReturnValue fireEquip(Player* player, Item* item, slots_t slot, bool isCheck);
+		uint32_t fireStepEvent(const CreaturePtr& creature, const ItemPtr& item, const Position& pos);
+		uint32_t fireAddRemItem(const ItemPtr& item, const ItemPtr& tileItem, const Position& pos);
+		ReturnValue fireEquip(const PlayerPtr& player, const ItemPtr& item, slots_t slot, bool isCheck);
 
 		uint32_t getSlot() const {
 			return slot;
 		}
 
 		//scripting
-		bool executeStep(Creature* creature, Item* item, const Position& pos);
-		bool executeEquip(Player* player, Item* item, slots_t slot, bool isCheck);
-		bool executeAddRemItem(Item* item, Item* tileItem, const Position& pos);
+		bool executeStep(const CreaturePtr& creature, const ItemPtr& item, const Position& pos);
+		bool executeEquip(const PlayerPtr& player, const ItemPtr& item, slots_t slot, bool isCheck);
+		bool executeAddRemItem(const ItemPtr& item, const ItemPtr& tileItem, const Position& pos);
 		//
 
 		//onEquip information
 		uint32_t getReqLevel() const {
 			return reqLevel;
 		}
+	
 		uint32_t getReqMagLv() const {
 			return reqMagLevel;
 		}
+	
 		bool isPremium() const {
 			return premium;
 		}
+	
 		const std::string& getVocationString() const {
 			return vocationString;
 		}
+	
 		void setVocationString(const std::string& str) {
 			vocationString = str;
 		}
+	
 		uint32_t getWieldInfo() const {
 			return wieldInfo;
 		}
+	
 		const VocEquipMap& getVocEquipMap() const {
 			return vocEquipMap;
 		}
-		void addVocEquipMap(std::string vocName) {
+	
+		void addVocEquipMap(const std::string& vocName) {
 			int32_t vocationId = g_vocations.getVocationId(vocName);
 			if (vocationId != -1) {
 				vocEquipMap[vocationId] = true;
 			}
 		}
+	
 		bool getTileItem() const {
 			return tileItem;
 		}
-		void setTileItem(bool b) {
+	
+		void setTileItem(const bool b) {
 			tileItem = b;
 		}
+	
 		void clearItemIdRange() {
 			return itemIdRange.clear();
 		}
+	
 		const std::vector<uint32_t>& getItemIdRange() const {
 			return itemIdRange;
 		}
+	
 		void addItemId(uint32_t id) {
 			itemIdRange.emplace_back(id);
 		}
+	
 		void clearActionIdRange() {
 			return actionIdRange.clear();
 		}
+	
 		const std::vector<uint32_t>& getActionIdRange() const {
 			return actionIdRange;
 		}
+	
 		void addActionId(uint32_t id) {
 			actionIdRange.emplace_back(id);
 		}
+	
 		void clearUniqueIdRange() {
 			return uniqueIdRange.clear();
 		}
+	
 		const std::vector<uint32_t>& getUniqueIdRange() const {
 			return uniqueIdRange;
 		}
+	
 		void addUniqueId(uint32_t id) {
 			uniqueIdRange.emplace_back(id);
 		}
+	
 		void clearPosList() {
 			return posList.clear();
 		}
+	
 		const std::vector<Position>& getPosList() const {
 			return posList;
 		}
+	
 		void addPosList(Position pos) {
 			posList.emplace_back(pos);
 		}
+	
 		void setSlot(uint32_t s) {
 			slot = s;
 		}
-		uint32_t getRequiredLevel() {
+	
+		uint32_t getRequiredLevel() const
+		{
 			return reqLevel;
 		}
+	
 		void setRequiredLevel(uint32_t level) {
 			reqLevel = level;
 		}
-		uint32_t getRequiredMagLevel() {
+	
+		uint32_t getRequiredMagLevel() const
+		{
 			return reqMagLevel;
 		}
-		void setRequiredMagLevel(uint32_t level) {
+	
+		void setRequiredMagLevel(const uint32_t level) {
 			reqMagLevel = level;
 		}
-		bool needPremium() {
+	
+		bool needPremium() const
+		{
 			return premium;
 		}
-		void setNeedPremium(bool b) {
+	
+		void setNeedPremium(const bool b) {
 			premium = b;
 		}
+	
 		uint32_t getWieldInfo() {
 			return wieldInfo;
 		}
-		void setWieldInfo(WieldInfo_t info) {
+	
+		void setWieldInfo(const WieldInfo_t info) {
 			wieldInfo |= info;
 		}
 
-		static uint32_t StepInField(Creature* creature, Item* item, const Position& pos);
-		static uint32_t StepOutField(Creature* creature, Item* item, const Position& pos);
+		static uint32_t StepInField(const CreaturePtr& creature, const ItemPtr& item, const Position& pos);
+		static uint32_t StepOutField(const CreaturePtr& creature, const ItemPtr& item, const Position& pos);
 
-		static uint32_t AddItemField(Item* item, Item* tileItem, const Position& pos);
-		static uint32_t RemoveItemField(Item* item, Item* tileItem, const Position& pos);
+		static uint32_t AddItemField(const ItemPtr& item, const ItemPtr& tileItem, const Position& pos);
+		static uint32_t RemoveItemField(const ItemPtr& item, const ItemPtr& tileItem, const Position& pos);
 
-		static ReturnValue EquipItem(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool isCheck);
-		static ReturnValue DeEquipItem(MoveEvent* moveEvent, Player* player, Item* item, slots_t slot, bool);
+		static ReturnValue EquipItem(MoveEvent* moveEvent, const PlayerPtr& player, const ItemPtr& item, slots_t slot, bool isCheck);
+		static ReturnValue DeEquipItem(MoveEvent* moveEvent, const PlayerPtr& player, const ItemPtr& item, slots_t slot, bool);
 
 		MoveEvent_t eventType = MOVE_EVENT_NONE;
 		StepFunction stepFunction;

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -98,7 +98,7 @@ void NetworkMessage::addItem(uint16_t id, uint8_t count)
 	}
 }
 
-void NetworkMessage::addItem(const Item* item)
+void NetworkMessage::addItem(const ItemConstPtr& item)
 {
 	const ItemType& it = Item::items[item->getID()];
 

--- a/src/networkmessage.h
+++ b/src/networkmessage.h
@@ -5,10 +5,9 @@
 #define FS_NETWORKMESSAGE_H
 
 #include "const.h"
+#include "thing.h"
 
 class Item;
-class Creature;
-class Player;
 struct Position;
 class RSA;
 
@@ -33,7 +32,7 @@ class NetworkMessage
 			info = {};
 		}
 
-		// simply read functions for incoming message
+		// simple read functions for incoming message
 		uint8_t getByte() {
 			if (!canRead(1)) {
 				return 0;
@@ -97,7 +96,7 @@ class NetworkMessage
 		// write functions for complex types
 		void addPosition(const Position& pos);
 		void addItem(uint16_t id, uint8_t count);
-		void addItem(const Item* item);
+		void addItem(const ItemConstPtr& item);
 		void addItemId(uint16_t itemId);
 
 		MsgSize_t getLength() const {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1069,8 +1069,8 @@ int NpcScriptInterface::luaNpcCloseShopWindow(lua_State* L)
 	return 1;
 }
 
-NpcEventsHandler::NpcEventsHandler(const std::string& file, const NpcPtr& og) :
-	scriptInterface(std::make_unique<NpcScriptInterface>())
+NpcEventsHandler::NpcEventsHandler(const std::string& file, NpcPtr og) :
+	scriptInterface(std::make_unique<NpcScriptInterface>()), npc(og)
 {
 	if (!scriptInterface->loadNpcLib("data/npc/lib/npc.lua")) {
 		std::cout << "[Warning - NpcLib::NpcLib] Can not load lib: " << file << std::endl;
@@ -1090,7 +1090,6 @@ NpcEventsHandler::NpcEventsHandler(const std::string& file, const NpcPtr& og) :
 		playerEndTradeEvent = scriptInterface->getEvent("onPlayerEndTrade");
 		thinkEvent = scriptInterface->getEvent("onThink");
 	}
-	npc = og;
 }
 
 bool NpcEventsHandler::isLoaded() const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -14,23 +14,23 @@ uint32_t Npc::npcAutoID = 0x80000000;
 
 void Npcs::reload()
 {
-	const std::map<uint32_t, Npc*>& npcs = g_game.getNpcs();
-	for (const auto& it : npcs) {
-		it.second->closeAllShopWindows();
+	const std::map<uint32_t, NpcPtr>& npcs = g_game.getNpcs();
+	for (const auto& val : npcs | std::views::values) {
+		val->closeAllShopWindows();
 	}
 
-	for (const auto& it : npcs) {
-		it.second->reload();
+	for (const auto& val : npcs | std::views::values) {
+		val->reload();
 	}
 }
 
-Npc* Npc::createNpc(const std::string& name)
+NpcPtr Npc::createNpc(const std::string& name)
 {
-	std::unique_ptr<Npc> npc(new Npc(name));
+	const auto& npc = std::make_shared<Npc>(name);
 	if (!npc->load()) {
 		return nullptr;
 	}
-	return npc.release();
+	return npc;
 }
 
 Npc::Npc(const std::string& name) :
@@ -49,12 +49,12 @@ Npc::~Npc()
 
 void Npc::addList()
 {
-	g_game.addNpc(this);
+	g_game.addNpc(this->getNpc());
 }
 
 void Npc::removeList()
 {
-	g_game.removeNpc(this);
+	g_game.removeNpc(this->getNpc());
 }
 
 bool Npc::load()
@@ -96,8 +96,8 @@ void Npc::reload()
 	SpectatorVec players;
 	g_game.map.getSpectators(players, getPosition(), true, true);
 	for (const auto& player : players) {
-		assert(dynamic_cast<Player*>(player) != nullptr);
-		spectators.insert(static_cast<Player*>(player));
+		assert(std::dynamic_pointer_cast<Player>(player) != nullptr);
+		spectators.insert(std::static_pointer_cast<Player>(player));
 	}
 
 	const bool hasSpectators = !spectators.empty();
@@ -109,14 +109,14 @@ void Npc::reload()
 
 	// Simulate that the creature is placed on the map again.
 	if (npcEventHandler) {
-		npcEventHandler->onCreatureAppear(this);
+		npcEventHandler->onCreatureAppear(this->getNpc());
 	}
 }
 
 bool Npc::loadFromXml()
 {
 	pugi::xml_document doc;
-	pugi::xml_parse_result result = doc.load_file(filename.c_str());
+	const pugi::xml_parse_result result = doc.load_file(filename.c_str());
 	if (!result) {
 		printXMLError("Error - Npc::loadFromXml", filename, result);
 		return false;
@@ -163,7 +163,7 @@ bool Npc::loadFromXml()
 		setSkull(getSkullType(asLowerCaseString(attr.as_string())));
 	}
 
-	pugi::xml_node healthNode = npcNode.child("health");
+	const pugi::xml_node healthNode = npcNode.child("health");
 	if (healthNode) {
 		if ((attr = healthNode.attribute("now"))) {
 			health = pugi::cast<int32_t>(attr.value());
@@ -183,9 +183,9 @@ bool Npc::loadFromXml()
 		}
 	}
 
-	pugi::xml_node lookNode = npcNode.child("look");
+	const pugi::xml_node lookNode = npcNode.child("look");
 	if (lookNode) {
-		pugi::xml_attribute lookTypeAttribute = lookNode.attribute("type");
+		const pugi::xml_attribute lookTypeAttribute = lookNode.attribute("type");
 		if (lookTypeAttribute) {
 			defaultOutfit.lookType = pugi::cast<uint16_t>(lookTypeAttribute.value());
 			defaultOutfit.lookHead = pugi::cast<uint16_t>(lookNode.attribute("head").value());
@@ -205,9 +205,9 @@ bool Npc::loadFromXml()
 		parameters[parameterNode.attribute("key").as_string()] = parameterNode.attribute("value").as_string();
 	}
 
-	pugi::xml_attribute scriptFile = npcNode.attribute("script");
+	const pugi::xml_attribute scriptFile = npcNode.attribute("script");
 	if (scriptFile) {
-		auto handler = std::make_unique<NpcEventsHandler>(scriptFile.as_string(), this);
+		auto handler = std::make_unique<NpcEventsHandler>(scriptFile.as_string(), this->getNpc());
 		if (!handler->isLoaded()) {
 			return false;
 		}
@@ -233,16 +233,16 @@ std::string Npc::getDescription(int32_t) const
 	return descr;
 }
 
-void Npc::onCreatureAppear(Creature* creature, bool isLogin)
+void Npc::onCreatureAppear(const CreaturePtr& creature, bool isLogin)
 {
 	Creature::onCreatureAppear(creature, isLogin);
 
-	if (creature == this) {
+	if (creature == getCreature()) {
 		SpectatorVec players;
 		g_game.map.getSpectators(players, getPosition(), true, true);
 		for (const auto& player : players) {
-			assert(dynamic_cast<Player*>(player) != nullptr);
-			spectators.insert(static_cast<Player*>(player));
+			assert(std::dynamic_pointer_cast<Player>(player) != nullptr);
+			spectators.insert(std::static_pointer_cast<Player>(player));
 		}
 
 		const bool hasSpectators = !spectators.empty();
@@ -255,7 +255,7 @@ void Npc::onCreatureAppear(Creature* creature, bool isLogin)
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureAppear(creature);
 		}
-	} else if (Player* player = creature->getPlayer()) {
+	} else if (const auto& player = creature->getPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureAppear(creature);
 		}
@@ -265,16 +265,16 @@ void Npc::onCreatureAppear(Creature* creature, bool isLogin)
 	}
 }
 
-void Npc::onRemoveCreature(Creature* creature, bool isLogout)
+void Npc::onRemoveCreature(const CreaturePtr& creature, bool isLogout)
 {
 	Creature::onRemoveCreature(creature, isLogout);
 
-	if (creature == this) {
+	if (creature == this->getCreature()) {
 		closeAllShopWindows();
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureDisappear(creature);
 		}
-	} else if (Player* player = creature->getPlayer()) {
+	} else if (const auto player = creature->getPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureDisappear(creature);
 		}
@@ -284,18 +284,18 @@ void Npc::onRemoveCreature(Creature* creature, bool isLogout)
 	}
 }
 
-void Npc::onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos,
-                         const Tile* oldTile, const Position& oldPos, bool teleport)
+void Npc::onCreatureMove(const CreaturePtr& creature, const TilePtr& newTile, const Position& newPos,
+                         const TilePtr& oldTile, const Position& oldPos, bool teleport)
 {
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
-	if (creature == this || creature->getPlayer()) {
+	if (creature == getCreature()  || creature->getPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureMove(creature, oldPos, newPos);
 		}
 
-		if (creature != this) {
-			Player* player = creature->getPlayer();
+		if (creature != this->getCreature()) {
+			const auto& player = creature->getPlayer();
 
 			// if player is now in range, add to spectators list, otherwise erase
 			if (player->canSee(position)) {
@@ -309,29 +309,28 @@ void Npc::onCreatureMove(Creature* creature, const Tile* newTile, const Position
 	}
 }
 
-void Npc::onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text)
+void Npc::onCreatureSay(const CreaturePtr& creature, SpeakClasses type, const std::string& text)
 {
-	if (creature == this) {
+	if (creature == this->getCreature()) {
 		return;
 	}
 
 	//only players for script events
-	Player* player = creature->getPlayer();
-	if (player) {
+	if (const auto& player = creature->getPlayer()) {
 		if (npcEventHandler) {
 			npcEventHandler->onCreatureSay(player, type, text);
 		}
 	}
 }
 
-void Npc::onPlayerCloseChannel(Player* player)
+void Npc::onPlayerCloseChannel(const PlayerPtr& player) const
 {
 	if (npcEventHandler) {
 		npcEventHandler->onPlayerCloseChannel(player);
 	}
 }
 
-void Npc::onThink(uint32_t interval)
+void Npc::onThink(const uint32_t interval)
 {
 	Creature::onThink(interval);
 
@@ -346,19 +345,19 @@ void Npc::onThink(uint32_t interval)
 
 void Npc::doSay(const std::string& text)
 {
-	g_game.internalCreatureSay(this, TALKTYPE_SAY, text, false);
+	g_game.internalCreatureSay(this->getNpc(), TALKTYPE_SAY, text, false);
 }
 
-void Npc::doSayToPlayer(Player* player, const std::string& text)
+void Npc::doSayToPlayer(const PlayerPtr& player, const std::string& text)
 {
 	if (player) {
-		player->sendCreatureSay(this, TALKTYPE_PRIVATE_NP, text);
-		player->onCreatureSay(this, TALKTYPE_PRIVATE_NP, text);
+		player->sendCreatureSay(this->getNpc(), TALKTYPE_PRIVATE_NP, text);
+		player->onCreatureSay(this->getNpc(), TALKTYPE_PRIVATE_NP, text);
 	}
 }
 
-void Npc::onPlayerTrade(Player* player, int32_t callback, uint16_t itemId, uint8_t count,
-                        uint8_t amount, bool ignore/* = false*/, bool inBackpacks/* = false*/)
+void Npc::onPlayerTrade(const PlayerPtr& player, int32_t callback, uint16_t itemId, uint8_t count,
+                        uint8_t amount, bool ignore/* = false*/, bool inBackpacks/* = false*/) const
 {
 	if (npcEventHandler) {
 		npcEventHandler->onPlayerTrade(player, callback, itemId, count, amount, ignore, inBackpacks);
@@ -366,7 +365,7 @@ void Npc::onPlayerTrade(Player* player, int32_t callback, uint16_t itemId, uint8
 	player->sendSaleItemList();
 }
 
-void Npc::onPlayerEndTrade(Player* player, int32_t buyCallback, int32_t sellCallback)
+void Npc::onPlayerEndTrade(const PlayerPtr& player, int32_t buyCallback, int32_t sellCallback)
 {
 	lua_State* L = getScriptInterface()->getLuaState();
 
@@ -423,7 +422,7 @@ void Npc::setIdle(const bool idle)
 	}
 }
 
-bool Npc::canWalkTo(const Position& fromPos, Direction dir) const
+bool Npc::canWalkTo(const Position& fromPos, Direction dir)
 {
 	if (masterRadius == 0) {
 		return false;
@@ -434,8 +433,8 @@ bool Npc::canWalkTo(const Position& fromPos, Direction dir) const
 		return false;
 	}
 
-	Tile* tile = g_game.map.getTile(toPos);
-	if (!tile || tile->queryAdd(*this, 0) != RETURNVALUE_NOERROR) {
+	const auto& tile = g_game.map.getTile(toPos);
+	if (!tile || tile->queryAdd(this->getNpc(), 0) != RETURNVALUE_NOERROR) {
 		return false;
 	}
 
@@ -450,11 +449,11 @@ bool Npc::canWalkTo(const Position& fromPos, Direction dir) const
 	return true;
 }
 
-bool Npc::getRandomStep(Direction& direction) const
+bool Npc::getRandomStep(Direction& direction)
 {
 	const Position& creaturePos = getPosition();
 
-	for (Direction dir : getShuffleDirections()) {
+	for (const Direction dir : getShuffleDirections()) {
 		if (canWalkTo(creaturePos, dir)) {
 			direction = dir;
 			return true;
@@ -474,7 +473,7 @@ bool Npc::doMoveTo(const Position& pos, int32_t minTargetDist/* = 1*/, int32_t m
 	return false;
 }
 
-void Npc::turnToCreature(Creature* creature)
+void Npc::turnToCreature(const CreaturePtr& creature)
 {
 	const Position& creaturePos = creature->getPosition();
 	const Position& myPos = getPosition();
@@ -502,10 +501,10 @@ void Npc::turnToCreature(Creature* creature)
 			dir = DIRECTION_SOUTH;
 		}
 	}
-	g_game.internalCreatureTurn(this, dir);
+	g_game.internalCreatureTurn(this->getNpc(), dir);
 }
 
-void Npc::setCreatureFocus(Creature* creature)
+void Npc::setCreatureFocus(const CreaturePtr& creature)
 {
 	if (creature) {
 		focusCreature = creature->getID();
@@ -515,12 +514,12 @@ void Npc::setCreatureFocus(Creature* creature)
 	}
 }
 
-void Npc::addShopPlayer(Player* player)
+void Npc::addShopPlayer(const PlayerPtr& player)
 {
 	shopPlayerSet.insert(player);
 }
 
-void Npc::removeShopPlayer(Player* player)
+void Npc::removeShopPlayer(const PlayerPtr& player)
 {
 	shopPlayerSet.erase(player);
 }
@@ -528,7 +527,7 @@ void Npc::removeShopPlayer(Player* player)
 void Npc::closeAllShopWindows()
 {
 	while (!shopPlayerSet.empty()) {
-		Player* player = *shopPlayerSet.begin();
+		const auto& player = *shopPlayerSet.begin();
 		if (!player->closeShopWindow()) {
 			removeShopPlayer(player);
 		}
@@ -579,7 +578,7 @@ bool NpcScriptInterface::loadNpcLib(const std::string& file)
 	return true;
 }
 
-void NpcScriptInterface::registerFunctions()
+void NpcScriptInterface::registerFunctions() const
 {
 	//npc exclusive functions
 	lua_register(luaState, "selfSay", NpcScriptInterface::luaActionSay);
@@ -606,15 +605,14 @@ void NpcScriptInterface::registerFunctions()
 int NpcScriptInterface::luaActionSay(lua_State* L)
 {
 	//selfSay(words[, target])
-	Npc* npc = getScriptEnv()->getNpc();
+	NpcPtr npc = getScriptEnv()->getNpc();
 	if (!npc) {
 		return 0;
 	}
 
 	const std::string& text = getString(L, 1);
 	if (lua_gettop(L) >= 2) {
-		Player* target = getPlayer(L, 2);
-		if (target) {
+		if (const auto& target = getPlayer(L, 2)) {
 			npc->doSayToPlayer(target, text);
 			return 0;
 		}
@@ -627,8 +625,7 @@ int NpcScriptInterface::luaActionSay(lua_State* L)
 int NpcScriptInterface::luaActionMove(lua_State* L)
 {
 	//selfMove(direction)
-	Npc* npc = getScriptEnv()->getNpc();
-	if (npc) {
+	if (auto npc = getScriptEnv()->getNpc()) {
 		g_game.internalMoveCreature(npc, getNumber<Direction>(L, 1));
 	}
 	return 0;
@@ -638,7 +635,7 @@ int NpcScriptInterface::luaActionMoveTo(lua_State* L)
 {
 	//selfMoveTo(x, y, z[, minTargetDist = 1[, maxTargetDist = 1[, fullPathSearch = true[, clearSight = true[, maxSearchDist = 0]]]]])
 	//selfMoveTo(position[, minTargetDist = 1[, maxTargetDist = 1[, fullPathSearch = true[, clearSight = true[, maxSearchDist = 0]]]]])
-	Npc* npc = getScriptEnv()->getNpc();
+	NpcPtr npc = getScriptEnv()->getNpc();
 	if (!npc) {
 		return 0;
 	}
@@ -668,7 +665,7 @@ int NpcScriptInterface::luaActionMoveTo(lua_State* L)
 int NpcScriptInterface::luaActionTurn(lua_State* L)
 {
 	//selfTurn(direction)
-	Npc* npc = getScriptEnv()->getNpc();
+	NpcPtr npc = getScriptEnv()->getNpc();
 	if (npc) {
 		g_game.internalCreatureTurn(npc, getNumber<Direction>(L, 1));
 	}
@@ -678,7 +675,7 @@ int NpcScriptInterface::luaActionTurn(lua_State* L)
 int NpcScriptInterface::luaActionFollow(lua_State* L)
 {
 	//selfFollow(player)
-	Npc* npc = getScriptEnv()->getNpc();
+	NpcPtr npc = getScriptEnv()->getNpc();
 	if (!npc) {
 		pushBoolean(L, false);
 		return 1;
@@ -693,16 +690,16 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 	//getDistanceTo(uid)
 	ScriptEnvironment* env = getScriptEnv();
 
-	Npc* npc = env->getNpc();
+	const auto& npc = env->getNpc();
 	if (!npc) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_THING_NOT_FOUND));
 		lua_pushnil(L);
 		return 1;
 	}
 
-	uint32_t uid = getNumber<uint32_t>(L, -1);
+	const uint32_t uid = getNumber<uint32_t>(L, -1);
 
-	Thing* thing = env->getThingByUID(uid);
+	const auto& thing = env->getThingByUID(uid);
 	if (!thing) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_THING_NOT_FOUND));
 		lua_pushnil(L);
@@ -714,7 +711,7 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 	if (npcPos.z != thingPos.z) {
 		lua_pushinteger(L, -1);
 	} else {
-		int32_t dist = std::max<int32_t>(Position::getDistanceX(npcPos, thingPos), Position::getDistanceY(npcPos, thingPos));
+		const int32_t dist = std::max<int32_t>(Position::getDistanceX(npcPos, thingPos), Position::getDistanceY(npcPos, thingPos));
 		lua_pushinteger(L, dist);
 	}
 	return 1;
@@ -723,8 +720,7 @@ int NpcScriptInterface::luagetDistanceTo(lua_State* L)
 int NpcScriptInterface::luaSetNpcFocus(lua_State* L)
 {
 	//doNpcSetCreatureFocus(cid)
-	Npc* npc = getScriptEnv()->getNpc();
-	if (npc) {
+	if (const auto& npc = getScriptEnv()->getNpc()) {
 		npc->setCreatureFocus(getCreature(L, -1));
 	}
 	return 0;
@@ -733,8 +729,7 @@ int NpcScriptInterface::luaSetNpcFocus(lua_State* L)
 int NpcScriptInterface::luaGetNpcCid(lua_State* L)
 {
 	//getNpcCid()
-	Npc* npc = getScriptEnv()->getNpc();
-	if (npc) {
+	if (const auto& npc = getScriptEnv()->getNpc()) {
 		lua_pushinteger(L, npc->getID());
 	} else {
 		lua_pushnil(L);
@@ -745,7 +740,7 @@ int NpcScriptInterface::luaGetNpcCid(lua_State* L)
 int NpcScriptInterface::luaGetNpcParameter(lua_State* L)
 {
 	//getNpcParameter(paramKey)
-	Npc* npc = getScriptEnv()->getNpc();
+	const auto& npc = getScriptEnv()->getNpc();
 	if (!npc) {
 		lua_pushnil(L);
 		return 1;
@@ -809,7 +804,7 @@ int NpcScriptInterface::luaOpenShopWindow(lua_State* L)
 	}
 	lua_pop(L, 1);
 
-	Player* player = getPlayer(L, -1);
+	const auto& player = getPlayer(L, -1);
 	if (!player) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		pushBoolean(L, false);
@@ -819,7 +814,7 @@ int NpcScriptInterface::luaOpenShopWindow(lua_State* L)
 	//Close any eventual other shop window currently open.
 	player->closeShopWindow(false);
 
-	Npc* npc = getScriptEnv()->getNpc();
+	const auto& npc = getScriptEnv()->getNpc();
 	if (!npc) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -837,14 +832,14 @@ int NpcScriptInterface::luaOpenShopWindow(lua_State* L)
 int NpcScriptInterface::luaCloseShopWindow(lua_State* L)
 {
 	//closeShopWindow(cid)
-	Npc* npc = getScriptEnv()->getNpc();
+	const auto& npc = getScriptEnv()->getNpc();
 	if (!npc) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	Player* player = getPlayer(L, 1);
+	const auto& player = getPlayer(L, 1);
 	if (!player) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		pushBoolean(L, false);
@@ -854,7 +849,7 @@ int NpcScriptInterface::luaCloseShopWindow(lua_State* L)
 	int32_t buyCallback;
 	int32_t sellCallback;
 
-	Npc* merchant = player->getShopOwner(buyCallback, sellCallback);
+	const auto& merchant = player->getShopOwner(buyCallback, sellCallback);
 
 	//Check if we actually have a shop window with this player.
 	if (merchant == npc) {
@@ -879,7 +874,7 @@ int NpcScriptInterface::luaCloseShopWindow(lua_State* L)
 int NpcScriptInterface::luaDoSellItem(lua_State* L)
 {
 	//doSellItem(cid, itemid, amount, <optional> subtype, <optional> actionid, <optional: default: 1> canDropOnMap)
-	Player* player = getPlayer(L, 1);
+	const auto& player = getPlayer(L, 1);
 	if (!player) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		pushBoolean(L, false);
@@ -888,7 +883,7 @@ int NpcScriptInterface::luaDoSellItem(lua_State* L)
 
 	uint32_t sellCount = 0;
 
-	uint32_t itemId = getNumber<uint32_t>(L, 2);
+	const uint32_t itemId = getNumber<uint32_t>(L, 2);
 	uint32_t amount = getNumber<uint32_t>(L, 3);
 	uint32_t subType;
 
@@ -899,20 +894,19 @@ int NpcScriptInterface::luaDoSellItem(lua_State* L)
 		subType = 1;
 	}
 
-	uint32_t actionId = getNumber<uint32_t>(L, 5, 0);
+	const uint32_t actionId = getNumber<uint32_t>(L, 5, 0);
 	bool canDropOnMap = getBoolean(L, 6, true);
 
 	const ItemType& it = Item::items[itemId];
 	if (it.stackable) {
 		while (amount > 0) {
 			int32_t stackCount = std::min<int32_t>(100, amount);
-			Item* item = Item::CreateItem(it.id, stackCount);
+			const auto& item = Item::CreateItem(it.id, stackCount);
 			if (item && actionId != 0) {
 				item->setActionId(actionId);
 			}
 
 			if (g_game.internalPlayerAddItem(player, item, canDropOnMap) != RETURNVALUE_NOERROR) {
-				delete item;
 				lua_pushinteger(L, sellCount);
 				return 1;
 			}
@@ -922,13 +916,12 @@ int NpcScriptInterface::luaDoSellItem(lua_State* L)
 		}
 	} else {
 		for (uint32_t i = 0; i < amount; ++i) {
-			Item* item = Item::CreateItem(it.id, subType);
+			const auto& item = Item::CreateItem(it.id, subType);
 			if (item && actionId != 0) {
 				item->setActionId(actionId);
 			}
 
 			if (g_game.internalPlayerAddItem(player, item, canDropOnMap) != RETURNVALUE_NOERROR) {
-				delete item;
 				lua_pushinteger(L, sellCount);
 				return 1;
 			}
@@ -945,9 +938,8 @@ int NpcScriptInterface::luaNpcGetParameter(lua_State* L)
 {
 	// npc:getParameter(key)
 	const std::string& key = getString(L, 2);
-	Npc* npc = getUserdata<Npc>(L, 1);
-	if (npc) {
-		auto it = npc->parameters.find(key);
+	if (const auto& npc = getSharedPtr<Npc>(L, 1)) {
+		const auto it = npc->parameters.find(key);
 		if (it != npc->parameters.end()) {
 			pushString(L, it->second);
 		} else {
@@ -962,9 +954,8 @@ int NpcScriptInterface::luaNpcGetParameter(lua_State* L)
 int NpcScriptInterface::luaNpcSetFocus(lua_State* L)
 {
 	// npc:setFocus(creature)
-	Creature* creature = getCreature(L, 2);
-	Npc* npc = getUserdata<Npc>(L, 1);
-	if (npc) {
+	const auto& creature = getCreature(L, 2);
+	if (const auto& npc = getSharedPtr<Npc>(L, 1)) {
 		npc->setCreatureFocus(creature);
 		pushBoolean(L, true);
 	} else {
@@ -982,14 +973,14 @@ int NpcScriptInterface::luaNpcOpenShopWindow(lua_State* L)
 		return 1;
 	}
 
-	Player* player = getPlayer(L, 2);
+	const auto& player = getPlayer(L, 2);
 	if (!player) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	Npc* npc = getUserdata<Npc>(L, 1);
+	const auto& npc = getSharedPtr<Npc>(L, 1);
 	if (!npc) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -1042,14 +1033,14 @@ int NpcScriptInterface::luaNpcOpenShopWindow(lua_State* L)
 int NpcScriptInterface::luaNpcCloseShopWindow(lua_State* L)
 {
 	// npc:closeShopWindow(player)
-	Player* player = getPlayer(L, 2);
+	const auto& player = getPlayer(L, 2);
 	if (!player) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_PLAYER_NOT_FOUND));
 		pushBoolean(L, false);
 		return 1;
 	}
 
-	Npc* npc = getUserdata<Npc>(L, 1);
+	const auto& npc = getSharedPtr<Npc>(L, 1);
 	if (!npc) {
 		reportErrorFunc(L, getErrorDesc(LUA_ERROR_CREATURE_NOT_FOUND));
 		pushBoolean(L, false);
@@ -1059,7 +1050,7 @@ int NpcScriptInterface::luaNpcCloseShopWindow(lua_State* L)
 	int32_t buyCallback;
 	int32_t sellCallback;
 
-	Npc* merchant = player->getShopOwner(buyCallback, sellCallback);
+	const auto& merchant = player->getShopOwner(buyCallback, sellCallback);
 	if (merchant == npc) {
 		player->sendCloseShop();
 		if (buyCallback != -1) {
@@ -1078,8 +1069,8 @@ int NpcScriptInterface::luaNpcCloseShopWindow(lua_State* L)
 	return 1;
 }
 
-NpcEventsHandler::NpcEventsHandler(const std::string& file, Npc* npc) :
-	scriptInterface(std::make_unique<NpcScriptInterface>()), npc(npc)
+NpcEventsHandler::NpcEventsHandler(const std::string& file, const NpcPtr& og) :
+	scriptInterface(std::make_unique<NpcScriptInterface>())
 {
 	if (!scriptInterface->loadNpcLib("data/npc/lib/npc.lua")) {
 		std::cout << "[Warning - NpcLib::NpcLib] Can not load lib: " << file << std::endl;
@@ -1099,6 +1090,7 @@ NpcEventsHandler::NpcEventsHandler(const std::string& file, Npc* npc) :
 		playerEndTradeEvent = scriptInterface->getEvent("onPlayerEndTrade");
 		thinkEvent = scriptInterface->getEvent("onThink");
 	}
+	npc = og;
 }
 
 bool NpcEventsHandler::isLoaded() const
@@ -1106,7 +1098,7 @@ bool NpcEventsHandler::isLoaded() const
 	return loaded;
 }
 
-void NpcEventsHandler::onCreatureAppear(Creature* creature)
+void NpcEventsHandler::onCreatureAppear(const CreaturePtr& creature)
 {
 	if (creatureAppearEvent == -1) {
 		return;
@@ -1124,12 +1116,12 @@ void NpcEventsHandler::onCreatureAppear(Creature* creature)
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(creatureAppearEvent);
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 	scriptInterface->callFunction(1);
 }
 
-void NpcEventsHandler::onCreatureDisappear(Creature* creature)
+void NpcEventsHandler::onCreatureDisappear(const CreaturePtr& creature)
 {
 	if (creatureDisappearEvent == -1) {
 		return;
@@ -1147,12 +1139,12 @@ void NpcEventsHandler::onCreatureDisappear(Creature* creature)
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(creatureDisappearEvent);
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 	scriptInterface->callFunction(1);
 }
 
-void NpcEventsHandler::onCreatureMove(Creature* creature, const Position& oldPos, const Position& newPos)
+void NpcEventsHandler::onCreatureMove(const CreaturePtr& creature, const Position& oldPos, const Position& newPos)
 {
 	if (creatureMoveEvent == -1) {
 		return;
@@ -1170,14 +1162,14 @@ void NpcEventsHandler::onCreatureMove(Creature* creature, const Position& oldPos
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(creatureMoveEvent);
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 	LuaScriptInterface::pushPosition(L, oldPos);
 	LuaScriptInterface::pushPosition(L, newPos);
 	scriptInterface->callFunction(3);
 }
 
-void NpcEventsHandler::onCreatureSay(Creature* creature, SpeakClasses type, const std::string& text)
+void NpcEventsHandler::onCreatureSay(const CreaturePtr& creature, SpeakClasses type, const std::string& text)
 {
 	if (creatureSayEvent == -1) {
 		return;
@@ -1195,14 +1187,14 @@ void NpcEventsHandler::onCreatureSay(Creature* creature, SpeakClasses type, cons
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(creatureSayEvent);
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 	lua_pushinteger(L, type);
 	LuaScriptInterface::pushString(L, text);
 	scriptInterface->callFunction(3);
 }
 
-void NpcEventsHandler::onPlayerTrade(Player* player, int32_t callback, uint16_t itemId,
+void NpcEventsHandler::onPlayerTrade(const PlayerPtr& player, int32_t callback, uint16_t itemId,
                               uint8_t count, uint8_t amount, bool ignore, bool inBackpacks)
 {
 	if (callback == -1) {
@@ -1221,7 +1213,7 @@ void NpcEventsHandler::onPlayerTrade(Player* player, int32_t callback, uint16_t 
 
 	lua_State* L = scriptInterface->getLuaState();
 	LuaScriptInterface::pushCallback(L, callback);
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 	lua_pushinteger(L, itemId);
 	lua_pushinteger(L, count);
@@ -1231,7 +1223,7 @@ void NpcEventsHandler::onPlayerTrade(Player* player, int32_t callback, uint16_t 
 	scriptInterface->callFunction(6);
 }
 
-void NpcEventsHandler::onPlayerCloseChannel(Player* player)
+void NpcEventsHandler::onPlayerCloseChannel(const PlayerPtr& player)
 {
 	if (playerCloseChannelEvent == -1) {
 		return;
@@ -1249,12 +1241,12 @@ void NpcEventsHandler::onPlayerCloseChannel(Player* player)
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(playerCloseChannelEvent);
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 	scriptInterface->callFunction(1);
 }
 
-void NpcEventsHandler::onPlayerEndTrade(Player* player)
+void NpcEventsHandler::onPlayerEndTrade(const PlayerPtr& player)
 {
 	if (playerEndTradeEvent == -1) {
 		return;
@@ -1272,7 +1264,7 @@ void NpcEventsHandler::onPlayerEndTrade(Player* player)
 
 	lua_State* L = scriptInterface->getLuaState();
 	scriptInterface->pushFunction(playerEndTradeEvent);
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 	scriptInterface->callFunction(1);
 }

--- a/src/npc.h
+++ b/src/npc.h
@@ -58,7 +58,7 @@ class NpcScriptInterface final : public LuaScriptInterface
 class NpcEventsHandler
 {
 	public:
-		NpcEventsHandler(const std::string& file, const NpcPtr& npc);
+		NpcEventsHandler(const std::string& file, NpcPtr npc);
 
 		std::unique_ptr<NpcScriptInterface> scriptInterface;
 

--- a/src/party.h
+++ b/src/party.h
@@ -10,7 +10,7 @@
 class Player;
 class Party;
 
-using PlayerVector = std::vector<Player*>;
+using PlayerVector = std::vector<PlayerPtr>;
 
 static constexpr int32_t EXPERIENCE_SHARE_RANGE = 30;
 static constexpr int32_t EXPERIENCE_SHARE_FLOORS = 1;
@@ -26,65 +26,74 @@ enum SharedExpStatus_t : uint8_t {
 class Party
 {
 	public:
-		explicit Party(Player* leader);
+		explicit Party(const PlayerPtr& leader);
 
-		Player* getLeader() const {
+		PlayerPtr getLeader() const {
 			return leader;
 		}
+	
 		PlayerVector& getMembers() {
 			return memberList;
 		}
+	
 		const PlayerVector& getInvitees() const {
 			return inviteList;
 		}
+	
 		size_t getMemberCount() const {
 			return memberList.size();
 		}
+	
 		size_t getInvitationCount() const {
 			return inviteList.size();
 		}
 
 		void disband();
-		bool invitePlayer(Player& player);
-		bool joinParty(Player& player);
-		void revokeInvitation(Player& player);
-		bool passPartyLeadership(Player* player, bool forceRemove = false);
-		bool leaveParty(Player* player, bool forceRemove = false);
+		bool invitePlayer(const PlayerPtr& player);
+		bool joinParty(const PlayerPtr& player);
+		void revokeInvitation(const PlayerPtr& player);
+		bool passPartyLeadership(const PlayerPtr& player, bool forceRemove = false);
+		bool leaveParty(const PlayerPtr& player, bool forceRemove = false);
 
-		bool removeInvite(Player& player, bool removeFromPlayer = true);
+		bool removeInvite(const PlayerPtr& player, bool removeFromPlayer = true);
 
-		bool isPlayerInvited(const Player* player) const;
+		bool isPlayerInvited(const PlayerConstPtr& player) const;
 		void updateAllPartyIcons();
-		void broadcastPartyMessage(MessageClasses msgClass, const std::string& msg, bool sendToInvitations = false);
+		void broadcastPartyMessage(MessageClasses msgClass, const std::string& msg, bool sendToInvitations = false) const;
+	
 		bool empty() const {
 			return memberList.empty() && inviteList.empty();
 		}
+	
 		bool canOpenCorpse(uint32_t ownerId) const;
 
-		void shareExperience(uint64_t experience, Creature* source = nullptr);
-		bool setSharedExperience(Player* player, bool sharedExpActive);
+		void shareExperience(uint64_t experience, const CreaturePtr& source = nullptr);
+		bool setSharedExperience(const PlayerPtr& player, bool sharedExpActive);
+	
 		bool isSharedExperienceActive() const {
 			return sharedExpActive;
 		}
+	
 		bool isSharedExperienceEnabled() const {
 			return sharedExpEnabled;
 		}
-		bool canUseSharedExperience(const Player* player) const;
-		SharedExpStatus_t getMemberSharedExperienceStatus(const Player* player) const;
+	
+		bool canUseSharedExperience(const PlayerConstPtr& player) const;
+		SharedExpStatus_t getMemberSharedExperienceStatus(const PlayerConstPtr& player) const;
 		void updateSharedExperience();
 
-		void updatePlayerTicks(Player* player, uint32_t points);
-		void clearPlayerPoints(Player* player);
+		void updatePlayerTicks(const PlayerPtr& player, uint32_t points);
+		void clearPlayerPoints(const PlayerPtr& player);
 
 	private:
-		SharedExpStatus_t getSharedExperienceStatus();
+		SharedExpStatus_t getSharedExperienceStatus() const;
 
 		std::map<uint32_t, int64_t> ticksMap;
 
 		PlayerVector memberList;
 		PlayerVector inviteList;
 
-		Player* leader;
+		PlayerPtr leader;
 
 		bool sharedExpActive = false;
 		bool sharedExpEnabled = false;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3311,12 +3311,12 @@ ReturnValue Player::queryRemove(const ThingPtr& thing, uint32_t count, uint32_t 
 	return RETURNVALUE_NOERROR;
 }
 
-CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 		uint32_t& flags)
 {
 	std::cout << "Is a player destination query \n";
 	if (index == 0 /*drop to capacity window*/ || index == INDEX_WHEREEVER) {
-		*destItem = nullptr;
+		destItem = nullptr;
 
 		ItemPtr item = thing->getItem();
 		if (item == nullptr) {
@@ -3345,7 +3345,7 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 					if (queryAdd(slotIndex, item, item->getItemCount(), 0) == RETURNVALUE_NOERROR) {
 						if (inventoryItem->equals(item) && inventoryItem->getItemCount() < 100) {
 							index = slotIndex;
-							*destItem = inventoryItem;
+							destItem = inventoryItem;
 							return this->getPlayer();
 						}
 					}
@@ -3359,7 +3359,7 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 			} else if (queryAdd(slotIndex, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { //empty slot
 				index = slotIndex;
 				std::cout << "Almost certainly the call path in player query destination.. it returns nullptr to destitem after successful query add \n";
-				*destItem = nullptr;
+				destItem = nullptr;
 				return this->getPlayer();
 			}
 		}
@@ -3373,7 +3373,7 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 				while (n) {
 					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
 						index = tmpContainer->capacity() - n;
-						*destItem = nullptr;
+						destItem = nullptr;
 						return tmpContainer;
 					}
 
@@ -3403,7 +3403,7 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 				//try find an already existing item to stack with
 				if (tmpItem->equals(item) && tmpItem->getItemCount() < 100) {
 					index = n;
-					*destItem = tmpItem;
+					destItem = tmpItem;
 					return tmpContainer;
 				}
 
@@ -3416,7 +3416,7 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 
 			if (n < tmpContainer->capacity() && tmpContainer->queryAdd(n, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
 				index = n;
-				*destItem = nullptr;
+				destItem = nullptr;
 				return tmpContainer;
 			}
 		}
@@ -3426,12 +3426,12 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 
 	auto destThing = getThing(index);
 	if (destThing) {
-		*destItem = destThing->getItem();
+		destItem = destThing->getItem();
 	}
 
 	if (auto subCylinder = std::dynamic_pointer_cast<Cylinder>(destThing)) {
 		index = INDEX_WHEREEVER;
-		*destItem = nullptr;
+		destItem = nullptr;
 		return subCylinder;
 	} else {
 		return this->getPlayer();

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2155,8 +2155,6 @@ void Player::onThink(const uint32_t interval)
 		addMessageBuffer();
 	}
 
-	if (!getTile()) { std::cout << "Tile is gone!" << std::endl; }
-
 	if (!getTile()->hasFlag(TILESTATE_NOLOGOUT) && !isAccessPlayer()) {
 		idleTime += interval;
 		const int32_t kickAfterMinutes = g_config.getNumber(ConfigManager::KICK_AFTER_MINUTES);
@@ -3314,14 +3312,11 @@ ReturnValue Player::queryRemove(const ThingPtr& thing, uint32_t count, uint32_t 
 CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 		uint32_t& flags)
 {
-	std::cout << "Is a player destination query \n";
 	if (index == 0 /*drop to capacity window*/ || index == INDEX_WHEREEVER) {
 		destItem = nullptr;
 
 		ItemPtr item = thing->getItem();
 		if (item == nullptr) {
-			std::cout << "Player queryDestination says thing->getItem() is nullptr, returning "
-				<< getPlayer()->getName() << " as the CylinderPtr \n";
 			return this->getPlayer();
 		}
 
@@ -3358,7 +3353,6 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 				}
 			} else if (queryAdd(slotIndex, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { //empty slot
 				index = slotIndex;
-				std::cout << "Almost certainly the call path in player query destination.. it returns nullptr to destitem after successful query add \n";
 				destItem = nullptr;
 				return this->getPlayer();
 			}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3711,12 +3711,12 @@ void Player::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t 
 		if (shopOwner && requireListUpdate) {
 			updateSaleShopList(item);
 		}
-	} else if (const auto& creature = thing->getCreature()) {
+	} else if (auto creature = thing->getCreature()) {
 		if (creature == getCreature()) {
 			//check containers
 			std::vector<ContainerPtr> containers;
 
-			for (const auto& val : openContainers | std::views::values) {
+			for (auto& val : openContainers | std::views::values) {
 				if (!Position::areInRange<1, 1, 0>(val.container->getPosition(), getPosition())) {
 					containers.push_back(val.container);
 				}

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -3314,11 +3314,14 @@ ReturnValue Player::queryRemove(const ThingPtr& thing, uint32_t count, uint32_t 
 CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
 		uint32_t& flags)
 {
+	std::cout << "Is a player destination query \n";
 	if (index == 0 /*drop to capacity window*/ || index == INDEX_WHEREEVER) {
 		*destItem = nullptr;
 
 		ItemPtr item = thing->getItem();
 		if (item == nullptr) {
+			std::cout << "Player queryDestination says thing->getItem() is nullptr, returning "
+				<< getPlayer()->getName() << " as the CylinderPtr \n";
 			return this->getPlayer();
 		}
 
@@ -3347,14 +3350,15 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 						}
 					}
 
-					if (const auto& subContainer = inventoryItem->getContainer()) {
+					if (auto subContainer = inventoryItem->getContainer()) {
 						containers.push_back(subContainer);
 					}
-				} else if (const auto& subContainer = inventoryItem->getContainer()) {
+				} else if (auto subContainer = inventoryItem->getContainer()) {
 					containers.push_back(subContainer);
 				}
 			} else if (queryAdd(slotIndex, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { //empty slot
 				index = slotIndex;
+				std::cout << "Almost certainly the call path in player query destination.. it returns nullptr to destitem after successful query add \n";
 				*destItem = nullptr;
 				return this->getPlayer();
 			}
@@ -3376,8 +3380,8 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 					--n;
 				}
 
-				for (const auto& tmpContainerItem : tmpContainer->getItemList()) {
-					if (const auto& subContainer = tmpContainerItem->getContainer()) {
+				for (auto tmpContainerItem : tmpContainer->getItemList()) {
+					if (auto subContainer = tmpContainerItem->getContainer()) {
 						containers.push_back(subContainer);
 					}
 				}
@@ -3403,7 +3407,7 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 					return tmpContainer;
 				}
 
-				if (const auto& subContainer = tmpItem->getContainer()) {
+				if (auto subContainer = tmpItem->getContainer()) {
 					containers.push_back(subContainer);
 				}
 
@@ -3420,12 +3424,12 @@ CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, Item
 		return this->getPlayer();
 	}
 
-	const auto& destThing = getThing(index);
+	auto destThing = getThing(index);
 	if (destThing) {
 		*destItem = destThing->getItem();
 	}
 
-	if (const auto& subCylinder = std::dynamic_pointer_cast<Cylinder>(destThing)) {
+	if (auto subCylinder = std::dynamic_pointer_cast<Cylinder>(destThing)) {
 		index = INDEX_WHEREEVER;
 		*destItem = nullptr;
 		return subCylinder;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -680,39 +680,32 @@ static std::vector<uint32_t> GetDiaganolDeflectArea(uint32_t targets) {
 
 
 Player::Player(ProtocolGame_ptr p) :
-	Creature(), lastPing(OTSYS_TIME()), lastPong(lastPing), client(std::move(p)), inbox(new Inbox(ITEM_INBOX)), storeInbox(new StoreInbox(ITEM_STORE_INBOX))
+	lastPing(OTSYS_TIME()), lastPong(lastPing), client(std::move(p)), inbox(std::make_shared<Inbox>(ITEM_INBOX)), storeInbox(std::make_shared<StoreInbox>(ITEM_STORE_INBOX))
 {
-	inbox->incrementReferenceCounter();
 
-	storeInbox->setParent(this);
-	storeInbox->incrementReferenceCounter();
 }
 
 Player::~Player()
 {
-	for (Item* item : inventory) {
+	for (const auto& item : inventory) {
 		if (item) {
-			item->setParent(nullptr);
-			item->decrementReferenceCounter();
+			item->clearParent();
 		}
 	}
 
 	if (depotLocker) {
 		depotLocker->removeInbox(inbox);
 	}
-
-	inbox->decrementReferenceCounter();
-
-	storeInbox->setParent(nullptr);
-	storeInbox->decrementReferenceCounter();
+	
+	storeInbox->clearParent();
 
 	setWriteItem(nullptr);
 	setEditHouse(nullptr);
 }
 
-bool Player::setVocation(uint16_t vocId)
+bool Player::setVocation(const uint16_t vocId)
 {
-	Vocation* voc = g_vocations.getVocation(vocId);
+	const auto& voc = g_vocations.getVocation(vocId);
 	if (!voc) {
 		return false;
 	}
@@ -721,7 +714,7 @@ bool Player::setVocation(uint16_t vocId)
 	updateRegeneration();
 	setBaseSpeed(voc->getBaseSpeed());
 	updateBaseSpeed();
-	g_game.changeSpeed(this, 0);
+	g_game.changeSpeed(this->getPlayer(), 0);
 	return true;
 }
 
@@ -733,7 +726,7 @@ bool Player::isPushable() const
 	return Creature::isPushable();
 }
 
-std::string Player::getDescription(int32_t lookDistance) const
+std::string Player::getDescription(const int32_t lookDistance) const
 {
 	std::ostringstream s;
 
@@ -819,7 +812,7 @@ std::string Player::getDescription(int32_t lookDistance) const
 	return s.str();
 }
 
-Item* Player::getInventoryItem(slots_t slot) const
+ItemPtr Player::getInventoryItem(const slots_t slot) const
 {
 	if (slot < CONST_SLOT_FIRST || slot > CONST_SLOT_LAST) {
 		return nullptr;
@@ -827,7 +820,7 @@ Item* Player::getInventoryItem(slots_t slot) const
 	return inventory[slot];
 }
 
-Item* Player::getInventoryItem(uint32_t slot) const
+ItemPtr Player::getInventoryItem(const uint32_t slot) const
 {
 	if (slot < CONST_SLOT_FIRST || slot > CONST_SLOT_LAST) {
 		return nullptr;
@@ -835,24 +828,24 @@ Item* Player::getInventoryItem(uint32_t slot) const
 	return inventory[slot];
 }
 
-bool Player::isInventorySlot(slots_t slot) const
+bool Player::isInventorySlot(const slots_t slot)
 {
 	return slot >= CONST_SLOT_FIRST && slot <= CONST_SLOT_LAST;
 }	
 
-void Player::addConditionSuppressions(uint32_t conditions)
+void Player::addConditionSuppressions(const uint32_t conditions)
 {
 	conditionSuppressions |= conditions;
 }
 
-void Player::removeConditionSuppressions(uint32_t conditions)
+void Player::removeConditionSuppressions(const uint32_t conditions)
 {
 	conditionSuppressions &= ~conditions;
 }
 
-Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
+ItemPtr Player::getWeapon(const slots_t slot, const bool ignoreAmmo) const
 {
-	Item* item = inventory[slot];
+	auto item = inventory[slot];
 	if (!item) {
 		return nullptr;
 	}
@@ -865,11 +858,11 @@ Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 	if (!ignoreAmmo && weaponType == WEAPON_DISTANCE) {
 		const ItemType& itemType = Item::items[item->getID()];
 		if (itemType.ammoType != AMMO_NONE) {
-			Item* ammoItem = inventory[CONST_SLOT_AMMO];
+			const auto& ammoItem = inventory[CONST_SLOT_AMMO];
 			if (!ammoItem || ammoItem->getAmmoType() != itemType.ammoType) {
 				// no ammo item was found, search for quiver instead
-				Container* quiver = inventory[CONST_SLOT_RIGHT] ? inventory[CONST_SLOT_RIGHT]->getContainer() : nullptr;
-				if (!quiver || quiver->getWeaponType() != WEAPON_QUIVER) {
+				const auto& quiver = inventory[CONST_SLOT_RIGHT] ? inventory[CONST_SLOT_RIGHT]->getContainer() : nullptr;
+				if (!quiver || quiver->getItem()->getWeaponType() != WEAPON_QUIVER) {
 					// no quiver equipped
 					return nullptr;
 				}
@@ -877,8 +870,8 @@ Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 				for (ContainerIterator containerItem = quiver->iterator(); containerItem.hasNext();
 					containerItem.advance()) {
 					if (itemType.ammoType == (*containerItem)->getAmmoType()) {
-						const Weapon* weapon = g_weapons->getWeapon(*containerItem);
-						if (weapon && weapon->ammoCheck(this)) {
+						const auto& weapon = g_weapons->getWeapon(*containerItem);
+						if (weapon && weapon->ammoCheck(this->getPlayer())) {
 							return *containerItem;
 						}
 					}
@@ -893,30 +886,28 @@ Item* Player::getWeapon(slots_t slot, bool ignoreAmmo) const
 	return item;
 }
 
-Item* Player::getWeapon(bool ignoreAmmo/* = false*/) const
+ItemPtr Player::getWeapon(bool ignoreAmmo/* = false*/) const
 {
-	Item* item = getWeapon(CONST_SLOT_LEFT, ignoreAmmo);
-	if (item) {
-		return item;
+	if (const auto& leftHandItem = getWeapon(CONST_SLOT_LEFT, ignoreAmmo)) {
+		return leftHandItem;
 	}
-
-	item = getWeapon(CONST_SLOT_RIGHT, ignoreAmmo);
-	if (item) {
-		return item;
+	
+	if (const auto& rightHandItem = getWeapon(CONST_SLOT_RIGHT, ignoreAmmo)) {
+		return rightHandItem;
 	}
 	return nullptr;
 }
 
 WeaponType_t Player::getWeaponType() const
 {
-	Item* item = getWeapon();
+	const auto& item = getWeapon();
 	if (!item) {
 		return WEAPON_NONE;
 	}
 	return item->getWeaponType();
 }
 
-int32_t Player::getWeaponSkill(const Item* item) const
+int32_t Player::getWeaponSkill(const ItemConstPtr& item) const
 {
 	if (!item) {
 		return getSkillLevel(SKILL_FIST);
@@ -924,7 +915,7 @@ int32_t Player::getWeaponSkill(const Item* item) const
 
 	int32_t attackSkill;
 
-	WeaponType_t weaponType = item->getWeaponType();
+	const WeaponType_t weaponType = item->getWeaponType();
 	switch (weaponType) {
 		case WEAPON_SWORD: {
 			attackSkill = getSkillLevel(SKILL_SWORD);
@@ -958,62 +949,54 @@ int32_t Player::getArmor() const
 {
 	int32_t armor = 0;
 
-	static const slots_t armorSlots[] = {CONST_SLOT_HEAD, CONST_SLOT_NECKLACE, CONST_SLOT_ARMOR, CONST_SLOT_LEGS, CONST_SLOT_FEET, CONST_SLOT_RING};
+	static constexpr slots_t armorSlots[] = {CONST_SLOT_HEAD, CONST_SLOT_NECKLACE, CONST_SLOT_ARMOR, CONST_SLOT_LEGS, CONST_SLOT_FEET, CONST_SLOT_RING};
 	for (slots_t slot : armorSlots) {
-		Item* inventoryItem = inventory[slot];
-		if (inventoryItem) {
+		if (const auto& inventoryItem = inventory[slot]) {
 			armor += inventoryItem->getArmor();
 		}
 	}
 	return static_cast<int32_t>(armor * vocation->armorMultiplier);
 }
 
-void Player::getShieldAndWeapon(const Item*& shield, const Item*& weapon) const
-{
-	shield = nullptr;
-	weapon = nullptr;
-
-	for (uint32_t slot = CONST_SLOT_RIGHT; slot <= CONST_SLOT_LEFT; slot++) {
-		Item* item = inventory[slot];
-		if (!item) {
-			continue;
-		}
-
-		switch (item->getWeaponType()) {
-			case WEAPON_NONE:
-				break;
-
-			case WEAPON_SHIELD:
-			case WEAPON_QUIVER: {
-				if (!shield || item->getDefense() > shield->getDefense()) {
-					shield = item;
-				}
-				break;
-			}
-
-			default: { // weapons that are not shields
-				weapon = item;
-				break;
-			}
-		}
-	}
-}
-
 int32_t Player::getDefense() const
 {
 	int32_t defenseSkill = getSkillLevel(SKILL_FIST);
 	int32_t defenseValue = 7;
-	const Item* weapon;
-	const Item* shield;
-	getShieldAndWeapon(shield, weapon);
 
-	if (weapon) {
-		defenseValue = weapon->getDefense() + weapon->getExtraDefense();
-		defenseSkill = getWeaponSkill(weapon);
+	std::optional<ItemConstPtr> leftHand = inventory[CONST_SLOT_LEFT];
+	std::optional<ItemConstPtr> rightHand = inventory[CONST_SLOT_RIGHT];
+	std::optional<ItemConstPtr> shield = std::nullopt;
+	std::optional<ItemConstPtr> weapon = std::nullopt;
+
+	// We aren't going to waste precious CPU cycles or memory trying to determine which item
+	// has highest defense if you happen to have two shields, two quivers, or a shield
+	// and a quiver in each hand... in this case we are just gonna end up using left hand
+	// So if this is something that concerns you, you can go back to looping and using switches
+	// and storing variables to keep track of highest defense and do the math and all that yourself.
+	if (leftHand && (leftHand.value()->getWeaponType() == WEAPON_SHIELD || leftHand.value()->getWeaponType() == WEAPON_QUIVER))
+	{
+		shield = leftHand.value();
+		if (rightHand)
+		{
+			weapon = rightHand.value();
+		}
+	}
+	else if (rightHand && (rightHand.value()->getWeaponType() == WEAPON_SHIELD || rightHand.value()->getWeaponType() == WEAPON_QUIVER))
+	{
+		shield = rightHand.value();
+		if (leftHand)
+		{
+			weapon = leftHand.value();
+		}
+	}
+	
+	if (weapon.has_value()) {
+		defenseValue = weapon.value()->getDefense() + weapon.value()->getExtraDefense();
+		defenseSkill = getWeaponSkill(weapon.value());
 	}
 
-	if (shield) {
-		defenseValue = weapon != nullptr ? shield->getDefense() + weapon->getExtraDefense() : shield->getDefense();
+	if (shield.has_value()) {
+		defenseValue = weapon != nullptr ? shield.value()->getDefense() + weapon.value()->getExtraDefense() : shield.value()->getDefense();
 		defenseSkill = getSkillLevel(SKILL_SHIELD);
 	}
 
@@ -1033,7 +1016,7 @@ int32_t Player::getDefense() const
 
 uint32_t Player::getAttackSpeed() const
 {
-	const Item* weapon = getWeapon(true);
+	const auto& weapon = getWeapon(true);
 	if (!weapon || weapon->getAttackSpeed() == 0) {
 		return vocation->getAttackSpeed();
 	}
@@ -1064,7 +1047,7 @@ float Player::getDefenseFactor() const
 uint16_t Player::getClientIcons() const
 {
 	uint16_t icons = 0;
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (!isSuppress(condition->getType())) {
 			icons |= condition->getIcons();
 		}
@@ -1074,7 +1057,7 @@ uint16_t Player::getClientIcons() const
 		icons |= ICON_REDSWORDS;
 	}
 
-	if (tile && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+	if (tile.lock() && tile.lock()->hasFlag(TILESTATE_PROTECTIONZONE)) {
 		icons |= ICON_PIGEON;
 
 		// Don't show ICON_SWORDS if player is in protection zone.
@@ -1101,13 +1084,12 @@ void Player::updateInventoryWeight()
 
 	inventoryWeight = 0;
 	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
-		const Item* item = inventory[i];
-		if (item) {
+		if (const auto& item = inventory[i]) {
 			inventoryWeight += item->getWeight();
 		}
 	}
 
-	if (StoreInbox* storeInbox = getStoreInbox()) {
+	if (const auto& storeInbox = getStoreInbox()) {
 		inventoryWeight += storeInbox->getWeight();
 	}
 }
@@ -1121,7 +1103,7 @@ void Player::addSkillAdvance(skills_t skill, uint64_t count)
 		return;
 	}
 
-	g_events->eventPlayerOnGainSkillTries(this, skill, count);
+	g_events->eventPlayerOnGainSkillTries(this->getPlayer(), skill, count);
 	if (count == 0) {
 		return;
 	}
@@ -1135,7 +1117,7 @@ void Player::addSkillAdvance(skills_t skill, uint64_t count)
 
 		sendTextMessage(MESSAGE_EVENT_ADVANCE, fmt::format("You advanced to {:s} level {:d}.", getSkillName(skill), skills[skill].level));
 
-		g_creatureEvents->playerAdvance(this, skill, (skills[skill].level - 1), skills[skill].level);
+		g_creatureEvents->playerAdvance(this->getPlayer(), skill, (skills[skill].level - 1), skills[skill].level);
 
 		sendUpdateSkills = true;
 		currReqTries = nextReqTries;
@@ -1165,7 +1147,7 @@ void Player::addSkillAdvance(skills_t skill, uint64_t count)
 	}
 }
 
-void Player::removeSkillTries(skills_t skill, uint64_t count, bool notify/* = false*/)
+void Player::removeSkillTries(const skills_t skill, uint64_t count, const bool notify/* = false*/)
 {
 	uint16_t oldLevel = skills[skill].level;
 	uint8_t oldPercent = skills[skill].percent;
@@ -1200,7 +1182,7 @@ void Player::removeSkillTries(skills_t skill, uint64_t count, bool notify/* = fa
 	}
 }
 
-void Player::setVarStats(stats_t stat, int32_t modifier)
+void Player::setVarStats(const stats_t stat, const int32_t modifier)
 {
 	varStats[stat] += modifier;
 
@@ -1209,7 +1191,7 @@ void Player::setVarStats(stats_t stat, int32_t modifier)
 			if (getHealth() > getMaxHealth()) {
 				Creature::changeHealth(getMaxHealth() - getHealth());
 			} else {
-				g_game.addCreatureHealth(this);
+				g_game.addCreatureHealth(this->getPlayer());
 			}
 			break;
 		}
@@ -1227,7 +1209,7 @@ void Player::setVarStats(stats_t stat, int32_t modifier)
 	}
 }
 
-int32_t Player::getDefaultStats(stats_t stat) const
+int32_t Player::getDefaultStats(const stats_t stat) const
 {
 	switch (stat) {
 		case STAT_MAXHITPOINTS: return healthMax;
@@ -1237,24 +1219,14 @@ int32_t Player::getDefaultStats(stats_t stat) const
 	}
 }
 
-void Player::addContainer(uint8_t cid, Container* container)
+void Player::addContainer(const uint8_t cid, const ContainerPtr& container)
 {
 	if (cid > 0xF) {
 		return;
 	}
 
-	if (container->getID() == ITEM_BROWSEFIELD) {
-		container->incrementReferenceCounter();
-	}
-
-	auto it = openContainers.find(cid);
-	if (it != openContainers.end()) {
+	if (const auto& it = openContainers.find(cid); it != openContainers.end()) {
 		OpenContainer& openContainer = it->second;
-		Container* oldContainer = openContainer.container;
-		if (oldContainer->getID() == ITEM_BROWSEFIELD) {
-			oldContainer->decrementReferenceCounter();
-		}
-
 		openContainer.container = container;
 		openContainer.index = 0;
 	} else {
@@ -1265,41 +1237,37 @@ void Player::addContainer(uint8_t cid, Container* container)
 	}
 }
 
-void Player::closeContainer(uint8_t cid)
+void Player::closeContainer(const uint8_t cid)
 {
-	auto it = openContainers.find(cid);
+	const auto& it = openContainers.find(cid);
 	if (it == openContainers.end()) {
 		return;
 	}
 
 	OpenContainer openContainer = it->second;
-	Container* container = openContainer.container;
+	ContainerPtr container = openContainer.container;
 	openContainers.erase(it);
-
-	if (container && container->getID() == ITEM_BROWSEFIELD) {
-		container->decrementReferenceCounter();
-	}
 }
 
-void Player::setContainerIndex(uint8_t cid, uint16_t index)
+void Player::setContainerIndex(const uint8_t cid, const uint16_t index)
 {
-	auto it = openContainers.find(cid);
+	const auto& it = openContainers.find(cid);
 	if (it == openContainers.end()) {
 		return;
 	}
 	it->second.index = index;
 }
 
-Container* Player::getContainerByID(uint8_t cid)
+ContainerPtr Player::getContainerByID(const uint8_t cid)
 {
-	auto it = openContainers.find(cid);
+	const auto& it = openContainers.find(cid);
 	if (it == openContainers.end()) {
 		return nullptr;
 	}
 	return it->second.container;
 }
 
-int8_t Player::getContainerID(const Container* container) const
+int8_t Player::getContainerID(const ContainerConstPtr& container) const
 {
 	for (const auto& it : openContainers) {
 		if (it.second.container == container) {
@@ -1309,16 +1277,16 @@ int8_t Player::getContainerID(const Container* container) const
 	return -1;
 }
 
-uint16_t Player::getContainerIndex(uint8_t cid) const
+uint16_t Player::getContainerIndex(const uint8_t cid) const
 {
-	auto it = openContainers.find(cid);
+	const auto& it = openContainers.find(cid);
 	if (it == openContainers.end()) {
 		return 0;
 	}
 	return it->second.index;
 }
 
-bool Player::canOpenCorpse(uint32_t ownerId) const
+bool Player::canOpenCorpse(const uint32_t ownerId) const
 {
 	return getID() == ownerId || (party && party->canOpenCorpse(ownerId));
 }
@@ -1369,7 +1337,7 @@ void Player::addStorageValue(const uint32_t key, const int32_t value, const bool
 
 bool Player::getStorageValue(const uint32_t key, int32_t& value) const
 {
-	auto it = storageMap.find(key);
+	const auto it = storageMap.find(key);
 	if (it == storageMap.end()) {
 		value = -1;
 		return false;
@@ -1387,9 +1355,9 @@ bool Player::canSee(const Position& pos) const
 	return client->canSee(pos);
 }
 
-bool Player::canSeeCreature(const Creature* creature) const
+bool Player::canSeeCreature(const CreatureConstPtr& creature) const
 {
-	if (creature == this) {
+	if (creature == getCreature()) {
 		return true;
 	}
 
@@ -1403,33 +1371,33 @@ bool Player::canSeeCreature(const Creature* creature) const
 	return true;
 }
 
-bool Player::canSeeGhostMode(const Creature*) const
+bool Player::canSeeGhostMode(const CreatureConstPtr&) const
 {
 	return group->access;
 }
 
-bool Player::canWalkthrough(const Creature* creature) const
+bool Player::canWalkthrough(const CreatureConstPtr& creature) const
 {
 	if (group->access || creature->isInGhostMode() || (g_config.getBoolean(ConfigManager::ALLOW_WALKTHROUGH) && creature->getPlayer() && creature->getPlayer()->isAccessPlayer())) {
 		return true;
 	}
 
-	const Player* player = creature->getPlayer();
+	const auto& player = creature->getPlayer();
 	if (!player || !g_config.getBoolean(ConfigManager::ALLOW_WALKTHROUGH)) {
 		return false;
 	}
 
-	const Tile* playerTile = player->getTile();
+	const auto& playerTile = player->getTile();
 	if (!playerTile || (!playerTile->hasFlag(TILESTATE_PROTECTIONZONE) && player->getLevel() > static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL)))) {
 		return false;
 	}
 
-	const Item* playerTileGround = playerTile->getGround();
+	const auto& playerTileGround = playerTile->getGround();
 	if (!playerTileGround || !playerTileGround->hasWalkStack()) {
 		return false;
 	}
 
-	Player* thisPlayer = const_cast<Player*>(this);
+	const auto& thisPlayer = const_cast<Player*>(this);
 	if ((OTSYS_TIME() - lastWalkthroughAttempt) > 2000) {
 		thisPlayer->setLastWalkthroughAttempt(OTSYS_TIME());
 		return false;
@@ -1444,18 +1412,18 @@ bool Player::canWalkthrough(const Creature* creature) const
 	return true;
 }
 
-bool Player::canWalkthroughEx(const Creature* creature) const
+bool Player::canWalkthroughEx(const CreatureConstPtr& creature) const
 {
 	if (group->access) {
 		return true;
 	}
 
-	const Player* player = creature->getPlayer();
+	const auto& player = creature->getPlayer();
 	if (!player || !g_config.getBoolean(ConfigManager::ALLOW_WALKTHROUGH)) {
 		return false;
 	}
 
-	const Tile* playerTile = player->getTile();
+	const auto& playerTile = player->getTile();
 	return playerTile && (playerTile->hasFlag(TILESTATE_PROTECTIONZONE) || player->getLevel() <= static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL)));
 }
 
@@ -1471,7 +1439,7 @@ bool Player::isNearDepotBox() const
 	const Position& pos = getPosition();
 	for (int32_t cx = -NOTIFY_DEPOT_BOX_RANGE; cx <= NOTIFY_DEPOT_BOX_RANGE; ++cx) {
 		for (int32_t cy = -NOTIFY_DEPOT_BOX_RANGE; cy <= NOTIFY_DEPOT_BOX_RANGE; ++cy) {
-			Tile* tile = g_game.map.getTile(pos.x + cx, pos.y + cy, pos.z);
+			const auto& tile = g_game.map.getTile(pos.x + cx, pos.y + cy, pos.z);
 			if (!tile) {
 				continue;
 			}
@@ -1484,7 +1452,7 @@ bool Player::isNearDepotBox() const
 	return false;
 }
 
-DepotChest* Player::getDepotChest(uint32_t depotId, bool autoCreate)
+DepotChestPtr Player::getDepotChest(uint32_t depotId, const bool autoCreate)
 {
 	auto it = depotChests.find(depotId);
 	if (it != depotChests.end()) {
@@ -1500,22 +1468,21 @@ DepotChest* Player::getDepotChest(uint32_t depotId, bool autoCreate)
 		return nullptr;
 	}
 
-	it = depotChests.emplace(depotId, new DepotChest(depotItemId)).first;
+	it = depotChests.emplace(depotId, std::make_shared<DepotChest>(depotItemId)).first;
 	it->second->setMaxDepotItems(getMaxDepotItems());
 	return it->second;
 }
 
-DepotLocker& Player::getDepotLocker()
+DepotLockerPtr& Player::getDepotLocker()
 {
 	if (!depotLocker) {
 		depotLocker = std::make_shared<DepotLocker>(ITEM_LOCKER1);
 		depotLocker->internalAddThing(Item::CreateItem(ITEM_MARKET));
 		depotLocker->internalAddThing(inbox);
-		DepotChest* depotChest = new DepotChest(ITEM_DEPOT, false);
-		if (depotChest) {
+		if (const DepotChestPtr depotChest = std::make_shared<DepotChest>(ITEM_DEPOT, false)) {
 			// adding in reverse to align them from first to last
 			for (int16_t depotId = depotChest->capacity(); depotId >= 0; --depotId) {
-				if (DepotChest* box = getDepotChest(depotId, true)) {
+				if (DepotChestPtr box = getDepotChest(depotId, true)) {
 					depotChest->internalAddThing(box);
 				}
 			}
@@ -1523,14 +1490,14 @@ DepotLocker& Player::getDepotLocker()
 			depotLocker->internalAddThing(depotChest);
 		}
 	}
-	return *depotLocker;
+	return depotLocker;
 }
 
 uint32_t Player::getDepotItemCount()
 {
 	uint32_t counter = 0;
 
-	for (auto item : getDepotLocker().getItems(true)) {
+	for (const auto item : getDepotLocker()->getItems(true)) {
 		
 		++counter;
 
@@ -1549,13 +1516,12 @@ uint32_t Player::getDepotItemCount()
 	return counter;
 }
 
-RewardChest& Player::getRewardChest()
+RewardChestPtr& Player::getRewardChest()
 {
 	if (!rewardChest) {
 		rewardChest = std::make_shared<RewardChest>(ITEM_REWARD_CHEST);
-		RewardChest* rewardChest = new RewardChest(ITEM_REWARD_CHEST);
 	}
-	return *rewardChest;
+	return rewardChest;
 }
 
 void Player::sendCancelMessage(ReturnValue message) const
@@ -1600,43 +1566,37 @@ void Player::sendPing()
 			return;
 		}
 
-		if (!g_creatureEvents->playerLogout(this)) {
+		if (!g_creatureEvents->playerLogout(this->getPlayer())) {
 			return;
 		}
 
 		if (client) {
 			client->logout(true, true);
 		}
-		g_game.removeCreature(this, true);
+		g_game.removeCreature(this->getPlayer(), true);
 	}
 }
 
-Item* Player::getWriteItem(uint32_t& windowTextId, uint16_t& maxWriteLen)
+ItemPtr Player::getWriteItem(uint32_t& windowTextId, uint16_t& maxWriteLen)
 {
 	windowTextId = this->windowTextId;
 	maxWriteLen = this->maxWriteLen;
 	return writeItem;
 }
 
-void Player::setWriteItem(Item* item, uint16_t maxWriteLen /*= 0*/)
+void Player::setWriteItem(const ItemPtr& item, uint16_t maxWriteLen /*= 0*/)
 {
 	windowTextId++;
-
-	if (writeItem) {
-		writeItem->decrementReferenceCounter();
-	}
-
 	if (item) {
 		writeItem = item;
 		this->maxWriteLen = maxWriteLen;
-		writeItem->incrementReferenceCounter();
 	} else {
 		writeItem = nullptr;
 		this->maxWriteLen = 0;
 	}
 }
 
-House* Player::getEditHouse(uint32_t& windowTextId, uint32_t& listId)
+House* Player::getEditHouse(uint32_t& windowTextId, uint32_t& listId) const
 {
 	windowTextId = this->windowTextId;
 	listId = this->editListId;
@@ -1663,7 +1623,7 @@ void Player::sendHouseWindow(House* house, uint32_t listId) const
 }
 
 //container
-void Player::sendAddContainerItem(const Container* container, const Item* item)
+void Player::sendAddContainerItem(const ContainerConstPtr& container, ItemPtr& item) const
 {
 	if (!client) {
 		return;
@@ -1676,7 +1636,7 @@ void Player::sendAddContainerItem(const Container* container, const Item* item)
 		}
 
 		uint16_t slot = openContainer.index;
-		if (container->getID() == ITEM_BROWSEFIELD) {
+		if (container->getItem()->getID() == ITEM_BROWSEFIELD) {
 			uint16_t containerSize = container->size() - 1;
 			uint16_t pageEnd = openContainer.index + container->capacity() - 1;
 			if (containerSize > pageEnd) {
@@ -1695,7 +1655,7 @@ void Player::sendAddContainerItem(const Container* container, const Item* item)
 	}
 }
 
-void Player::sendUpdateContainerItem(const Container* container, uint16_t slot, const Item* newItem)
+void Player::sendUpdateContainerItem(const ContainerConstPtr& container, uint16_t slot, const ItemConstPtr& newItem) const
 {
 	if (!client) {
 		return;
@@ -1711,8 +1671,7 @@ void Player::sendUpdateContainerItem(const Container* container, uint16_t slot, 
 			continue;
 		}
 
-		uint16_t pageEnd = openContainer.index + container->capacity();
-		if (slot >= pageEnd) {
+		if (const uint16_t pageEnd = openContainer.index + container->capacity(); slot >= pageEnd) {
 			continue;
 		}
 
@@ -1720,7 +1679,7 @@ void Player::sendUpdateContainerItem(const Container* container, uint16_t slot, 
 	}
 }
 
-void Player::sendRemoveContainerItem(const Container* container, uint16_t slot)
+void Player::sendRemoveContainerItem(const ContainerConstPtr& container, const uint16_t slot)
 {
 	if (!client) {
 		return;
@@ -1742,8 +1701,8 @@ void Player::sendRemoveContainerItem(const Container* container, uint16_t slot)
 	}
 }
 
-void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item* oldItem,
-                              const ItemType& oldType, const Item* newItem, const ItemType& newType)
+void Player::onUpdateTileItem(const TilePtr& tile, const Position& pos, const ItemPtr& oldItem,
+                              const ItemType& oldType, const ItemPtr& newItem, const ItemType& newType)
 {
 	Creature::onUpdateTileItem(tile, pos, oldItem, oldType, newItem, newType);
 
@@ -1753,13 +1712,13 @@ void Player::onUpdateTileItem(const Tile* tile, const Position& pos, const Item*
 
 	if (tradeState != TRADE_TRANSFER) {
 		if (tradeItem && oldItem == tradeItem) {
-			g_game.internalCloseTrade(this);
+			g_game.internalCloseTrade(this->getPlayer());
 		}
 	}
 }
 
-void Player::onRemoveTileItem(const Tile* tile, const Position& pos, const ItemType& iType,
-                              const Item* item)
+void Player::onRemoveTileItem(const TilePtr& tile, const Position& pos, const ItemType& iType,
+                              const ItemPtr& item)
 {
 	Creature::onRemoveTileItem(tile, pos, iType, item);
 
@@ -1767,39 +1726,37 @@ void Player::onRemoveTileItem(const Tile* tile, const Position& pos, const ItemT
 		checkTradeState(item);
 
 		if (tradeItem) {
-			const Container* container = item->getContainer();
+			const auto& container = item->getContainer();
 			if (container && container->isHoldingItem(tradeItem)) {
-				g_game.internalCloseTrade(this);
+				g_game.internalCloseTrade(this->getPlayer());
 			}
 		}
 	}
 }
 
-void Player::onCreatureAppear(Creature* creature, bool isLogin)
+void Player::onCreatureAppear(const CreaturePtr& creature, bool isLogin)
 {
 	Creature::onCreatureAppear(creature, isLogin);
 
-	if (isLogin && creature == this) {
+	if (isLogin && creature == getCreature()) {
 		sendItems();
 
 		for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
-			Item* item = inventory[slot];
-			if (item) {
+			if (const auto& item = inventory[slot]) {
 				item->startDecaying();
-				g_moveEvents->onPlayerEquip(this, item, static_cast<slots_t>(slot), false);
+				g_moveEvents->onPlayerEquip(this->getPlayer(), item, static_cast<slots_t>(slot), false);
 			}
 		}
 
-		for (Condition* condition : storedConditionList) {
+		for (const auto& condition : storedConditionList) {
 			addCondition(condition);
 		}
 		storedConditionList.clear();
 
 		updateRegeneration();
 
-		BedItem* bed = g_game.getBedBySleeper(guid);
-		if (bed) {
-			bed->wakeUp(this);
+		if (const auto& bed = g_game.getBedBySleeper(guid)) {
+			bed->wakeUp(this->getPlayer());
 		}
 
 		Account account = IOLoginData::loadAccount(accountNumber);
@@ -1809,7 +1766,7 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin)
 		}
 
 		if (guild) {
-			guild->addMember(this);
+			guild->addMember(this->getPlayer());
 		}
 
 		int32_t offlineTime;
@@ -1820,7 +1777,7 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin)
 			offlineTime = 0;
 		}
 
-		for (Condition* condition : getMuteConditions()) {
+		for (const auto& condition : getMuteConditions()) {
 			condition->setTicks(condition->getTicks() - (offlineTime * 1000));
 			if (condition->getTicks() <= 0) {
 				removeCondition(condition);
@@ -1832,7 +1789,7 @@ void Player::onCreatureAppear(Creature* creature, bool isLogin)
 	}
 }
 
-void Player::onAttackedCreatureDisappear(bool isLogout)
+void Player::onAttackedCreatureDisappear(const bool isLogout)
 {
 	sendCancelTarget();
 
@@ -1841,7 +1798,7 @@ void Player::onAttackedCreatureDisappear(bool isLogout)
 	}
 }
 
-void Player::onFollowCreatureDisappear(bool isLogout)
+void Player::onFollowCreatureDisappear(const bool isLogout)
 {
 	sendCancelTarget();
 
@@ -1850,7 +1807,7 @@ void Player::onFollowCreatureDisappear(bool isLogout)
 	}
 }
 
-void Player::onChangeZone(ZoneType_t zone)
+void Player::onChangeZone(const ZoneType_t zone)
 {
 	if (zone == ZONE_PROTECTION) {
 		if (attackedCreature && !hasFlag(PlayerFlag_IgnoreProtectionZone)) {
@@ -1860,7 +1817,7 @@ void Player::onChangeZone(ZoneType_t zone)
 
 		if (!group->access && isMounted()) {
 			dismount();
-			g_game.internalCreatureChangeOutfit(this, defaultOutfit);
+			g_game.internalCreatureChangeOutfit(this->getPlayer(), defaultOutfit);
 			wasMounted = true;
 		}
 	} else {
@@ -1870,11 +1827,11 @@ void Player::onChangeZone(ZoneType_t zone)
 		}
 	}
 
-	g_game.updateCreatureWalkthrough(this);
+	g_game.updateCreatureWalkthrough(this->getPlayer());
 	sendIcons();
 }
 
-void Player::onAttackedCreatureChangeZone(ZoneType_t zone)
+void Player::onAttackedCreatureChangeZone(const ZoneType_t zone)
 {
 	if (zone == ZONE_PROTECTION) {
 		if (!hasFlag(PlayerFlag_IgnoreProtectionZone)) {
@@ -1899,15 +1856,14 @@ void Player::onAttackedCreatureChangeZone(ZoneType_t zone)
 	}
 }
 
-void Player::onRemoveCreature(Creature* creature, bool isLogout)
+void Player::onRemoveCreature(const CreaturePtr& creature, bool isLogout)
 {
 	Creature::onRemoveCreature(creature, isLogout);
 
-	if (creature == this) {
+	if (creature == getCreature()) {
 		for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
-			Item* item = inventory[slot];
-			if (item) {
-				g_moveEvents->onPlayerDeEquip(this, item, static_cast<slots_t>(slot));
+			if (const auto& item = inventory[slot]) {
+				g_moveEvents->onPlayerDeEquip(this->getPlayer(), item, static_cast<slots_t>(slot));
 			}
 		}
 		if (isLogout) {
@@ -1921,7 +1877,7 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout)
 		}
 
 		if (tradePartner) {
-			g_game.internalCloseTrade(this);
+			g_game.internalCloseTrade(this->getPlayer());
 		}
 
 		closeShopWindow();
@@ -1929,24 +1885,24 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout)
 		clearPartyInvitations();
 
 		if (party) {
-			party->leaveParty(this, true);
+			party->leaveParty(this->getPlayer(), true);
 		}
 
-		g_chat->removeUserFromAllChannels(*this);
+		g_chat->removeUserFromAllChannels(this->getPlayer());
 
 		if (g_config.getBoolean(ConfigManager::PLAYER_CONSOLE_LOGS)) {
 			std::cout << getName() << " has logged out." << std::endl;
 		}
 
 		if (guild) {
-			guild->removeMember(this);
+			guild->removeMember(this->getPlayer());
 		}
 
 		IOLoginData::updateOnlineStatus(guid, false);
 
 		bool saved = false;
 		for (uint32_t tries = 0; tries < 3; ++tries) {
-			if (IOLoginData::savePlayer(this)) {
+			if (IOLoginData::savePlayer(this->getPlayer())) {
 				saved = true;
 				break;
 			}
@@ -1958,7 +1914,7 @@ void Player::onRemoveCreature(Creature* creature, bool isLogout)
 	}
 }
 
-void Player::openShopWindow(Npc* npc, const std::list<ShopInfo>& shop)
+void Player::openShopWindow(const NpcPtr& npc, const std::list<ShopInfo>& shop)
 {
 	shopItemList = shop;
 	sendShop(npc);
@@ -1971,14 +1927,14 @@ bool Player::closeShopWindow(bool sendCloseShopWindow /*= true*/)
 	int32_t onBuy;
 	int32_t onSell;
 
-	Npc* npc = getShopOwner(onBuy, onSell);
+	const auto& npc = getShopOwner(onBuy, onSell);
 	if (!npc) {
 		shopItemList.clear();
 		return false;
 	}
 
 	setShopOwner(nullptr, -1, -1);
-	npc->onPlayerEndTrade(this, onBuy, onSell);
+	npc->onPlayerEndTrade(this->getPlayer(), onBuy, onSell);
 
 	if (sendCloseShopWindow) {
 		sendCloseShop();
@@ -1995,28 +1951,28 @@ void Player::onWalk(Direction& dir)
 	setNextAction(OTSYS_TIME() + getStepDuration(dir));
 }
 
-void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Position& newPos,
-                            const Tile* oldTile, const Position& oldPos, bool teleport)
+void Player::onCreatureMove(const CreaturePtr& creature, const TilePtr& newTile, const Position& newPos,
+                            const TilePtr& oldTile, const Position& oldPos, bool teleport)
 {
 	Creature::onCreatureMove(creature, newTile, newPos, oldTile, oldPos, teleport);
 
-	if (hasFollowPath && (creature == followCreature || (creature == this && followCreature))) {
+	if (hasFollowPath && (creature == followCreature || (creature == this->getPlayer() && followCreature))) {
 		isUpdatingPath = false;
 		g_dispatcher.addTask(createTask([id = getID()]() { g_game.updateCreatureWalk(id); }));
 	}
 
-	if (creature != this) {
+	if (creature != this->getPlayer()) {
 		return;
 	}
 
 	if (tradeState != TRADE_TRANSFER) {
 		//check if we should close trade
 		if (tradeItem && !Position::areInRange<1, 1, 0>(tradeItem->getPosition(), getPosition())) {
-			g_game.internalCloseTrade(this);
+			g_game.internalCloseTrade(this->getPlayer());
 		}
 
 		if (tradePartner && !Position::areInRange<2, 2, 0>(tradePartner->getPosition(), getPosition())) {
-			g_game.internalCloseTrade(this);
+			g_game.internalCloseTrade(this->getPlayer());
 		}
 	}
 
@@ -2044,7 +2000,7 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 	if (teleport || oldPos.z != newPos.z) {
 		int32_t ticks = g_config.getNumber(ConfigManager::STAIRHOP_DELAY);
 		if (ticks > 0) {
-			if (Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_PACIFIED, ticks, 0)) {
+			if (const auto& condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_PACIFIED, ticks, 0)) {
 				addCondition(condition);
 			}
 		}
@@ -2052,12 +2008,12 @@ void Player::onCreatureMove(Creature* creature, const Tile* newTile, const Posit
 }
 
 //container
-void Player::onAddContainerItem(const Item* item)
+void Player::onAddContainerItem(const ItemPtr& item)
 {
 	checkTradeState(item);
 }
 
-void Player::onUpdateContainerItem(const Container* container, const Item* oldItem, const Item* newItem)
+void Player::onUpdateContainerItem(const ContainerPtr& container, const ItemPtr& oldItem, const ItemPtr& newItem)
 {
 	if (oldItem != newItem) {
 		onRemoveContainerItem(container, oldItem);
@@ -2068,20 +2024,20 @@ void Player::onUpdateContainerItem(const Container* container, const Item* oldIt
 	}
 }
 
-void Player::onRemoveContainerItem(const Container* container, const Item* item)
+void Player::onRemoveContainerItem(const ContainerPtr& container, const ItemPtr& item)
 {
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);
 
 		if (tradeItem) {
 			if (tradeItem->getParent() != container && container->isHoldingItem(tradeItem)) {
-				g_game.internalCloseTrade(this);
+				g_game.internalCloseTrade(this->getPlayer());
 			}
 		}
 	}
 }
 
-void Player::onCloseContainer(const Container* container)
+void Player::onCloseContainer(const ContainerConstPtr& container) const
 {
 	if (!client) {
 		return;
@@ -2094,13 +2050,13 @@ void Player::onCloseContainer(const Container* container)
 	}
 }
 
-void Player::onSendContainer(const Container* container)
+void Player::onSendContainer(const ContainerPtr& container) const
 {
 	if (!client) {
 		return;
 	}
 
-	bool hasParent = container->hasParent();
+	const bool hasParent = container->hasParent();
 	for (const auto& it : openContainers) {
 		const OpenContainer& openContainer = it.second;
 		if (openContainer.container == container) {
@@ -2110,7 +2066,7 @@ void Player::onSendContainer(const Container* container)
 }
 
 //inventory
-void Player::onUpdateInventoryItem(Item* oldItem, Item* newItem)
+void Player::onUpdateInventoryItem(const ItemPtr& oldItem, const ItemPtr& newItem)
 {
 	if (oldItem != newItem) {
 		onRemoveInventoryItem(oldItem);
@@ -2121,37 +2077,37 @@ void Player::onUpdateInventoryItem(Item* oldItem, Item* newItem)
 	}
 }
 
-void Player::onRemoveInventoryItem(Item* item)
+void Player::onRemoveInventoryItem(const ItemPtr& item)
 {
 	if (tradeState != TRADE_TRANSFER) {
 		checkTradeState(item);
 
 		if (tradeItem) {
-			const Container* container = item->getContainer();
+			const auto& container = item->getContainer();
 			if (container && container->isHoldingItem(tradeItem)) {
-				g_game.internalCloseTrade(this);
+				g_game.internalCloseTrade(this->getPlayer());
 			}
 		}
 	}
 }
 
-void Player::checkTradeState(const Item* item)
+void Player::checkTradeState(const ItemPtr& item)
 {
 	if (!tradeItem || tradeState == TRADE_TRANSFER) {
 		return;
 	}
 
 	if (tradeItem == item) {
-		g_game.internalCloseTrade(this);
+		g_game.internalCloseTrade(this->getPlayer());
 	} else {
-		const Container* container = dynamic_cast<const Container*>(item->getParent());
+		auto container = std::dynamic_pointer_cast<Container>(item->getParent());
 		while (container) {
 			if (container == tradeItem) {
-				g_game.internalCloseTrade(this);
+				g_game.internalCloseTrade(this->getPlayer());
 				break;
 			}
 
-			container = dynamic_cast<const Container*>(container->getParent());
+			container = std::dynamic_pointer_cast<Container>(container->getParent());
 		}
 	}
 }
@@ -2187,7 +2143,7 @@ uint32_t Player::getNextActionTime() const
 	return std::max<int64_t>(SCHEDULER_MINTICKS, nextAction - OTSYS_TIME());
 }
 
-void Player::onThink(uint32_t interval)
+void Player::onThink(const uint32_t interval)
 {
 	Creature::onThink(interval);
 
@@ -2198,6 +2154,8 @@ void Player::onThink(uint32_t interval)
 		MessageBufferTicks = 0;
 		addMessageBuffer();
 	}
+
+	if (!getTile()) { std::cout << "Tile is gone!" << std::endl; }
 
 	if (!getTile()->hasFlag(TILESTATE_NOLOGOUT) && !isAccessPlayer()) {
 		idleTime += interval;
@@ -2211,7 +2169,7 @@ void Player::onThink(uint32_t interval)
 
 	// if (isImbued()) { // TODO: Reimplement a check like this to first see if player has any items, then items with imbuements before decaying.
 		for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
-			Item* item = inventory[slot];
+			const auto& item = inventory[slot];
 			if (item && item->hasImbuements()) {
 				item->decayImbuements(hasCondition(CONDITION_INFIGHT));
 				sendSkills();
@@ -2237,7 +2195,7 @@ uint32_t Player::isMuted() const
 	}
 
 	int32_t muteTicks = 0;
-	for (Condition* condition : conditions) {
+	for (const auto& condition : conditions) {
 		if (condition->getType() == CONDITION_MUTED && condition->getTicks() > muteTicks) {
 			muteTicks = condition->getTicks();
 		}
@@ -2262,14 +2220,13 @@ void Player::removeMessageBuffer()
 	if (maxMessageBuffer != 0 && MessageBufferCount <= maxMessageBuffer + 1) {
 		if (++MessageBufferCount > maxMessageBuffer) {
 			uint32_t muteCount = 1;
-			auto it = muteCountMap.find(guid);
-			if (it != muteCountMap.end()) {
+			if (const auto& it = muteCountMap.find(guid); it != muteCountMap.end()) {
 				muteCount = it->second;
 			}
 
 			uint32_t muteTime = 5 * muteCount * muteCount;
 			muteCountMap[guid] = muteCount + 1;
-			Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_MUTED, muteTime * 1000, 0);
+			const auto& condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_MUTED, muteTime * 1000, 0);
 			addCondition(condition);
 
 			sendTextMessage(MESSAGE_STATUS_SMALL, fmt::format("You are muted for {:d} seconds.", muteTime));
@@ -2277,13 +2234,13 @@ void Player::removeMessageBuffer()
 	}
 }
 
-void Player::drainHealth(Creature* attacker, int32_t damage)
+void Player::drainHealth(const CreaturePtr& attacker, const int32_t damage)
 {
 	Creature::drainHealth(attacker, damage);
 	sendStats();
 }
 
-void Player::drainMana(Creature* attacker, int32_t manaLoss)
+void Player::drainMana(const CreaturePtr& attacker, const int32_t manaLoss)
 {
 	onAttacked();
 	changeMana(-manaLoss);
@@ -2308,7 +2265,7 @@ void Player::addManaSpent(uint64_t amount)
 		return;
 	}
 
-	g_events->eventPlayerOnGainSkillTries(this, SKILL_MAGLEVEL, amount);
+	g_events->eventPlayerOnGainSkillTries(this->getPlayer(), SKILL_MAGLEVEL, amount);
 	if (amount == 0) {
 		return;
 	}
@@ -2322,7 +2279,7 @@ void Player::addManaSpent(uint64_t amount)
 
 		sendTextMessage(MESSAGE_EVENT_ADVANCE, fmt::format("You advanced to magic level {:d}.", magLevel));
 
-		g_creatureEvents->playerAdvance(this, SKILL_MAGLEVEL, magLevel - 1, magLevel);
+		g_creatureEvents->playerAdvance(this->getPlayer(), SKILL_MAGLEVEL, magLevel - 1, magLevel);
 
 		sendUpdateStats = true;
 		currReqMana = nextReqMana;
@@ -2350,14 +2307,14 @@ void Player::addManaSpent(uint64_t amount)
 	}
 }
 
-void Player::removeManaSpent(uint64_t amount, bool notify/* = false*/)
+void Player::removeManaSpent(uint64_t amount, const bool notify/* = false*/)
 {
 	if (amount == 0) {
 		return;
 	}
 
-	uint32_t oldLevel = magLevel;
-	uint8_t oldPercent = magLevelPercent;
+	const uint32_t oldLevel = magLevel;
+	const uint8_t oldPercent = magLevelPercent;
 
 	while (amount > manaSpent && magLevel > 0) {
 		amount -= manaSpent;
@@ -2387,7 +2344,7 @@ void Player::removeManaSpent(uint64_t amount, bool notify/* = false*/)
 	}
 }
 
-void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = false*/)
+void Player::addExperience(const CreaturePtr& source, uint64_t exp, bool sendText/* = false*/)
 {
 	uint64_t currLevelExp = Player::getExpForLevel(level);
 	uint64_t nextLevelExp = Player::getExpForLevel(level + 1);
@@ -2399,7 +2356,7 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		return;
 	}
 
-	g_events->eventPlayerOnGainExperience(this, source, exp, rawExp);
+	g_events->eventPlayerOnGainExperience(this->getPlayer(), source, exp, rawExp);
 	if (exp == 0) {
 		return;
 	}
@@ -2407,7 +2364,7 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 	experience += exp;
 
 	if (sendText) {
-		std::string expString = std::to_string(exp) + (exp != 1 ? " experience points." : " experience point.");
+		const std::string expString = std::to_string(exp) + (exp != 1 ? " experience points." : " experience point.");
 
 		TextMessage message(MESSAGE_EXPERIENCE, "You gained " + expString);
 		message.position = position;
@@ -2417,13 +2374,13 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 
 		SpectatorVec spectators;
 		g_game.map.getSpectators(spectators, position, false, true);
-		spectators.erase(this);
+		spectators.erase(this->getPlayer());
 		if (!spectators.empty()) {
 			message.type = MESSAGE_EXPERIENCE_OTHERS;
 			message.text = getName() + " gained " + expString;
-			for (Creature* spectator : spectators) {
-				assert(dynamic_cast<Player*>(spectator) != nullptr);
-				static_cast<Player*>(spectator)->sendTextMessage(message);
+			for (const auto& spectator : spectators) {
+				assert(std::dynamic_pointer_cast<Player>(spectator) != nullptr);
+				std::static_pointer_cast<Player>(spectator)->sendTextMessage(message);
 			}
 		}
 	}
@@ -2452,19 +2409,19 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 		updateBaseSpeed();
 		setBaseSpeed(getBaseSpeed());
 
-		g_game.changeSpeed(this, 0);
-		g_game.addCreatureHealth(this);
+		g_game.changeSpeed(this->getPlayer(), 0);
+		g_game.addCreatureHealth(this->getPlayer());
 
 		const uint32_t protectionLevel = static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL));
 		if (prevLevel < protectionLevel && level >= protectionLevel) {
-			g_game.updateCreatureWalkthrough(this);
+			g_game.updateCreatureWalkthrough(this->getPlayer());
 		}
 
 		if (party) {
 			party->updateSharedExperience();
 		}
 
-		g_creatureEvents->playerAdvance(this, SKILL_LEVEL, prevLevel, level);
+		g_creatureEvents->playerAdvance(this->getPlayer(), SKILL_LEVEL, prevLevel, level);
 
 		sendTextMessage(MESSAGE_EVENT_ADVANCE, fmt::format("You advanced from Level {:d} to Level {:d}.", prevLevel, level));
 	}
@@ -2477,13 +2434,13 @@ void Player::addExperience(Creature* source, uint64_t exp, bool sendText/* = fal
 	sendStats();
 }
 
-void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
+void Player::removeExperience(uint64_t exp, const bool sendText/* = false*/)
 {
 	if (experience == 0 || exp == 0) {
 		return;
 	}
 
-	g_events->eventPlayerOnLoseExperience(this, exp);
+	g_events->eventPlayerOnLoseExperience(this->getPlayer(), exp);
 	if (exp == 0) {
 		return;
 	}
@@ -2494,7 +2451,7 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 	if (sendText) {
 		lostExp -= experience;
 
-		std::string expString = std::to_string(lostExp) + (lostExp != 1 ? " experience points." : " experience point.");
+		const std::string expString = std::to_string(lostExp) + (lostExp != 1 ? " experience points." : " experience point.");
 
 		TextMessage message(MESSAGE_EXPERIENCE, "You lost " + expString);
 		message.position = position;
@@ -2504,13 +2461,13 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 
 		SpectatorVec spectators;
 		g_game.map.getSpectators(spectators, position, false, true);
-		spectators.erase(this);
+		spectators.erase(this->getPlayer());
 		if (!spectators.empty()) {
 			message.type = MESSAGE_EXPERIENCE_OTHERS;
 			message.text = getName() + " lost " + expString;
-			for (Creature* spectator : spectators) {
-				assert(dynamic_cast<Player*>(spectator) != nullptr);
-				static_cast<Player*>(spectator)->sendTextMessage(message);
+			for (const auto& spectator : spectators) {
+				assert(std::dynamic_pointer_cast<Player>(spectator) != nullptr);
+				std::static_pointer_cast<Player>(spectator)->sendTextMessage(message);
 			}
 		}
 	}
@@ -2533,12 +2490,12 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 		updateBaseSpeed();
 		setBaseSpeed(getBaseSpeed());
 
-		g_game.changeSpeed(this, 0);
-		g_game.addCreatureHealth(this);
+		g_game.changeSpeed(this->getPlayer(), 0);
+		g_game.addCreatureHealth(this->getPlayer());
 
 		const uint32_t protectionLevel = static_cast<uint32_t>(g_config.getNumber(ConfigManager::PROTECTION_LEVEL));
 		if (oldLevel >= protectionLevel && level < protectionLevel) {
-			g_game.updateCreatureWalkthrough(this);
+			g_game.updateCreatureWalkthrough(this->getPlayer());
 		}
 
 		if (party) {
@@ -2557,7 +2514,7 @@ void Player::removeExperience(uint64_t exp, bool sendText/* = false*/)
 	sendStats();
 }
 
-uint8_t Player::getPercentLevel(uint64_t count, uint64_t nextLevelCount)
+uint8_t Player::getPercentLevel(const uint64_t count, uint64_t nextLevelCount)
 {
 	if (nextLevelCount == 0) {
 		return 0;
@@ -2614,7 +2571,7 @@ void Player::onAttackedCreatureBlockHit(BlockType_t blockType)
 
 bool Player::hasShield() const
 {
-	Item* item = inventory[CONST_SLOT_LEFT];
+	auto item = inventory[CONST_SLOT_LEFT];
 	if (item && item->getWeaponType() == WEAPON_SHIELD) {
 		return true;
 	}
@@ -2626,7 +2583,7 @@ bool Player::hasShield() const
 	return false;
 }
 
-BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_t& damage,
+BlockType_t Player::blockHit(const CreaturePtr& attacker, CombatType_t combatType, int32_t& damage,
                              bool checkDefense /* = false*/, bool checkArmor /* = false*/, bool field /* = false*/, bool ignoreResistances /* = false*/)
 {
 	BlockType_t blockType = Creature::blockHit(attacker, combatType, damage, checkDefense, checkArmor, field, ignoreResistances);
@@ -2643,13 +2600,12 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 				continue;
 			}
 
-			Item* item = inventory[slot];
+			auto item = inventory[slot];
 			if (!item) {
 				continue;
 			}
 
-			const ItemType& it = Item::items[item->getID()];
-			if (!it.abilities) {
+			if (const ItemType& it = Item::items[item->getID()]; !it.abilities) {
 				if (damage <= 0) {
 					damage = 0;
 					return BLOCK_ARMOR;
@@ -2657,8 +2613,7 @@ BlockType_t Player::blockHit(Creature* attacker, CombatType_t combatType, int32_
 				continue;
 			}
 
-			uint16_t charges = item->getCharges();
-			if (charges != 0) {
+			if (const uint16_t charges = item->getCharges(); charges != 0) {
 				g_game.transformItem(item, item->getID(), charges - 1);
 			}
 		}
@@ -2680,13 +2635,13 @@ uint32_t Player::getIP() const
 	return 0;
 }
 
-void Player::death(Creature* lastHitCreature)
+void Player::death(const CreaturePtr& lastHitCreature)
 {
 	loginPosition = town->getTemplePosition();
 
 	if (skillLoss) {
 		uint8_t unfairFightReduction = 100;
-		bool lastHitPlayer = Player::lastHitIsPlayer(lastHitCreature);
+		const bool lastHitPlayer = Player::lastHitIsPlayer(lastHitCreature);
 
 		if (lastHitPlayer) {
 			uint32_t sumLevels = 0;
@@ -2694,8 +2649,7 @@ void Player::death(Creature* lastHitCreature)
 			for (const auto& it : damageMap) {
 				CountBlock_t cb = it.second;
 				if ((OTSYS_TIME() - cb.ticks) <= inFightTicks) {
-					Player* damageDealer = g_game.getPlayerByID(it.first);
-					if (damageDealer) {
+					if (const auto& damageDealer = g_game.getPlayerByID(it.first)) {
 						sumLevels += damageDealer->getLevel();
 					}
 				}
@@ -2730,7 +2684,7 @@ void Player::death(Creature* lastHitCreature)
 
 		//Level loss
 		uint64_t expLoss = static_cast<uint64_t>(experience * deathLossPercent);
-		g_events->eventPlayerOnLoseExperience(this, expLoss);
+		g_events->eventPlayerOnLoseExperience(this->getPlayer(), expLoss);
 
 		if (expLoss != 0) {
 			uint32_t oldLevel = level;
@@ -2788,7 +2742,7 @@ void Player::death(Creature* lastHitCreature)
 			if (condition->isPersistent()) {
 				it = conditions.erase(it);
 
-				condition->endCondition(this);
+				condition->endCondition(this->getPlayer());
 				onEndCondition(condition->getType());
 				delete condition;
 			} else {
@@ -2804,7 +2758,7 @@ void Player::death(Creature* lastHitCreature)
 			if (condition->isPersistent()) {
 				it = conditions.erase(it);
 
-				condition->endCondition(this);
+				condition->endCondition(this->getPlayer());
 				onEndCondition(condition->getType());
 				delete condition;
 			} else {
@@ -2813,15 +2767,15 @@ void Player::death(Creature* lastHitCreature)
 		}
 
 		health = healthMax;
-		g_game.internalTeleport(this, getTemplePosition(), true);
-		g_game.addCreatureHealth(this);
+		g_game.internalTeleport(this->getPlayer(), getTemplePosition(), true);
+		g_game.addCreatureHealth(this->getPlayer());
 		onThink(EVENT_CREATURE_THINK_INTERVAL);
 		onIdleStatus();
 		sendStats();
 	}
 }
 
-bool Player::dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified)
+bool Player::dropCorpse(const CreaturePtr& lastHitCreature, const CreaturePtr& mostDamageCreature, bool lastHitUnjustified, bool mostDamageUnjustified)
 {
 	if (getZone() != ZONE_PVP || !Player::lastHitIsPlayer(lastHitCreature)) {
 		return Creature::dropCorpse(lastHitCreature, mostDamageCreature, lastHitUnjustified, mostDamageUnjustified);
@@ -2831,9 +2785,9 @@ bool Player::dropCorpse(Creature* lastHitCreature, Creature* mostDamageCreature,
 	return false;
 }
 
-Item* Player::getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature)
+ItemPtr Player::getCorpse(const CreaturePtr& lastHitCreature, const CreaturePtr& mostDamageCreature)
 {
-	Item* corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
+	const auto& corpse = Creature::getCorpse(lastHitCreature, mostDamageCreature);
 	if (corpse && corpse->getContainer()) {
 		size_t killersSize = getKillers().size();
 
@@ -2858,7 +2812,7 @@ Item* Player::getCorpse(Creature* lastHitCreature, Creature* mostDamageCreature)
 	return corpse;
 }
 
-void Player::addInFightTicks(bool pzlock /*= false*/)
+void Player::addInFightTicks(const bool pzlock /*= false*/)
 {
 	if (hasFlag(PlayerFlag_NotGainInFight)) {
 		return;
@@ -2868,46 +2822,45 @@ void Player::addInFightTicks(bool pzlock /*= false*/)
 		pzLocked = true;
 	}
 
-	Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, g_config.getNumber(ConfigManager::PZ_LOCKED), 0);
+	const auto& condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_INFIGHT, g_config.getNumber(ConfigManager::PZ_LOCKED), 0);
 	addCondition(condition);
 }
 
 void Player::removeList()
 {
-	g_game.removePlayer(this);
+	g_game.removePlayer(this->getPlayer());
 
 	for (const auto& it : g_game.getPlayers()) {
-		it.second->notifyStatusChange(this, VIPSTATUS_OFFLINE);
+		it.second->notifyStatusChange(this->getPlayer(), VIPSTATUS_OFFLINE);
 	}
 }
 
 void Player::addList()
 {
 	for (const auto& it : g_game.getPlayers()) {
-		it.second->notifyStatusChange(this, VIPSTATUS_ONLINE);
+		it.second->notifyStatusChange(this->getPlayer(), VIPSTATUS_ONLINE);
 	}
 
-	g_game.addPlayer(this);
+	g_game.addPlayer(this->getPlayer());
 }
 
 void Player::kickPlayer(bool displayEffect)
 {
-	g_creatureEvents->playerLogout(this);
+	g_creatureEvents->playerLogout(this->getPlayer());
 	if (client) {
 		client->logout(displayEffect, true);
 	} else {
-		g_game.removeCreature(this);
+		g_game.removeCreature(this->getPlayer());
 	}
 }
 
-void Player::notifyStatusChange(Player* loginPlayer, VipStatus_t status)
+void Player::notifyStatusChange(const PlayerPtr& loginPlayer, VipStatus_t status)
 {
 	if (!client) {
 		return;
 	}
 
-	auto it = VIPList.find(loginPlayer->guid);
-	if (it == VIPList.end()) {
+	if (const auto& it = VIPList.find(loginPlayer->guid); it == VIPList.end()) {
 		return;
 	}
 
@@ -2920,7 +2873,7 @@ void Player::notifyStatusChange(Player* loginPlayer, VipStatus_t status)
 	}
 }
 
-bool Player::removeVIP(uint32_t vipGuid)
+bool Player::removeVIP(const uint32_t vipGuid)
 {
 	if (VIPList.erase(vipGuid) == 0) {
 		return false;
@@ -2930,15 +2883,14 @@ bool Player::removeVIP(uint32_t vipGuid)
 	return true;
 }
 
-bool Player::addVIP(uint32_t vipGuid, const std::string& vipName, VipStatus_t status)
+bool Player::addVIP(const uint32_t vipGuid, const std::string& vipName, VipStatus_t status)
 {
 	if (VIPList.size() >= getMaxVIPEntries()) {
 		sendTextMessage(MESSAGE_STATUS_SMALL, "You cannot add more buddies.");
 		return false;
 	}
 
-	auto result = VIPList.insert(vipGuid);
-	if (!result.second) {
+	if (const auto result = VIPList.insert(vipGuid); !result.second) {
 		sendTextMessage(MESSAGE_STATUS_SMALL, "This player is already in your list.");
 		return false;
 	}
@@ -2950,7 +2902,7 @@ bool Player::addVIP(uint32_t vipGuid, const std::string& vipName, VipStatus_t st
 	return true;
 }
 
-bool Player::addVIPInternal(uint32_t vipGuid)
+bool Player::addVIPInternal(const uint32_t vipGuid)
 {
 	if (VIPList.size() >= getMaxVIPEntries()) {
 		return false;
@@ -2959,10 +2911,9 @@ bool Player::addVIPInternal(uint32_t vipGuid)
 	return VIPList.insert(vipGuid).second;
 }
 
-bool Player::editVIP(uint32_t vipGuid, const std::string& description, uint32_t icon, bool notify)
+bool Player::editVIP(const uint32_t vipGuid, const std::string& description, const uint32_t icon, const bool notify)
 {
-	auto it = VIPList.find(vipGuid);
-	if (it == VIPList.end()) {
+	if (const auto& it = VIPList.find(vipGuid); it == VIPList.end()) {
 		return false; // player is not in VIP
 	}
 
@@ -2971,18 +2922,18 @@ bool Player::editVIP(uint32_t vipGuid, const std::string& description, uint32_t 
 }
 
 //close container and its child containers
-void Player::autoCloseContainers(const Container* container)
+void Player::autoCloseContainers(const ContainerConstPtr& container)
 {
 	std::vector<uint32_t> closeList;
 	for (const auto& it : openContainers) {
-		Container* tmpContainer = it.second.container;
+		auto tmpContainer = it.second.container;
 		while (tmpContainer) {
 			if (tmpContainer->isRemoved() || tmpContainer == container) {
 				closeList.push_back(it.first);
 				break;
 			}
 
-			tmpContainer = dynamic_cast<Container*>(tmpContainer->getParent());
+			tmpContainer = std::dynamic_pointer_cast<Container>(tmpContainer->getParent());
 		}
 	}
 
@@ -2994,13 +2945,13 @@ void Player::autoCloseContainers(const Container* container)
 	}
 }
 
-bool Player::hasCapacity(const Item* item, uint32_t count) const
+bool Player::hasCapacity(const ItemPtr& item, uint32_t count) const
 {
 	if (hasFlag(PlayerFlag_CannotPickupItem)) {
 		return false;
 	}
 
-	if (hasFlag(PlayerFlag_HasInfiniteCapacity) || item->getTopParent() == this) {
+	if (hasFlag(PlayerFlag_HasInfiniteCapacity) || item->getTopParent() == this->getPlayer()) {
 		return true;
 	}
 
@@ -3011,15 +2962,14 @@ bool Player::hasCapacity(const Item* item, uint32_t count) const
 	return itemWeight <= getFreeCapacity();
 }
 
-ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags, Creature*) const
+ReturnValue Player::queryAdd(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr)
 {
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (item == nullptr) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	bool childIsOwner = hasBitSet(FLAG_CHILDISOWNER, flags);
-	if (childIsOwner) {
+	if (const bool childIsOwner = hasBitSet(FLAG_CHILDISOWNER, flags)) {
 		//a child container is querying the player, just check if enough capacity
 		bool skipLimit = hasBitSet(FLAG_NOLIMIT, flags);
 		if (skipLimit || hasCapacity(item, count)) {
@@ -3089,7 +3039,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 					if (item->getWeaponType() != WEAPON_SHIELD && item->getWeaponType() != WEAPON_QUIVER) {
 						ret = RETURNVALUE_CANNOTBEDRESSED;
 					} else {
-						const Item* leftItem = inventory[CONST_SLOT_LEFT];
+						const auto& leftItem = inventory[CONST_SLOT_LEFT];
 						if (leftItem) {
 							if ((leftItem->getSlotPosition() | slotPosition) & SLOTP_TWO_HAND) {
 								if (leftItem->getWeaponType() != WEAPON_DISTANCE ||
@@ -3106,14 +3056,14 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 						}
 					}
 				} else if (slotPosition & SLOTP_TWO_HAND) {
-					const Item* leftItem = inventory[CONST_SLOT_LEFT];
+					const auto& leftItem = inventory[CONST_SLOT_LEFT];
 					if (leftItem && leftItem != item) {
 						ret = RETURNVALUE_BOTHHANDSNEEDTOBEFREE;
 					} else {
 						ret = RETURNVALUE_NOERROR;
 					}
 				} else if (inventory[CONST_SLOT_LEFT]) {
-					const Item* leftItem = inventory[CONST_SLOT_LEFT];
+					const auto& leftItem = inventory[CONST_SLOT_LEFT];
 					WeaponType_t type = item->getWeaponType(), leftType = leftItem->getWeaponType();
 
 					if (leftItem->getSlotPosition() & SLOTP_TWO_HAND) {
@@ -3144,7 +3094,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 			if (slotPosition & SLOTP_LEFT) {
 				if (!g_config.getBoolean(ConfigManager::CLASSIC_EQUIPMENT_SLOTS)) {
 					WeaponType_t type = item->getWeaponType();
-					const Item* rightItem = inventory[CONST_SLOT_RIGHT];
+					const auto& rightItem = inventory[CONST_SLOT_RIGHT];
 					if (type == WEAPON_NONE || type == WEAPON_SHIELD || type == WEAPON_AMMO || type == WEAPON_QUIVER) {
 						ret = RETURNVALUE_CANNOTBEDRESSED;
 					} else if (rightItem && (slotPosition & SLOTP_TWO_HAND)) {
@@ -3157,7 +3107,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 						ret = RETURNVALUE_NOERROR;
 					}
 				} else if (slotPosition & SLOTP_TWO_HAND) {
-					const Item* rightItem = inventory[CONST_SLOT_RIGHT];
+					const auto& rightItem = inventory[CONST_SLOT_RIGHT];
 					if (rightItem && rightItem != item) {
 						if (item->getWeaponType() != WEAPON_DISTANCE || rightItem->getWeaponType() != WEAPON_QUIVER) {
 							ret = RETURNVALUE_BOTHHANDSNEEDTOBEFREE;
@@ -3168,7 +3118,7 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 						ret = RETURNVALUE_NOERROR;
 					}
 				} else if (inventory[CONST_SLOT_RIGHT]) {
-					const Item* rightItem = inventory[CONST_SLOT_RIGHT];
+					const auto& rightItem = inventory[CONST_SLOT_RIGHT];
 					WeaponType_t type = item->getWeaponType(), rightType = rightItem->getWeaponType();
 
 					if (rightItem->getSlotPosition() & SLOTP_TWO_HAND) {
@@ -3243,18 +3193,18 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 	}
 
 	if (index != CONST_SLOT_WHEREEVER && index != -1) { // we don't try to equip whereever call
-		ret = g_moveEvents->onPlayerEquip(const_cast<Player*>(this), const_cast<Item*>(item), static_cast<slots_t>(index), true);
+		ret = g_moveEvents->onPlayerEquip(std::const_pointer_cast<Player>(this->getPlayer()), std::const_pointer_cast<Item>(item), static_cast<slots_t>(index), true);
 		if (ret != RETURNVALUE_NOERROR) {
 			return ret;
 		}
 	}
 
 	//need an exchange with source? (destination item is swapped with currently moved item)
-	const Item* inventoryItem = getInventoryItem(static_cast<slots_t>(index));
+	const auto& inventoryItem = getInventoryItem(static_cast<slots_t>(index));
 	if (inventoryItem && (!inventoryItem->isStackable() || inventoryItem->getID() != item->getID())) {
 		if (!g_config.getBoolean(ConfigManager::CLASSIC_EQUIPMENT_SLOTS)) {
-			const Cylinder* cylinder = item->getTopParent();
-			if (cylinder && (dynamic_cast<const DepotChest*>(cylinder) || dynamic_cast<const Player*>(cylinder))) {
+			const auto& cylinder = item->getTopParent();
+			if (cylinder && (std::dynamic_pointer_cast<const DepotChest>(cylinder) || std::dynamic_pointer_cast<const Player>(cylinder))) {
 				return RETURNVALUE_NEEDEXCHANGE;
 			}
 			return RETURNVALUE_NOTENOUGHROOM;	
@@ -3264,10 +3214,10 @@ ReturnValue Player::queryAdd(int32_t index, const Thing& thing, uint32_t count, 
 	return ret;
 }
 
-ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount,
-		uint32_t flags) const
+ReturnValue Player::queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t& maxQueryCount,
+		uint32_t flags)
 {
-	const Item* item = thing.getItem();
+	auto item = thing->getItem();
 	if (item == nullptr) {
 		maxQueryCount = 0;
 		return RETURNVALUE_NOTPOSSIBLE;
@@ -3276,29 +3226,28 @@ ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t co
 	if (index == INDEX_WHEREEVER) {
 		uint32_t n = 0;
 		for (int32_t slotIndex = CONST_SLOT_FIRST; slotIndex <= CONST_SLOT_LAST; ++slotIndex) {
-			Item* inventoryItem = inventory[slotIndex];
-			if (inventoryItem) {
-				if (Container* subContainer = inventoryItem->getContainer()) {
+			if (const auto& inventoryItem = inventory[slotIndex]) {
+				if (auto subContainer = inventoryItem->getContainer()) {
 					uint32_t queryCount = 0;
-					subContainer->queryMaxCount(INDEX_WHEREEVER, *item, item->getItemCount(), queryCount, flags);
+					subContainer->queryMaxCount(INDEX_WHEREEVER, item, item->getItemCount(), queryCount, flags);
 					n += queryCount;
 
 					//iterate through all items, including sub-containers (deep search)
 					for (ContainerIterator it = subContainer->iterator(); it.hasNext(); it.advance()) {
-						if (Container* tmpContainer = (*it)->getContainer()) {
+						if (auto tmpContainer = (*it)->getContainer()) {
 							queryCount = 0;
-							tmpContainer->queryMaxCount(INDEX_WHEREEVER, *item, item->getItemCount(), queryCount, flags);
+							tmpContainer->queryMaxCount(INDEX_WHEREEVER, item, item->getItemCount(), queryCount, flags);
 							n += queryCount;
 						}
 					}
 				} else if (inventoryItem->isStackable() && item->equals(inventoryItem) && inventoryItem->getItemCount() < 100) {
-					uint32_t remainder = (100 - inventoryItem->getItemCount());
+					const uint32_t remainder = (100 - inventoryItem->getItemCount());
 
-					if (queryAdd(slotIndex, *item, remainder, flags) == RETURNVALUE_NOERROR) {
+					if (queryAdd(slotIndex, item, remainder, flags) == RETURNVALUE_NOERROR) {
 						n += remainder;
 					}
 				}
-			} else if (queryAdd(slotIndex, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { //empty slot
+			} else if (queryAdd(slotIndex, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { //empty slot
 				if (item->isStackable()) {
 					n += 100;
 				} else {
@@ -3309,10 +3258,9 @@ ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t co
 
 		maxQueryCount = n;
 	} else {
-		const Item* destItem = nullptr;
+		ItemPtr destItem = nullptr;
 
-		const Thing* destThing = getThing(index);
-		if (destThing) {
+		if (const auto& destThing = getThing(index)) {
 			destItem = destThing->getItem();
 		}
 
@@ -3322,7 +3270,7 @@ ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t co
 			} else {
 				maxQueryCount = 0;
 			}
-		} else if (queryAdd(index, *item, count, flags) == RETURNVALUE_NOERROR) { //empty slot
+		} else if (queryAdd(index, item, count, flags) == RETURNVALUE_NOERROR) { //empty slot
 			if (item->isStackable()) {
 				maxQueryCount = 100;
 			} else {
@@ -3340,14 +3288,14 @@ ReturnValue Player::queryMaxCount(int32_t index, const Thing& thing, uint32_t co
 	}
 }
 
-ReturnValue Player::queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* /*= nullptr*/) const
+ReturnValue Player::queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr /*= nullptr*/)
 {
-	int32_t index = getThingIndex(&thing);
+	int32_t index = getThingIndex(thing);
 	if (index == -1) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (item == nullptr) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -3363,25 +3311,24 @@ ReturnValue Player::queryRemove(const Thing& thing, uint32_t count, uint32_t fla
 	return RETURNVALUE_NOERROR;
 }
 
-Cylinder* Player::queryDestination(int32_t& index, const Thing& thing, Item** destItem,
+CylinderPtr Player::queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
 		uint32_t& flags)
 {
 	if (index == 0 /*drop to capacity window*/ || index == INDEX_WHEREEVER) {
 		*destItem = nullptr;
 
-		const Item* item = thing.getItem();
+		ItemPtr item = thing->getItem();
 		if (item == nullptr) {
-			return this;
+			return this->getPlayer();
 		}
 
-		bool autoStack = !((flags & FLAG_IGNOREAUTOSTACK) == FLAG_IGNOREAUTOSTACK);
-		bool isStackable = item->isStackable();
+		const bool autoStack = !((flags & FLAG_IGNOREAUTOSTACK) == FLAG_IGNOREAUTOSTACK);
+		const bool isStackable = item->isStackable();
 
-		std::vector<Container*> containers;
+		std::vector<ContainerPtr> containers;
 
 		for (uint32_t slotIndex = CONST_SLOT_FIRST; slotIndex <= CONST_SLOT_LAST; ++slotIndex) {
-			Item* inventoryItem = inventory[slotIndex];
-			if (inventoryItem) {
+			if (auto inventoryItem = inventory[slotIndex]) {
 				if (inventoryItem == tradeItem) {
 					continue;
 				}
@@ -3392,35 +3339,35 @@ Cylinder* Player::queryDestination(int32_t& index, const Thing& thing, Item** de
 
 				if (autoStack && isStackable) {
 					//try find an already existing item to stack with
-					if (queryAdd(slotIndex, *item, item->getItemCount(), 0) == RETURNVALUE_NOERROR) {
+					if (queryAdd(slotIndex, item, item->getItemCount(), 0) == RETURNVALUE_NOERROR) {
 						if (inventoryItem->equals(item) && inventoryItem->getItemCount() < 100) {
 							index = slotIndex;
 							*destItem = inventoryItem;
-							return this;
+							return this->getPlayer();
 						}
 					}
 
-					if (Container* subContainer = inventoryItem->getContainer()) {
+					if (const auto& subContainer = inventoryItem->getContainer()) {
 						containers.push_back(subContainer);
 					}
-				} else if (Container* subContainer = inventoryItem->getContainer()) {
+				} else if (const auto& subContainer = inventoryItem->getContainer()) {
 					containers.push_back(subContainer);
 				}
-			} else if (queryAdd(slotIndex, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { //empty slot
+			} else if (queryAdd(slotIndex, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) { //empty slot
 				index = slotIndex;
 				*destItem = nullptr;
-				return this;
+				return this->getPlayer();
 			}
 		}
 
 		size_t i = 0;
 		while (i < containers.size()) {
-			Container* tmpContainer = containers[i++];
+			const auto& tmpContainer = containers[i++];
 			if (!autoStack || !isStackable) {
 				//we need to find first empty container as fast as we can for non-stackable items
 				uint32_t n = tmpContainer->capacity() - std::min(tmpContainer->capacity(), static_cast<uint32_t>(tmpContainer->size()));
 				while (n) {
-					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
+					if (tmpContainer->queryAdd(tmpContainer->capacity() - n, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
 						index = tmpContainer->capacity() - n;
 						*destItem = nullptr;
 						return tmpContainer;
@@ -3429,8 +3376,8 @@ Cylinder* Player::queryDestination(int32_t& index, const Thing& thing, Item** de
 					--n;
 				}
 
-				for (Item* tmpContainerItem : tmpContainer->getItemList()) {
-					if (Container* subContainer = tmpContainerItem->getContainer()) {
+				for (const auto& tmpContainerItem : tmpContainer->getItemList()) {
+					if (const auto& subContainer = tmpContainerItem->getContainer()) {
 						containers.push_back(subContainer);
 					}
 				}
@@ -3440,7 +3387,7 @@ Cylinder* Player::queryDestination(int32_t& index, const Thing& thing, Item** de
 
 			uint32_t n = 0;
 
-			for (Item* tmpItem : tmpContainer->getItemList()) {
+			for (auto tmpItem : tmpContainer->getItemList()) {
 				if (tmpItem == tradeItem) {
 					continue;
 				}
@@ -3456,64 +3403,63 @@ Cylinder* Player::queryDestination(int32_t& index, const Thing& thing, Item** de
 					return tmpContainer;
 				}
 
-				if (Container* subContainer = tmpItem->getContainer()) {
+				if (const auto& subContainer = tmpItem->getContainer()) {
 					containers.push_back(subContainer);
 				}
 
 				n++;
 			}
 
-			if (n < tmpContainer->capacity() && tmpContainer->queryAdd(n, *item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
+			if (n < tmpContainer->capacity() && tmpContainer->queryAdd(n, item, item->getItemCount(), flags) == RETURNVALUE_NOERROR) {
 				index = n;
 				*destItem = nullptr;
 				return tmpContainer;
 			}
 		}
 
-		return this;
+		return this->getPlayer();
 	}
 
-	Thing* destThing = getThing(index);
+	const auto& destThing = getThing(index);
 	if (destThing) {
 		*destItem = destThing->getItem();
 	}
 
-	Cylinder* subCylinder = dynamic_cast<Cylinder*>(destThing);
-	if (subCylinder) {
+	if (const auto& subCylinder = std::dynamic_pointer_cast<Cylinder>(destThing)) {
 		index = INDEX_WHEREEVER;
 		*destItem = nullptr;
 		return subCylinder;
 	} else {
-		return this;
+		return this->getPlayer();
 	}
 }
 
-void Player::addThing(int32_t index, Thing* thing)
+void Player::addThing(int32_t index, ThingPtr thing)
 {
 	if (index < CONST_SLOT_FIRST || index > CONST_SLOT_LAST) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	item->setParent(this);
+	item->setParent(getPlayer());
 	inventory[index] = item;
 
 	//send to client
 	sendInventoryItem(static_cast<slots_t>(index), item);
 }
 
-void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
+void Player::updateThing(ThingPtr thing, uint16_t itemId, uint32_t count)
 {
 	int32_t index = getThingIndex(thing);
 	if (index == -1) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -3528,18 +3474,18 @@ void Player::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 	onUpdateInventoryItem(item, item);
 }
 
-void Player::replaceThing(uint32_t index, Thing* thing)
+void Player::replaceThing(uint32_t index, ThingPtr thing)
 {
 	if (index > CONST_SLOT_LAST) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* oldItem = getInventoryItem(static_cast<slots_t>(index));
+	const auto& oldItem = getInventoryItem(static_cast<slots_t>(index));
 	if (!oldItem) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -3549,15 +3495,14 @@ void Player::replaceThing(uint32_t index, Thing* thing)
 
 	//event methods
 	onUpdateInventoryItem(oldItem, item);
-
-	item->setParent(this);
+	item->setParent(getPlayer());
 
 	inventory[index] = item;
 }
 
-void Player::removeThing(Thing* thing, uint32_t count)
+void Player::removeThing(ThingPtr thing, uint32_t count)
 {
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -3575,7 +3520,7 @@ void Player::removeThing(Thing* thing, uint32_t count)
 			//event methods
 			onRemoveInventoryItem(item);
 
-			item->setParent(nullptr);
+			item->clearParent();
 			inventory[index] = nullptr;
 		} else {
 			uint8_t newCount = static_cast<uint8_t>(std::max<int32_t>(0, item->getItemCount() - count));
@@ -3593,13 +3538,12 @@ void Player::removeThing(Thing* thing, uint32_t count)
 
 		//event methods
 		onRemoveInventoryItem(item);
-
-		item->setParent(nullptr);
+		item->clearParent();
 		inventory[index] = nullptr;
 	}
 }
 
-int32_t Player::getThingIndex(const Thing* thing) const
+int32_t Player::getThingIndex(ThingPtr thing)
 {
 	for (int i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
 		if (inventory[i] == thing) {
@@ -3619,11 +3563,11 @@ size_t Player::getLastIndex() const
 	return CONST_SLOT_LAST + 1;
 }
 
-uint32_t Player::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/) const
+uint32_t Player::getItemTypeCount(const uint16_t itemId, int32_t subType /*= -1*/) const
 {
 	uint32_t count = 0;
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; i++) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
@@ -3632,7 +3576,7 @@ uint32_t Player::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/) con
 			count += Item::countByType(item, subType);
 		}
 
-		if (Container* container = item->getContainer()) {
+		if (const auto& container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
 				if ((*it)->getID() == itemId) {
 					count += Item::countByType(*it, subType);
@@ -3643,17 +3587,17 @@ uint32_t Player::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/) con
 	return count;
 }
 
-bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType, bool ignoreEquipped/* = false*/) const
+bool Player::removeItemOfType(const uint16_t itemId, uint32_t amount, int32_t subType, bool ignoreEquipped/* = false*/) const
 {
 	if (amount == 0) {
 		return true;
 	}
 
-	std::vector<Item*> itemList;
+	std::vector<ItemPtr> itemList;
 
 	uint32_t count = 0;
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; i++) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
@@ -3671,11 +3615,11 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 				g_game.internalRemoveItems(std::move(itemList), amount, Item::items[itemId].stackable);
 				return true;
 			}
-		} else if (Container* container = item->getContainer()) {
+		} else if (const auto& container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
-				Item* containerItem = *it;
+				const auto& containerItem = *it;
 				if (containerItem->getID() == itemId) {
-					uint32_t itemCount = Item::countByType(containerItem, subType);
+					const uint32_t itemCount = Item::countByType(containerItem, subType);
 					if (itemCount == 0) {
 						continue;
 					}
@@ -3697,14 +3641,14 @@ bool Player::removeItemOfType(uint16_t itemId, uint32_t amount, int32_t subType,
 std::map<uint32_t, uint32_t>& Player::getAllItemTypeCount(std::map<uint32_t, uint32_t>& countMap) const
 {
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; i++) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
 
 		countMap[item->getID()] += Item::countByType(item, -1);
 
-		if (Container* container = item->getContainer()) {
+		if (const auto& container = item->getContainer()) {
 			for (ContainerIterator it = container->iterator(); it.hasNext(); it.advance()) {
 				countMap[(*it)->getID()] += Item::countByType(*it, -1);
 			}
@@ -3713,7 +3657,7 @@ std::map<uint32_t, uint32_t>& Player::getAllItemTypeCount(std::map<uint32_t, uin
 	return countMap;
 }
 
-Thing* Player::getThing(size_t index) const
+ThingPtr Player::getThing(size_t index)
 {
 	if (index >= CONST_SLOT_FIRST && index <= CONST_SLOT_LAST) {
 		return inventory[index];
@@ -3721,14 +3665,14 @@ Thing* Player::getThing(size_t index) const
 	return nullptr;
 }
 
-void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link /*= LINK_OWNER*/)
+void Player::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link /*= LINK_OWNER*/)
 {
 	if (link == LINK_OWNER) {
 		//calling movement scripts
-		g_moveEvents->onPlayerEquip(this, thing->getItem(), static_cast<slots_t>(index), false);
-		g_events->eventPlayerOnInventoryUpdate(this, thing->getItem(), static_cast<slots_t>(index), true);
+		g_moveEvents->onPlayerEquip(this->getPlayer(), thing->getItem(), static_cast<slots_t>(index), false);
+		g_events->eventPlayerOnInventoryUpdate(this->getPlayer(), thing->getItem(), static_cast<slots_t>(index), true);
 		if (isInventorySlot(static_cast<slots_t>(index))) {
-			Item* item = thing->getItem();
+			const auto& item = thing->getItem();
 			if (item && item->hasImbuements()) {
 				addItemImbuements(thing->getItem());
 			}
@@ -3738,58 +3682,58 @@ void Player::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_
 	bool requireListUpdate = false;
 
 	if (link == LINK_OWNER || link == LINK_TOPPARENT) {
-		const Item* i = (oldParent ? oldParent->getItem() : nullptr);
+		const auto& i = (oldParent ? oldParent->getItem() : nullptr);
 
 		// Check if we owned the old container too, so we don't need to do anything,
 		// as the list was updated in postRemoveNotification
-		assert(i ? i->getContainer() != nullptr : true);
+		/* assert(i ? i->getContainer() != nullptr : true);
 
 		if (i) {
 			requireListUpdate = static_cast<const Container*>(i)->getHoldingPlayer() != this;
 		} else {
 			requireListUpdate = oldParent != this;
-		}
-
+		} */
+		requireListUpdate = true;
 		updateInventoryWeight();
 		updateItemsLight();
 		sendStats();
 	}
 
-	if (const Item* item = thing->getItem()) {
-		if (const Container* container = item->getContainer()) {
+	if (const auto& item = thing->getItem()) {
+		if (const auto& container = item->getContainer()) {
 			onSendContainer(container);
 		}
 
 		if (shopOwner && requireListUpdate) {
 			updateSaleShopList(item);
 		}
-	} else if (const Creature* creature = thing->getCreature()) {
-		if (creature == this) {
+	} else if (const auto& creature = thing->getCreature()) {
+		if (creature == getCreature()) {
 			//check containers
-			std::vector<Container*> containers;
+			std::vector<ContainerPtr> containers;
 
-			for (const auto& it : openContainers) {
-				Container* container = it.second.container;
+			for (const auto& val : openContainers | std::views::values) {
+				const auto& container = val.container;
 				if (!Position::areInRange<1, 1, 0>(container->getPosition(), getPosition())) {
 					containers.push_back(container);
 				}
 			}
 
-			for (const Container* container : containers) {
+			for (const auto& container : containers) {
 				autoCloseContainers(container);
 			}
 		}
 	}
 }
 
-void Player::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link /*= LINK_OWNER*/)
+void Player::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link /*= LINK_OWNER*/)
 {
 	if (link == LINK_OWNER) {
 		//calling movement scripts
-		g_moveEvents->onPlayerDeEquip(this, thing->getItem(), static_cast<slots_t>(index));
-		g_events->eventPlayerOnInventoryUpdate(this, thing->getItem(), static_cast<slots_t>(index), false);
+		g_moveEvents->onPlayerDeEquip(this->getPlayer(), thing->getItem(), static_cast<slots_t>(index));
+		g_events->eventPlayerOnInventoryUpdate(this->getPlayer(), thing->getItem(), static_cast<slots_t>(index), false);
 		if (isInventorySlot(static_cast<slots_t>(index))) {
-			Item* item = thing->getItem();
+			const auto& item = thing->getItem();
 			if (item && item->hasImbuements()) {
 				removeItemImbuements(thing->getItem());
 			}
@@ -3799,31 +3743,32 @@ void Player::postRemoveNotification(Thing* thing, const Cylinder* newParent, int
 	bool requireListUpdate = false;
 
 	if (link == LINK_OWNER || link == LINK_TOPPARENT) {
-		const Item* i = (newParent ? newParent->getItem() : nullptr);
+		// const Item* i = (newParent ? newParent->getItem() : nullptr);
 
 		// Check if we owned the old container too, so we don't need to do anything,
 		// as the list was updated in postRemoveNotification
-		assert(i ? i->getContainer() != nullptr : true);
+		/* assert(i ? i->getContainer() != nullptr : true);
 
 		if (i) {
 			requireListUpdate = static_cast<const Container*>(i)->getHoldingPlayer() != this;
 		} else {
 			requireListUpdate = newParent != this;
-		}
-
+		} */
+		
+		requireListUpdate = true;
 		updateInventoryWeight();
 		updateItemsLight();
 		sendStats();
 	}
 
-	if (const Item* item = thing->getItem()) {
-		if (const Container* container = item->getContainer()) {
+	if (const auto& item = thing->getItem()) {
+		if (const auto& container = item->getContainer()) {
 			if (container->isRemoved() || !Position::areInRange<1, 1, 0>(getPosition(), container->getPosition())) {
 				autoCloseContainers(container);
-			} else if (container->getTopParent() == this) {
+			} else if (container->getItem()->getTopParent() == this->getPlayer()) {
 				onSendContainer(container);
-			} else if (const Container* topContainer = dynamic_cast<const Container*>(container->getTopParent())) {
-				if (const DepotChest* depotChest = dynamic_cast<const DepotChest*>(topContainer)) {
+			} else if (const auto& topContainer = std::dynamic_pointer_cast<Container>(container->getItem()->getTopParent())) {
+				if (const auto& depotChest = std::dynamic_pointer_cast<DepotChest>(topContainer)) {
 					bool isOwner = false;
 
 					for (const auto& it : depotChests) {
@@ -3836,7 +3781,7 @@ void Player::postRemoveNotification(Thing* thing, const Cylinder* newParent, int
 					if (!isOwner) {
 						autoCloseContainers(container);
 					}
-				} else if (const Inbox* inboxContainer = dynamic_cast<const Inbox*>(topContainer)) {
+				} else if (const auto& inboxContainer = std::dynamic_pointer_cast<Inbox>(topContainer)) {
 					if (inboxContainer == inbox) {
 						onSendContainer(container);
 					} else {
@@ -3856,7 +3801,7 @@ void Player::postRemoveNotification(Thing* thing, const Cylinder* newParent, int
 	}
 }
 
-bool Player::updateSaleShopList(const Item* item)
+bool Player::updateSaleShopList(const ItemConstPtr& item)
 {
 	uint16_t itemId = item->getID();
 	bool isCurrency = false;
@@ -3868,15 +3813,15 @@ bool Player::updateSaleShopList(const Item* item)
 	}
 
 	if (!isCurrency) {
-		auto it = std::find_if(shopItemList.begin(), shopItemList.end(), [itemId](const ShopInfo& shopInfo) { return shopInfo.itemId == itemId && shopInfo.sellPrice != 0; });
+		const auto it = std::ranges::find_if(shopItemList, [itemId](const ShopInfo& shopInfo) { return shopInfo.itemId == itemId && shopInfo.sellPrice != 0; });
 		if (it == shopItemList.end()) {
-			const Container* container = item->getContainer();
+			const auto& container = item->getContainer();
 			if (!container) {
 				return false;
 			}
 
 			const auto& items = container->getItemList();
-			return std::any_of(items.begin(), items.end(), [this](const Item* containerItem) {
+			return std::any_of(items.begin(), items.end(), [this](const ItemPtr& containerItem) {
 				return updateSaleShopList(containerItem);
 			});
 		}
@@ -3896,14 +3841,14 @@ bool Player::hasShopItemForSale(uint32_t itemId, uint8_t subType) const
 	});
 }
 
-void Player::internalAddThing(Thing* thing)
+void Player::internalAddThing(ThingPtr thing)
 {
 	internalAddThing(0, thing);
 }
 
-void Player::internalAddThing(uint32_t index, Thing* thing)
+void Player::internalAddThing(uint32_t index, ThingPtr thing)
 {
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return;
 	}
@@ -3915,11 +3860,11 @@ void Player::internalAddThing(uint32_t index, Thing* thing)
 		}
 
 		inventory[index] = item;
-		item->setParent(this);
+		item->setParent(getPlayer());
 	}
 }
 
-bool Player::setFollowCreature(Creature* creature)
+bool Player::setFollowCreature(const CreaturePtr& creature)
 {
 	if (!Creature::setFollowCreature(creature)) {
 		setFollowCreature(nullptr);
@@ -3933,7 +3878,7 @@ bool Player::setFollowCreature(Creature* creature)
 	return true;
 }
 
-bool Player::setAttackedCreature(Creature* creature)
+bool Player::setAttackedCreature(const CreaturePtr& creature)
 {
 	if (!Creature::setAttackedCreature(creature)) {
 		sendCancelTarget();
@@ -3970,7 +3915,7 @@ void Player::goToFollowCreature()
 	}
 }
 
-void Player::getPathSearchParams(const Creature* creature, FindPathParams& fpp) const
+void Player::getPathSearchParams(const CreatureConstPtr& creature, FindPathParams& fpp) const
 {
 	Creature::getPathSearchParams(creature, fpp);
 	fpp.fullPathSearch = true;
@@ -3989,21 +3934,21 @@ void Player::doAttacking(uint32_t)
 	if ((OTSYS_TIME() - lastAttack) >= getAttackSpeed()) {
 		bool result = false;
 
-		Item* tool = getWeapon();
-		const Weapon* weapon = g_weapons->getWeapon(tool);
+		const auto& tool = getWeapon();
+		const auto& weapon = g_weapons->getWeapon(tool);
 		uint32_t delay = getAttackSpeed();
 		bool classicSpeed = g_config.getBoolean(ConfigManager::CLASSIC_ATTACK_SPEED);
 
 		if (weapon) {
 			if (!weapon->interruptSwing()) {
-				result = weapon->useWeapon(this, tool, attackedCreature);
+				result = weapon->useWeapon(this->getPlayer(), tool, attackedCreature);
 			} else if (!classicSpeed && !canDoAction()) {
 				delay = getNextActionTime();
 			} else {
-				result = weapon->useWeapon(this, tool, attackedCreature);
+				result = weapon->useWeapon(this->getPlayer(), tool, attackedCreature);
 			}
 		} else {
-			result = Weapon::useFist(this, attackedCreature);
+			result = Weapon::useFist(this->getPlayer(), attackedCreature);
 		}
 
 		SchedulerTask* task = createSchedulerTask(std::max<uint32_t>(SCHEDULER_MINTICKS, delay), [id = getID()]() { g_game.checkCreatureAttack(id); });
@@ -4020,25 +3965,25 @@ void Player::doAttacking(uint32_t)
 	}
 }
 
-uint64_t Player::getGainedExperience(Creature* attacker) const
+uint64_t Player::getGainedExperience(const CreaturePtr& attacker) const
 {
 	if (g_config.getBoolean(ConfigManager::EXPERIENCE_FROM_PLAYERS)) {
-		Player* attackerPlayer = attacker->getPlayer();
-		if (attackerPlayer && attackerPlayer != this && skillLoss && std::abs(static_cast<int32_t>(attackerPlayer->getLevel() - level)) <= g_config.getNumber(ConfigManager::EXP_FROM_PLAYERS_LEVEL_RANGE)) {
+		const auto attackerPlayer = attacker->getPlayer();
+		if (attackerPlayer && attackerPlayer != this->getPlayer() && skillLoss && std::abs(static_cast<int32_t>(attackerPlayer->getLevel() - level)) <= g_config.getNumber(ConfigManager::EXP_FROM_PLAYERS_LEVEL_RANGE)) {
 			return std::max<uint64_t>(0, std::floor(getLostExperience() * getDamageRatio(attacker) * 0.75));
 		}
 	}
 	return 0;
 }
 
-void Player::onFollowCreature(const Creature* creature)
+void Player::onFollowCreature(const CreatureConstPtr& creature)
 {
 	if (!creature) {
 		stopWalk();
 	}
 }
 
-void Player::setChaseMode(bool mode)
+void Player::setChaseMode(const bool mode)
 {
 	bool prevChaseMode = chaseMode;
 	chaseMode = mode;
@@ -4088,8 +4033,7 @@ void Player::updateItemsLight(bool internal /*=false*/)
 	LightInfo maxLight;
 
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
-		Item* item = inventory[i];
-		if (item) {
+		if (const auto& item = inventory[i]) {
 			LightInfo curLight = item->getLightInfo();
 
 			if (curLight.level > maxLight.level) {
@@ -4102,12 +4046,12 @@ void Player::updateItemsLight(bool internal /*=false*/)
 		itemsLight = maxLight;
 
 		if (!internal) {
-			g_game.changeLight(this);
+			g_game.changeLight(this->getPlayer());
 		}
 	}
 }
 
-void Player::onAddCondition(ConditionType_t type)
+void Player::onAddCondition(const ConditionType_t type)
 {
 	Creature::onAddCondition(type);
 
@@ -4118,7 +4062,7 @@ void Player::onAddCondition(ConditionType_t type)
 	sendIcons();
 }
 
-void Player::onAddCombatCondition(ConditionType_t type)
+void Player::onAddCombatCondition(const ConditionType_t type)
 {
 	switch (type) {
 		case CONDITION_POISON:
@@ -4158,7 +4102,7 @@ void Player::onAddCombatCondition(ConditionType_t type)
 	}
 }
 
-void Player::onEndCondition(ConditionType_t type)
+void Player::onEndCondition(const ConditionType_t type)
 {
 	Creature::onEndCondition(type);
 
@@ -4181,8 +4125,7 @@ void Player::onCombatRemoveCondition(Condition* condition)
 	if (condition->getId() > 0) {
 		//Means the condition is from an item, id == slot
 		if (g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
-			Item* item = getInventoryItem(static_cast<slots_t>(condition->getId()));
-			if (item) {
+			if (const auto& item = getInventoryItem(static_cast<slots_t>(condition->getId()))) {
 				//25% chance to destroy the item
 				if (25 >= uniform_random(1, 100)) {
 					g_game.internalRemoveItem(item);
@@ -4204,7 +4147,7 @@ void Player::onCombatRemoveCondition(Condition* condition)
 	}
 }
 
-void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true */)
+void Player::onAttackedCreature(const CreaturePtr& target, bool addFightTicks /* = true */)
 {
 	Creature::onAttackedCreature(target);
 
@@ -4212,7 +4155,7 @@ void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true *
 		return;
 	}
 
-	if (target == this) {
+	if (target == getCreature()) {
 		if (addFightTicks) {
 			addInFightTicks();
 		}
@@ -4223,7 +4166,7 @@ void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true *
 		return;
 	}
 
-	Player* targetPlayer = target->getPlayer();
+	const auto& targetPlayer = target->getPlayer();
 	if (targetPlayer && !isPartner(targetPlayer) && !isGuildMate(targetPlayer)) {
 		if (!pzLocked && g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
 			pzLocked = true;
@@ -4234,14 +4177,14 @@ void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true *
 
 		if (getSkull() == SKULL_NONE && getSkullClient(targetPlayer) == SKULL_YELLOW) {
 			addAttacked(targetPlayer);
-			targetPlayer->sendCreatureSkull(this);
-		} else if (!targetPlayer->hasAttacked(this)) {
+			targetPlayer->sendCreatureSkull(this->getPlayer());
+		} else if (!targetPlayer->hasAttacked(this->getPlayer())) {
 			if (!pzLocked) {
 				pzLocked = true;
 				sendIcons();
 			}
 
-			if (!Combat::isInPvpZone(this, targetPlayer) && !isInWar(targetPlayer)) {
+			if (!Combat::isInPvpZone(this->getPlayer(), targetPlayer) && !isInWar(targetPlayer)) {
 				addAttacked(targetPlayer);
 
 				if (targetPlayer->getSkull() == SKULL_NONE && getSkull() == SKULL_NONE) {
@@ -4249,7 +4192,7 @@ void Player::onAttackedCreature(Creature* target, bool addFightTicks /* = true *
 				}
 
 				if (getSkull() == SKULL_NONE) {
-					targetPlayer->sendCreatureSkull(this);
+					targetPlayer->sendCreatureSkull(this->getPlayer());
 				}
 			}
 		}
@@ -4272,53 +4215,53 @@ void Player::onIdleStatus()
 	Creature::onIdleStatus();
 
 	if (party) {
-		party->clearPlayerPoints(this);
+		party->clearPlayerPoints(this->getPlayer());
 	}
 }
 
 void Player::onPlacedCreature()
 {
 	//scripting event - onLogin
-	if (!g_creatureEvents->playerLogin(this)) {
+	if (!g_creatureEvents->playerLogin(this->getPlayer())) {
 		kickPlayer(true);
 	}
 }
 
-void Player::onAttackedCreatureDrainHealth(Creature* target, int32_t points)
+void Player::onAttackedCreatureDrainHealth(const CreaturePtr& target, int32_t points)
 {
 	Creature::onAttackedCreatureDrainHealth(target, points);
 
 	if (target) {
 		if (party && !Combat::isPlayerCombat(target)) {
-			Monster* tmpMonster = target->getMonster();
+			const auto& tmpMonster = target->getMonster();
 			if (tmpMonster && tmpMonster->isHostile()) {
 				//We have fulfilled a requirement for shared experience
-				party->updatePlayerTicks(this, points);
+				party->updatePlayerTicks(this->getPlayer(), points);
 			}
 		}
 	}
 }
 
-void Player::onTargetCreatureGainHealth(Creature* target, int32_t points)
+void Player::onTargetCreatureGainHealth(const CreaturePtr& target, int32_t points)
 {
 	if (target && party) {
-		Player* tmpPlayer = nullptr;
+		PlayerPtr tmpPlayer = nullptr;
 
 		if (target->getPlayer()) {
 			tmpPlayer = target->getPlayer();
-		} else if (Creature* targetMaster = target->getMaster()) {
-			if (Player* targetMasterPlayer = targetMaster->getPlayer()) {
+		} else if (const auto& targetMaster = target->getMaster()) {
+			if (const auto& targetMasterPlayer = targetMaster->getPlayer()) {
 				tmpPlayer = targetMasterPlayer;
 			}
 		}
 
 		if (isPartner(tmpPlayer)) {
-			party->updatePlayerTicks(this, points);
+			party->updatePlayerTicks(this->getPlayer(), points);
 		}
 	}
 }
 
-bool Player::onKilledCreature(Creature* target, bool lastHit/* = true*/)
+bool Player::onKilledCreature(const CreaturePtr& target, bool lastHit/* = true*/)
 {
 	bool unjustified = false;
 
@@ -4328,7 +4271,7 @@ bool Player::onKilledCreature(Creature* target, bool lastHit/* = true*/)
 
 	Creature::onKilledCreature(target, lastHit);
 
-	Player* targetPlayer = target->getPlayer();
+	PlayerPtr targetPlayer = target->getPlayer();
 	if (!targetPlayer) {
 		return false;
 	}
@@ -4337,7 +4280,7 @@ bool Player::onKilledCreature(Creature* target, bool lastHit/* = true*/)
 		targetPlayer->setDropLoot(false);
 		targetPlayer->setSkillLoss(false);
 	} else if (!hasFlag(PlayerFlag_NotGainInFight) && !isPartner(targetPlayer)) {
-		if (!Combat::isInPvpZone(this, targetPlayer) && hasAttacked(targetPlayer) && !targetPlayer->hasAttacked(this) && !isGuildMate(targetPlayer) && targetPlayer != this) {
+		if (!Combat::isInPvpZone(this->getPlayer(), targetPlayer) && hasAttacked(targetPlayer) && !targetPlayer->hasAttacked(this->getPlayer()) && !isGuildMate(targetPlayer) && targetPlayer != this->getPlayer()) {
 			if (targetPlayer->getSkull() == SKULL_NONE && !isInWar(targetPlayer)) {
 				unjustified = true;
 				addUnjustifiedDead(targetPlayer);
@@ -4354,7 +4297,7 @@ bool Player::onKilledCreature(Creature* target, bool lastHit/* = true*/)
 	return unjustified;
 }
 
-void Player::gainExperience(uint64_t gainExp, Creature* source)
+void Player::gainExperience(uint64_t gainExp, const CreaturePtr& source)
 {
 	if (hasFlag(PlayerFlag_NotGainExperience) || gainExp == 0 || staminaMinutes == 0) {
 		return;
@@ -4363,7 +4306,7 @@ void Player::gainExperience(uint64_t gainExp, Creature* source)
 	addExperience(source, gainExp, true);
 }
 
-void Player::onGainExperience(uint64_t gainExp, Creature* target)
+void Player::onGainExperience(uint64_t gainExp, const CreaturePtr& target)
 {
 	if (hasFlag(PlayerFlag_NotGainExperience)) {
 		return;
@@ -4379,7 +4322,7 @@ void Player::onGainExperience(uint64_t gainExp, Creature* target)
 	gainExperience(gainExp, target);
 }
 
-void Player::onGainSharedExperience(uint64_t gainExp, Creature* source)
+void Player::onGainSharedExperience(uint64_t gainExp, const CreaturePtr& source)
 {
 	gainExperience(gainExp, source);
 }
@@ -4405,7 +4348,7 @@ bool Player::isAttackable() const
 	return !hasFlag(PlayerFlag_CannotBeAttacked);
 }
 
-bool Player::lastHitIsPlayer(Creature* lastHitCreature)
+bool Player::lastHitIsPlayer(const CreaturePtr& lastHitCreature)
 {
 	if (!lastHitCreature) {
 		return false;
@@ -4415,7 +4358,7 @@ bool Player::lastHitIsPlayer(Creature* lastHitCreature)
 		return true;
 	}
 
-	Creature* lastHitMaster = lastHitCreature->getMaster();
+	const auto& lastHitMaster = lastHitCreature->getMaster();
 	return lastHitMaster && lastHitMaster->getPlayer();
 }
 
@@ -4505,7 +4448,7 @@ bool Player::canWear(uint32_t lookType, uint8_t addons) const
 	return false;
 }
 
-bool Player::hasOutfit(uint32_t lookType, uint8_t addons)
+bool Player::hasOutfit(uint32_t lookType, uint8_t addons) const
 {
 	const Outfit* outfit = Outfits::getInstance().getOutfitByLookType(sex, lookType);
 	if (!outfit) {
@@ -4598,7 +4541,7 @@ bool Player::getOutfitAddons(const Outfit& outfit, uint8_t& addons) const
 	return true;
 }
 
-void Player::setSex(PlayerSex_t newSex)
+void Player::setSex(const PlayerSex_t newSex)
 {
 	sex = newSex;
 }
@@ -4611,18 +4554,18 @@ Skulls_t Player::getSkull() const
 	return skull;
 }
 
-Skulls_t Player::getSkullClient(const Creature* creature) const
+Skulls_t Player::getSkullClient(const CreatureConstPtr& creature) const
 {
 	if (!creature || g_game.getWorldType() != WORLD_TYPE_PVP) {
 		return SKULL_NONE;
 	}
 
-	const Player* player = creature->getPlayer();
+	const auto& player = creature->getPlayer();
 	if (!player || player->getSkull() != SKULL_NONE) {
 		return Creature::getSkullClient(creature);
 	}
 
-	if (player->hasAttacked(this)) {
+	if (player->hasAttacked(this->getPlayer())) {
 		return SKULL_YELLOW;
 	}
 
@@ -4632,27 +4575,27 @@ Skulls_t Player::getSkullClient(const Creature* creature) const
 	return Creature::getSkullClient(creature);
 }
 
-bool Player::hasAttacked(const Player* attacked) const
+bool Player::hasAttacked(const PlayerConstPtr& attacked) const
 {
 	if (hasFlag(PlayerFlag_NotGainInFight) || !attacked) {
 		return false;
 	}
 
-	return attackedSet.find(attacked->guid) != attackedSet.end();
+	return attackedSet.contains(attacked->guid);
 }
 
-void Player::addAttacked(const Player* attacked)
+void Player::addAttacked(const PlayerConstPtr& attacked)
 {
-	if (hasFlag(PlayerFlag_NotGainInFight) || !attacked || attacked == this) {
+	if (hasFlag(PlayerFlag_NotGainInFight) || !attacked || attacked == this->getPlayer()) {
 		return;
 	}
 
 	attackedSet.insert(attacked->guid);
 }
 
-void Player::removeAttacked(const Player* attacked)
+void Player::removeAttacked(const PlayerConstPtr& attacked)
 {
-	if (!attacked || attacked == this) {
+	if (!attacked || attacked == this->getPlayer()) {
 		return;
 	}
 
@@ -4667,9 +4610,9 @@ void Player::clearAttacked()
 	attackedSet.clear();
 }
 
-void Player::addUnjustifiedDead(const Player* attacked)
+void Player::addUnjustifiedDead(const PlayerConstPtr& attacked)
 {
-	if (hasFlag(PlayerFlag_NotGainInFight) || attacked == this || g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
+	if (hasFlag(PlayerFlag_NotGainInFight) || attacked == this->getPlayer() || g_game.getWorldType() == WORLD_TYPE_PVP_ENFORCED) {
 		return;
 	}
 
@@ -4686,10 +4629,9 @@ void Player::addUnjustifiedDead(const Player* attacked)
 	}
 }
 
-void Player::checkSkullTicks(int64_t ticks)
+void Player::checkSkullTicks(const int64_t ticks)
 {
-	int64_t newTicks = skullTicks - ticks;
-	if (newTicks < 0) {
+	if (const int64_t newTicks = skullTicks - ticks; newTicks < 0) {
 		skullTicks = 0;
 	} else {
 		skullTicks = newTicks;
@@ -4720,7 +4662,7 @@ double Player::getLostPercent() const
 
 	double lossPercent;
 	if (level >= 25) {
-		double tmpLevel = level + (levelPercent / 100.);
+		const double tmpLevel = level + (levelPercent / 100.);
 		lossPercent = static_cast<double>((tmpLevel + 50) * 50 * ((tmpLevel * tmpLevel) - (5 * tmpLevel) + 8)) / experience;
 	} else {
 		lossPercent = 10;
@@ -4764,7 +4706,7 @@ bool Player::hasLearnedInstantSpell(const std::string& spellName) const
 	return false;
 }
 
-bool Player::isInWar(const Player* player) const
+bool Player::isInWar(const PlayerConstPtr& player) const
 {
 	if (!player || !guild) {
 		return false;
@@ -4778,9 +4720,9 @@ bool Player::isInWar(const Player* player) const
 	return isInWarList(playerGuild->getId()) && player->isInWarList(guild->getId());
 }
 
-bool Player::isInWarList(uint32_t guildId) const
+bool Player::isInWarList(const uint32_t guildId) const
 {
-	return std::find(guildWarVector.begin(), guildWarVector.end(), guildId) != guildWarVector.end();
+	return std::ranges::find(guildWarVector, guildId) != guildWarVector.end();
 }
 
 bool Player::isPremium() const
@@ -4792,13 +4734,13 @@ bool Player::isPremium() const
 	return premiumEndsAt > time(nullptr);
 }
 
-void Player::setPremiumTime(time_t premiumEndsAt)
+void Player::setPremiumTime(const time_t premiumEndsAt)
 {
 	this->premiumEndsAt = premiumEndsAt;
 	sendBasicData();
 }
 
-PartyShields_t Player::getPartyShield(const Player* player) const
+PartyShields_t Player::getPartyShield(const PlayerConstPtr& player) const
 {
 	if (!player) {
 		return SHIELD_NONE;
@@ -4842,7 +4784,7 @@ PartyShields_t Player::getPartyShield(const Player* player) const
 		}
 	}
 
-	if (player->isInviting(this)) {
+	if (player->isInviting(this->getPlayer())) {
 		return SHIELD_WHITEYELLOW;
 	}
 
@@ -4853,23 +4795,23 @@ PartyShields_t Player::getPartyShield(const Player* player) const
 	return SHIELD_NONE;
 }
 
-bool Player::isInviting(const Player* player) const
+bool Player::isInviting(const PlayerConstPtr& player) const
 {
-	if (!player || !party || party->getLeader() != this) {
+	if (!player || !party || party->getLeader() != this->getPlayer()) {
 		return false;
 	}
 	return party->isPlayerInvited(player);
 }
 
-bool Player::isPartner(const Player* player) const
+bool Player::isPartner(const PlayerConstPtr& player) const
 {
-	if (!player || !party || player == this) {
+	if (!player || !party || player == this->getPlayer()) {
 		return false;
 	}
 	return party == player->party;
 }
 
-bool Player::isGuildMate(const Player* player) const
+bool Player::isGuildMate(const PlayerConstPtr& player) const
 {
 	if (!player || !guild) {
 		return false;
@@ -4877,7 +4819,7 @@ bool Player::isGuildMate(const Player* player) const
 	return guild == player->guild;
 }
 
-void Player::sendPlayerPartyIcons(Player* player)
+void Player::sendPlayerPartyIcons(const PlayerPtr& player) const
 {
 	sendCreatureShield(player);
 	sendCreatureSkull(player);
@@ -4885,8 +4827,7 @@ void Player::sendPlayerPartyIcons(Player* player)
 
 bool Player::addPartyInvitation(Party* party)
 {
-	auto it = std::find(invitePartyList.begin(), invitePartyList.end(), party);
-	if (it != invitePartyList.end()) {
+	if (const auto it = std::ranges::find(invitePartyList, party); it != invitePartyList.end()) {
 		return false;
 	}
 
@@ -4902,12 +4843,12 @@ void Player::removePartyInvitation(Party* party)
 void Player::clearPartyInvitations()
 {
 	for (Party* invitingParty : invitePartyList) {
-		invitingParty->removeInvite(*this, false);
+		invitingParty->removeInvite(this->getPlayer(), false);
 	}
 	invitePartyList.clear();
 }
 
-GuildEmblems_t Player::getGuildEmblem(const Player* player) const
+GuildEmblems_t Player::getGuildEmblem(const PlayerConstPtr& player) const
 {
 	if (!player) {
 		return GUILDEMBLEM_NONE;
@@ -4942,12 +4883,12 @@ uint8_t Player::getCurrentMount() const
 	return 0;
 }
 
-void Player::setCurrentMount(uint8_t mountId)
+void Player::setCurrentMount(const uint8_t mountId)
 {
 	addStorageValue(PSTRG_MOUNTS_CURRENTMOUNT, mountId);
 }
 
-bool Player::toggleMount(bool mount)
+bool Player::toggleMount(const bool mount)
 {
 	if ((OTSYS_TIME() - lastToggleMount) < 3000 && !wasMounted) {
 		sendCancelMessage(RETURNVALUE_YOUAREEXHAUSTED);
@@ -4959,23 +4900,23 @@ bool Player::toggleMount(bool mount)
 			return false;
 		}
 
-		if (!group->access && tile->hasFlag(TILESTATE_PROTECTIONZONE)) {
+		if (!group->access && tile.lock()->hasFlag(TILESTATE_PROTECTIONZONE)) {
 			sendCancelMessage(RETURNVALUE_ACTIONNOTPERMITTEDINPROTECTIONZONE);
 			return false;
 		}
 
-		const Outfit* playerOutfit = Outfits::getInstance().getOutfitByLookType(getSex(), defaultOutfit.lookType);
+		const auto& playerOutfit = Outfits::getInstance().getOutfitByLookType(getSex(), defaultOutfit.lookType);
 		if (!playerOutfit) {
 			return false;
 		}
 
-		uint8_t currentMountId = getCurrentMount();
+		const uint8_t currentMountId = getCurrentMount();
 		if (currentMountId == 0) {
 			sendOutfitWindow();
 			return false;
 		}
 
-		Mount* currentMount = g_game.mounts.getMountByID(currentMountId);
+		const auto& currentMount = g_game.mounts.getMountByID(currentMountId);
 		if (!currentMount) {
 			return false;
 		}
@@ -4999,7 +4940,7 @@ bool Player::toggleMount(bool mount)
 		defaultOutfit.lookMount = currentMount->clientId;
 
 		if (currentMount->speed != 0) {
-			g_game.changeSpeed(this, currentMount->speed);
+			g_game.changeSpeed(this->getPlayer(), currentMount->speed);
 		}
 	} else {
 		if (!isMounted()) {
@@ -5009,12 +4950,12 @@ bool Player::toggleMount(bool mount)
 		dismount();
 	}
 
-	g_game.internalCreatureChangeOutfit(this, defaultOutfit);
+	g_game.internalCreatureChangeOutfit(this->getPlayer(), defaultOutfit);
 	lastToggleMount = OTSYS_TIME();
 	return true;
 }
 
-bool Player::tameMount(uint8_t mountId)
+bool Player::tameMount(const uint8_t mountId)
 {
 	if (!g_game.mounts.getMountByID(mountId)) {
 		return false;
@@ -5034,7 +4975,7 @@ bool Player::tameMount(uint8_t mountId)
 	return true;
 }
 
-bool Player::untameMount(uint8_t mountId)
+bool Player::untameMount(const uint8_t mountId)
 {
 	if (!g_game.mounts.getMountByID(mountId)) {
 		return false;
@@ -5054,7 +4995,7 @@ bool Player::untameMount(uint8_t mountId)
 	if (getCurrentMount() == mountId) {
 		if (isMounted()) {
 			dismount();
-			g_game.internalCreatureChangeOutfit(this, defaultOutfit);
+			g_game.internalCreatureChangeOutfit(this->getPlayer(), defaultOutfit);
 		}
 
 		setCurrentMount(0);
@@ -5085,9 +5026,9 @@ bool Player::hasMount(const Mount* mount) const
 
 void Player::dismount()
 {
-	Mount* mount = g_game.mounts.getMountByID(getCurrentMount());
+	const auto& mount = g_game.mounts.getMountByID(getCurrentMount());
 	if (mount && mount->speed > 0) {
-		g_game.changeSpeed(this, -mount->speed);
+		g_game.changeSpeed(this->getPlayer(), -mount->speed);
 	}
 
 	defaultOutfit.lookMount = 0;
@@ -5114,7 +5055,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 		oldSkillValue = magLevel;
 		oldPercentToNextLevel = static_cast<long double>(manaSpent * 100) / nextReqMana;
 
-		g_events->eventPlayerOnGainSkillTries(this, SKILL_MAGLEVEL, tries);
+		g_events->eventPlayerOnGainSkillTries(this->getPlayer(), SKILL_MAGLEVEL, tries);
 		uint32_t currMagLevel = magLevel;
 
 		while ((manaSpent + tries) >= nextReqMana) {
@@ -5123,7 +5064,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 			magLevel++;
 			manaSpent = 0;
 
-			g_creatureEvents->playerAdvance(this, SKILL_MAGLEVEL, magLevel - 1, magLevel);
+			g_creatureEvents->playerAdvance(this->getPlayer(), SKILL_MAGLEVEL, magLevel - 1, magLevel);
 
 			sendUpdate = true;
 			currReqMana = nextReqMana;
@@ -5166,7 +5107,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 		oldSkillValue = skills[skill].level;
 		oldPercentToNextLevel = static_cast<long double>(skills[skill].tries * 100) / nextReqTries;
 
-		g_events->eventPlayerOnGainSkillTries(this, skill, tries);
+		g_events->eventPlayerOnGainSkillTries(this->getPlayer(), skill, tries);
 		uint32_t currSkillLevel = skills[skill].level;
 
 		while ((skills[skill].tries + tries) >= nextReqTries) {
@@ -5176,7 +5117,7 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 			skills[skill].tries = 0;
 			skills[skill].percent = 0;
 
-			g_creatureEvents->playerAdvance(this, skill, (skills[skill].level - 1), skills[skill].level);
+			g_creatureEvents->playerAdvance(this->getPlayer(), skill, (skills[skill].level - 1), skills[skill].level);
 
 			sendUpdate = true;
 			currReqTries = nextReqTries;
@@ -5219,12 +5160,12 @@ bool Player::addOfflineTrainingTries(skills_t skill, uint64_t tries)
 	return sendUpdate;
 }
 
-bool Player::hasModalWindowOpen(uint32_t modalWindowId) const
+bool Player::hasModalWindowOpen(const uint32_t modalWindowId) const
 {
-	return find(modalWindows.begin(), modalWindows.end(), modalWindowId) != modalWindows.end();
+	return std::ranges::find(modalWindows, modalWindowId) != modalWindows.end();
 }
 
-void Player::onModalWindowHandled(uint32_t modalWindowId)
+void Player::onModalWindowHandled(const uint32_t modalWindowId)
 {
 	modalWindows.remove(modalWindowId);
 }
@@ -5249,15 +5190,15 @@ uint16_t Player::getHelpers() const
 	uint16_t helpers;
 
 	if (guild && party) {
-		std::unordered_set<Player*> helperSet;
+		std::unordered_set<PlayerPtr> helperSet;
 
-		const auto& guildMembers = guild->getMembersOnline();
+		auto guildMembers = guild->getMembersOnline();
 		helperSet.insert(guildMembers.begin(), guildMembers.end());
 
-		const auto& partyMembers = party->getMembers();
+		auto partyMembers = party->getMembers();
 		helperSet.insert(partyMembers.begin(), partyMembers.end());
 
-		const auto& partyInvitees = party->getInvitees();
+		auto partyInvitees = party->getInvitees();
 		helperSet.insert(partyInvitees.begin(), partyInvitees.end());
 
 		helperSet.insert(party->getLeader());
@@ -5274,10 +5215,10 @@ uint16_t Player::getHelpers() const
 	return helpers;
 }
 
-void Player::sendClosePrivate(uint16_t channelId)
+void Player::sendClosePrivate(const uint16_t channelId)
 {
 	if (channelId == CHANNEL_GUILD || channelId == CHANNEL_PARTY) {
-		g_chat->removeUserFromChannel(*this, channelId);
+		g_chat->removeUserFromChannel(this->getPlayer(), channelId);
 	}
 
 	if (client) {
@@ -5287,17 +5228,16 @@ void Player::sendClosePrivate(uint16_t channelId)
 
 uint64_t Player::getMoney() const
 {
-	std::vector<const Container*> containers;
+	std::vector<ContainerPtr> containers;
 	uint64_t moneyCount = 0;
 
 	for (int32_t i = CONST_SLOT_FIRST; i <= CONST_SLOT_LAST; ++i) {
-		Item* item = inventory[i];
+		const auto& item = inventory[i];
 		if (!item) {
 			continue;
 		}
 
-		const Container* container = item->getContainer();
-		if (container) {
+		if (const auto& container = item->getContainer()) {
 			containers.push_back(container);
 		} else {
 			moneyCount += item->getWorth();
@@ -5306,10 +5246,9 @@ uint64_t Player::getMoney() const
 
 	size_t i = 0;
 	while (i < containers.size()) {
-		const Container* container = containers[i++];
-		for (const Item* item : container->getItemList()) {
-			const Container* tmpContainer = item->getContainer();
-			if (tmpContainer) {
+		const auto& container = containers[i++];
+		for (const auto& item : container->getItemList()) {
+			if (const auto& tmpContainer = item->getContainer()) {
 				containers.push_back(tmpContainer);
 			} else {
 				moneyCount += item->getWorth();
@@ -5337,36 +5276,35 @@ size_t Player::getMaxDepotItems() const
 	return g_config.getNumber(isPremium() ? ConfigManager::DEPOT_PREMIUM_LIMIT : ConfigManager::DEPOT_FREE_LIMIT);
 }
 
-const bool Player::addAugment(std::shared_ptr<Augment>& augment) {
-	if (std::find(augments.begin(), augments.end(), augment) == augments.end()) {
+const bool Player::addAugment(const std::shared_ptr<Augment>& augment) {
+	if (std::ranges::find(augments, augment) == augments.end()) {
 		augments.push_back(augment);
-		g_events->eventPlayerOnAugment(this, augment);
+		g_events->eventPlayerOnAugment(this->getPlayer(), augment);
 		return true;
 	}
 	return false;
 }
 
-const bool Player::addAugment(std::string_view augmentName) {
+const bool Player::addAugment(const std::string_view augmentName) {
 
 	if (auto augment = Augments::GetAugment(augmentName)) {
 		augments.emplace_back(augment);
-		g_events->eventPlayerOnAugment(this, augment);
+		g_events->eventPlayerOnAugment(this->getPlayer(), augment);
 		return true;
 	}
 	return false;
 }
 
-const bool Player::removeAugment(std::shared_ptr<Augment>& augment) {
-	auto it = std::find(augments.begin(), augments.end(), augment);
-	if (it != augments.end()) {
-		g_events->eventPlayerOnRemoveAugment(this, augment);
+const bool Player::removeAugment(const std::shared_ptr<Augment>& augment) {
+	if (const auto it = std::ranges::find(augments, augment); it != augments.end()) {
+		g_events->eventPlayerOnRemoveAugment(this->getPlayer(), augment);
 		augments.erase(it);
 		return true;
 	}
 	return false;
 }
 
-const bool Player::isAugmented()
+const bool Player::isAugmented() const
 {
 	return augments.size() > 0;
 }
@@ -5381,7 +5319,7 @@ const bool Player::hasAugment(const std::string_view augmentName, bool checkItem
 
 	if (checkItems) {
 		for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
-			Item* item = inventory[slot];
+			const auto& item = inventory[slot];
 			for (const auto& aug : item->getAugments()) {
 				if (aug->getName() == augmentName) {
 					return true;
@@ -5403,7 +5341,7 @@ const bool Player::hasAugment(const std::shared_ptr<Augment>& augment, bool chec
 
 	if (checkItems) {
 		for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
-			Item* item = inventory[slot];
+			const auto& item = inventory[slot];
 			for (const auto& aug : item->getAugments()) {
 				if (aug == augment) {
 					return true;
@@ -5420,16 +5358,15 @@ const std::vector<std::shared_ptr<Augment>> Player::getPlayerAugments() const {
 }
 
 const bool Player::removeAugment(std::string_view augmentName) {
-	auto originalSize = augments.size();
+	const auto& originalSize = augments.size();
 	
-	augments.erase(std::remove_if(augments.begin(), augments.end(),
-		[&](const std::shared_ptr<Augment>& augment) {
-			auto match = augment->getName() == augmentName;
-			if (match) {
-				g_events->eventPlayerOnRemoveAugment(this, augment);
-			}
-			return augment->getName() == augmentName;
-		}), augments.end());
+	std::erase_if(augments,
+	              [&](const std::shared_ptr<Augment>& augment) {
+		              if (const auto match = augment->getName() == augmentName) {
+			              g_events->eventPlayerOnRemoveAugment(this->getPlayer(), augment);
+		              }
+		              return augment->getName() == augmentName;
+	              });
 	
 	return augments.size() > originalSize;
 }
@@ -5473,15 +5410,15 @@ void Player::setGuild(Guild* guild)
 
 		this->guild = guild;
 		this->guildRank = rank;
-		guild->addMember(this);
+		guild->addMember(this->getPlayer());
 	}
 
 	if (oldGuild) {
-		oldGuild->removeMember(this);
+		oldGuild->removeMember(this->getPlayer());
 	}
 }
 
-void Player::updateRegeneration()
+void Player::updateRegeneration() const
 {
 	if (!vocation) {
 		return;
@@ -5496,7 +5433,7 @@ void Player::updateRegeneration()
 	}
 }
 
-void Player::addItemImbuements(Item* item) {
+void Player::addItemImbuements(const ItemPtr& item) {
 	if (item->hasImbuements()) {
 		const std::vector<std::shared_ptr<Imbuement>>& imbuementList = item->getImbuements();
 		for (auto& imbue : imbuementList) {
@@ -5552,7 +5489,7 @@ void Player::addItemImbuements(Item* item) {
 						capacity += imbue->value;
 						break;
 					case ImbuementType::IMBUEMENT_TYPE_SPEED_BOOST:
-						g_game.changeSpeed(this, static_cast<int32_t>(imbue->value));
+						g_game.changeSpeed(this->getPlayer(), static_cast<int32_t>(imbue->value));
 						break;
 				}
 			}
@@ -5562,7 +5499,7 @@ void Player::addItemImbuements(Item* item) {
 	sendStats();
 }
 
-void Player::removeItemImbuements(Item* item) {
+void Player::removeItemImbuements(const ItemPtr& item) {
 	if (item->hasImbuements()) {
 		const std::vector<std::shared_ptr<Imbuement>>& imbuementList = item->getImbuements();
 		for (auto& imbue : imbuementList) {
@@ -5618,7 +5555,7 @@ void Player::removeItemImbuements(Item* item) {
 					capacity -= imbue->value;
 					break;
 				case ImbuementType::IMBUEMENT_TYPE_SPEED_BOOST:
-					g_game.changeSpeed(this, -static_cast<int32_t>(imbue->value));
+					g_game.changeSpeed(this->getPlayer(), -static_cast<int32_t>(imbue->value));
 					break;
 				}
 			}
@@ -5629,7 +5566,7 @@ void Player::removeItemImbuements(Item* item) {
 }
 
 
-void Player::removeImbuementEffect(std::shared_ptr<Imbuement> imbue) {
+void Player::removeImbuementEffect(const std::shared_ptr<Imbuement>& imbue) {
 	
 	if (imbue->isSkill()) {
 		switch (imbue->imbuetype) {
@@ -5683,7 +5620,7 @@ void Player::removeImbuementEffect(std::shared_ptr<Imbuement> imbue) {
 			capacity -= imbue->value;
 			break;
 		case ImbuementType::IMBUEMENT_TYPE_SPEED_BOOST:
-			g_game.changeSpeed(this, -static_cast<int32_t>(imbue->value));
+			g_game.changeSpeed(this->getPlayer(), -static_cast<int32_t>(imbue->value));
 			break;
 		}
 	}
@@ -5691,7 +5628,7 @@ void Player::removeImbuementEffect(std::shared_ptr<Imbuement> imbue) {
 	sendStats();
 }
 
-void Player::addImbuementEffect(std::shared_ptr<Imbuement> imbue) {
+void Player::addImbuementEffect(const std::shared_ptr<Imbuement>& imbue) {
 
 	if (imbue->isSkill()) {
 		switch (imbue->imbuetype) {
@@ -5745,7 +5682,7 @@ void Player::addImbuementEffect(std::shared_ptr<Imbuement> imbue) {
 			capacity += imbue->value;
 			break;
 		case ImbuementType::IMBUEMENT_TYPE_SPEED_BOOST:
-			g_game.changeSpeed(this, static_cast<int32_t>(imbue->value));
+			g_game.changeSpeed(this->getPlayer(), static_cast<int32_t>(imbue->value));
 			break;
 		}
 	}
@@ -5753,11 +5690,12 @@ void Player::addImbuementEffect(std::shared_ptr<Imbuement> imbue) {
 	sendStats();
 }
 
-CreatureType_t Player::getCreatureType(Monster& monster) {
+CreatureType_t Player::getCreatureType(const MonsterPtr& monster) const
+{
 	auto creatureType = CREATURETYPE_MONSTER;
-	if (monster.getFriendList().size() > 0) {
-		for (auto monsterFriend : monster.getFriendList()) {
-			if (Player* ally = monsterFriend->getPlayer()) {
+	if (monster->getFriendList().size() > 0) {
+		for (auto monsterFriend : monster->getFriendList()) {
+			if (const auto& ally = monsterFriend->getPlayer()) {
 
 				if (ally->getGuild() && this->getGuild() && ally->getGuild() == this->getGuild()) {
 					creatureType = CREATURETYPE_SUMMON_GUILD;
@@ -5770,13 +5708,13 @@ CreatureType_t Player::getCreatureType(Monster& monster) {
 		}
 	}
 
-	if (monster.getMaster() && monster.getMaster()->getID() == this->getID()) {
+	if (monster->getMaster() && monster->getMaster()->getID() == this->getID()) {
 		creatureType = CREATURETYPE_SUMMON_OWN;
 	}
 	return creatureType;
 }
 
-static ModifierTotals getValidatedTotals(const std::vector<std::shared_ptr<DamageModifier>> modifierList, const CombatType_t damageType, const CombatOrigin originType, const CreatureType_t creatureType, const RaceType_t race, const std::string_view creatureName) {
+static ModifierTotals getValidatedTotals(const std::vector<std::shared_ptr<DamageModifier>>& modifierList, const CombatType_t damageType, const CombatOrigin originType, const CreatureType_t creatureType, const RaceType_t race, const std::string_view creatureName) {
 	uint16_t percent = 0;
 	uint16_t flat = 0;
 	// to-do: const and auto&
@@ -5808,27 +5746,27 @@ static ModifierTotals getValidatedTotals(const std::vector<std::shared_ptr<Damag
 	return ModifierTotals(flat, percent);
 }
 
-std::unordered_map <uint8_t, std::vector<std::shared_ptr<DamageModifier>>> Player::getAttackModifiers() {
+std::unordered_map <uint8_t, std::vector<std::shared_ptr<DamageModifier>>> Player::getAttackModifiers() const
+{
 	std::unordered_map<uint8_t, std::vector<std::shared_ptr<DamageModifier>>> modifierMap;
 
 	if (!augments.empty()) {
-		for (auto& aug : augments) {
-			for (auto mod : aug->getAttackModifiers()) {
+		for (const auto& aug : augments) {
+			for (const auto& mod : aug->getAttackModifiers()) {
 				modifierMap[mod->getType()].emplace_back(mod);
 			}
 		}
 	}
 
 	for (uint8_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_RING; ++slot) {
-		Item* item = inventory[slot];
-		if (item && !item->getAugments().empty()) {
-			for (auto& aug : item->getAugments()) {
+		if (const auto& item = inventory[slot]; item && !item->getAugments().empty()) {
+			for (const auto& aug : item->getAugments()) {
 				if (!g_config.getBoolean(ConfigManager::AUGMENT_SLOT_PROTECTION) || (item->getEquipSlot() == getPositionForSlot(static_cast<slots_t>(slot)))) {
-					for (auto mod : aug->getAttackModifiers()) {
+					for (const auto& mod : aug->getAttackModifiers()) {
 						modifierMap[mod->getType()].emplace_back(mod);
 					}
 				} else if ( g_config.getBoolean(ConfigManager::AUGMENT_SLOT_PROTECTION) && (slot == CONST_SLOT_RIGHT || slot == CONST_SLOT_LEFT) && (item->getWeaponType() != WEAPON_NONE && item->getWeaponType() != WEAPON_AMMO)) {
-					for (auto mod : aug->getAttackModifiers()) {
+					for (const auto& mod : aug->getAttackModifiers()) {
 						modifierMap[mod->getType()].emplace_back(mod);
 					}
 				}
@@ -5839,34 +5777,33 @@ std::unordered_map <uint8_t, std::vector<std::shared_ptr<DamageModifier>>> Playe
 	return modifierMap;
 }
 
-std::unordered_map <uint8_t, std::vector<std::shared_ptr<DamageModifier>>> Player::getDefenseModifiers() {
+std::unordered_map <uint8_t, std::vector<std::shared_ptr<DamageModifier>>> Player::getDefenseModifiers() const
+{
 	std::unordered_map<uint8_t, std::vector<std::shared_ptr<DamageModifier>>> modifierMap;
 
 	if (!augments.empty()) {
-		for (auto& aug : augments) {
-			for (auto mod : aug->getDefenseModifiers()) {
+		for (const auto& aug : augments) {
+			for (const auto& mod : aug->getDefenseModifiers()) {
 				modifierMap[mod->getType()].emplace_back(mod);
 			}
 		}
 	}
 
 	for (uint8_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_RING; ++slot) {
-		Item* item = inventory[slot];
-		if (item && !item->getAugments().empty()) {
-			for (auto& aug : item->getAugments()) {
+		if (const auto& item = inventory[slot]; item && !item->getAugments().empty()) {
+			for (const auto& aug : item->getAugments()) {
 				if (!g_config.getBoolean(ConfigManager::AUGMENT_SLOT_PROTECTION) || (item->getEquipSlot() == getPositionForSlot(static_cast<slots_t>(slot)))) {
-					for (auto mod : aug->getDefenseModifiers()) {
+					for (const auto& mod : aug->getDefenseModifiers()) {
 						modifierMap[mod->getType()].emplace_back(mod);
 					}
 				} else if (g_config.getBoolean(ConfigManager::AUGMENT_SLOT_PROTECTION) && (slot == CONST_SLOT_RIGHT || slot == CONST_SLOT_LEFT) && (item->getWeaponType() != WEAPON_NONE && item->getWeaponType() != WEAPON_AMMO)) {
-					for (auto mod : aug->getDefenseModifiers()) {
+					for (const auto& mod : aug->getDefenseModifiers()) {
 						modifierMap[mod->getType()].emplace_back(mod);
 					}
 				}
 			}
 		}
 	}
-
 	return modifierMap;
 }
 
@@ -5878,7 +5815,8 @@ std::unordered_map<uint8_t, ModifierTotals> Player::getConvertedTotals(const uin
 	std::unordered_map<uint8_t, ModifierTotals> itemList;
 	itemList.reserve(COMBAT_COUNT);
 	
-	[[unlikely]]if ((modType != ATTACK_MODIFIER_CONVERSION) && (modType != DEFENSE_MODIFIER_REFORM)) {
+	[[unlikely]]
+	if ((modType != ATTACK_MODIFIER_CONVERSION) && (modType != DEFENSE_MODIFIER_REFORM)) {
 		std::cout << "::: WARNING Player::getConvertedTotals called with invalid Mod Type! \n";
 		return playerList;
 	}
@@ -5909,9 +5847,8 @@ std::unordered_map<uint8_t, ModifierTotals> Player::getConvertedTotals(const uin
 					}
 
 					percent = std::min<uint16_t>(percent, 100);
-					auto index = combatTypeToIndex(modifier->getConversionType());
-					auto [it, inserted] = playerList.try_emplace(index, ModifierTotals{flat, percent});
-					if (!inserted) {
+					const auto& index = combatTypeToIndex(modifier->getConversionType());
+					if (auto [it, inserted] = playerList.try_emplace(index, ModifierTotals{flat, percent}); !inserted) {
 						it->second += ModifierTotals{flat, percent};
 					}
 				}
@@ -5920,8 +5857,7 @@ std::unordered_map<uint8_t, ModifierTotals> Player::getConvertedTotals(const uin
 	}
 
 	for (int32_t slot = CONST_SLOT_FIRST; slot <= CONST_SLOT_LAST; ++slot) {
-		Item* item = inventory[slot];
-		if (item && !item->getAugments().empty()) {
+		if (const auto& item = inventory[slot]; item && !item->getAugments().empty()) {
 			for (const auto& aug : item->getAugments()) {
 				const auto& modifiers = modType == ATTACK_MODIFIER_CONVERSION ? aug->getAttackModifiers(modType) : aug->getDefenseModifiers(modType);
 				for (const auto& modifier : modifiers) {
@@ -5947,9 +5883,8 @@ std::unordered_map<uint8_t, ModifierTotals> Player::getConvertedTotals(const uin
 						}
 						
 						percent = std::min<uint16_t>(percent, 100);
-						auto index = combatTypeToIndex(modifier->getConversionType());
-						auto [it, inserted] = playerList.try_emplace(index, ModifierTotals{flat, percent});
-						if (!inserted) {
+						const auto index = combatTypeToIndex(modifier->getConversionType());
+						if (auto [it, inserted] = playerList.try_emplace(index, ModifierTotals{flat, percent}); !inserted) {
 							it->second += ModifierTotals{flat, percent};
 						}
 					}
@@ -5961,7 +5896,8 @@ std::unordered_map<uint8_t, ModifierTotals> Player::getConvertedTotals(const uin
 	return playerList;
 }
 
-std::unordered_map<uint8_t, ModifierTotals> Player::getAttackModifierTotals(const CombatType_t damageType, const CombatOrigin originType, const CreatureType_t creatureType, const RaceType_t race, const std::string_view creatureName) {
+std::unordered_map<uint8_t, ModifierTotals> Player::getAttackModifierTotals(const CombatType_t damageType, const CombatOrigin originType, const CreatureType_t creatureType, const RaceType_t race, const std::string_view creatureName) const
+{
 	
 	std::unordered_map<uint8_t, ModifierTotals> modMap;
 	modMap.reserve(ATTACK_MODIFIER_LAST);
@@ -5974,7 +5910,8 @@ std::unordered_map<uint8_t, ModifierTotals> Player::getAttackModifierTotals(cons
 	return modMap;
 }
 
-std::unordered_map<uint8_t, ModifierTotals> Player::getDefenseModifierTotals(const CombatType_t damageType, const CombatOrigin originType, const CreatureType_t creatureType, const RaceType_t race, std::string_view creatureName) {
+std::unordered_map<uint8_t, ModifierTotals> Player::getDefenseModifierTotals(const CombatType_t damageType, const CombatOrigin originType, const CreatureType_t creatureType, const RaceType_t race, std::string_view creatureName) const
+{
 	
 	std::unordered_map<uint8_t, ModifierTotals> modMap;
 	modMap.reserve(DEFENSE_MODIFIER_LAST);
@@ -6018,7 +5955,7 @@ std::vector<Position> Player::getOpenPositionsInRadius(int radius) const {
 	return openPositions;
 }
 
-void Player::absorbDamage(std::optional<std::reference_wrapper<Creature>> attacker,
+void Player::absorbDamage(const std::optional<CreaturePtr> attacker,
 							CombatDamage& originalDamage,
 							int32_t percent,
 							int32_t flat) {
@@ -6048,15 +5985,15 @@ void Player::absorbDamage(std::optional<std::reference_wrapper<Creature>> attack
 		absorbParams.distanceEffect = CONST_ANI_NONE;
 
 		if (!attacker.has_value()) {
-			Combat::doTargetCombat(nullptr, this, absorb, absorbParams);
+			Combat::doTargetCombat(nullptr, this->getPlayer(), absorb, absorbParams);
 			return;
 		}
 
-		Combat::doTargetCombat(&attacker.value().get(), this, absorb, absorbParams);
+		Combat::doTargetCombat(attacker.value(), this->getPlayer(), absorb, absorbParams);
 	}
 }
 
-void Player::restoreManaFromDamage(std::optional<std::reference_wrapper<Creature>> attacker,
+void Player::restoreManaFromDamage(std::optional<CreaturePtr> attacker,
 									CombatDamage& originalDamage,
 									int32_t percent,
 									int32_t flat) {
@@ -6086,15 +6023,15 @@ void Player::restoreManaFromDamage(std::optional<std::reference_wrapper<Creature
 		restoreParams.distanceEffect = CONST_ANI_NONE;
 
 		if (!attacker.has_value()) {
-			Combat::doTargetCombat(nullptr, this, restore, restoreParams);
+			Combat::doTargetCombat(nullptr, this->getPlayer(), restore, restoreParams);
 			return;
 		}
 
-		Combat::doTargetCombat(&attacker.value().get(), this, restore, restoreParams);
+		Combat::doTargetCombat(attacker.value(), this->getPlayer(), restore, restoreParams);
 	}
 }
 
-void Player::reviveSoulFromDamage(std::optional<std::reference_wrapper<Creature>> attacker,
+void Player::reviveSoulFromDamage(std::optional<CreaturePtr> attacker,
 									CombatDamage& originalDamage,
 									int32_t percent,
 									int32_t flat) {
@@ -6112,7 +6049,7 @@ void Player::reviveSoulFromDamage(std::optional<std::reference_wrapper<Creature>
 		originalDamage.primary.value += reviveDamage;
 
 		auto message = (attacker.has_value()) ?
-			"You gained " + std::to_string(reviveDamage) + " soul from " + attacker.value().get().getName() + "'s attack." :
+			"You gained " + std::to_string(reviveDamage) + " soul from " + attacker.value()->getName() + "'s attack." :
 			"You gained " + std::to_string(reviveDamage) + " soul from revival.";
 		
 		sendTextMessage(MESSAGE_HEALED, message);
@@ -6120,7 +6057,7 @@ void Player::reviveSoulFromDamage(std::optional<std::reference_wrapper<Creature>
 	}
 }
 
-void Player::replenishStaminaFromDamage(std::optional<std::reference_wrapper<Creature>> attacker,
+void Player::replenishStaminaFromDamage(std::optional<CreaturePtr> attacker,
 										CombatDamage& originalDamage,
 										int32_t percent,
 										int32_t flat) {
@@ -6142,7 +6079,7 @@ void Player::replenishStaminaFromDamage(std::optional<std::reference_wrapper<Cre
 		}
 
 		auto message = (attacker.has_value()) ?
-			"You gained " + std::to_string(replenishDamage) + " stamina from " + attacker.value().get().getName() + "'s attack." :
+			"You gained " + std::to_string(replenishDamage) + " stamina from " + attacker.value()->getName() + "'s attack." :
 			"You gained " + std::to_string(replenishDamage) + " stamina from replenishment.";
 
 		sendTextMessage(MESSAGE_HEALED,  message);
@@ -6150,10 +6087,11 @@ void Player::replenishStaminaFromDamage(std::optional<std::reference_wrapper<Cre
 	}
 }
 
-void Player::resistDamage(std::optional<std::reference_wrapper<Creature>> attacker,
+void Player::resistDamage(std::optional<CreaturePtr> attacker,
 							CombatDamage& originalDamage,
 							int32_t percent,
-							int32_t flat) {
+							int32_t flat) const
+{
 	int32_t resistDamage = 0;
 	const int32_t originalDamageValue = std::abs(originalDamage.primary.value);
 	if (percent) {
@@ -6168,14 +6106,14 @@ void Player::resistDamage(std::optional<std::reference_wrapper<Creature>> attack
 		originalDamage.primary.value += resistDamage;
 		
 		auto message = (attacker.has_value()) ?
-			"You resisted " + std::to_string(resistDamage) + " damage from " + attacker.value().get().getName() + "'s attack." :
+			"You resisted " + std::to_string(resistDamage) + " damage from " + attacker.value()->getName() + "'s attack." :
 			"You resisted " + std::to_string(resistDamage) + " damage.";
 
 		sendTextMessage(MESSAGE_HEALED, message);
 	}
 }
 
-void Player::reflectDamage(std::optional<std::reference_wrapper<Creature>> attacker,
+void Player::reflectDamage(std::optional<CreaturePtr> attacker,
 							CombatDamage& originalDamage,
 							int32_t percent,
 							int32_t flat,
@@ -6196,7 +6134,7 @@ void Player::reflectDamage(std::optional<std::reference_wrapper<Creature>> attac
 	}
 
 	if (reflectDamage != 0)	{
-		Creature& target = attacker.value().get();
+		const auto& target = attacker.value();
 		reflectDamage = std::min<int32_t>(reflectDamage, originalDamageValue);
 		originalDamage.primary.value += reflectDamage;
 
@@ -6213,14 +6151,14 @@ void Player::reflectDamage(std::optional<std::reference_wrapper<Creature>> attac
 
 		sendTextMessage(
 		MESSAGE_DAMAGE_DEALT,
-		 "You reflected " + std::to_string(reflectDamage) + " damage from " + target.getName() + "'s attack back at them."
+		 "You reflected " + std::to_string(reflectDamage) + " damage from " + target->getName() + "'s attack back at them."
 		 );
 	
-		Combat::doTargetCombat(this, &target, reflect, params);
+		Combat::doTargetCombat(this->getPlayer(), target, reflect, params);
 	}
 }
 
-void Player::deflectDamage(std::optional<std::reference_wrapper<Creature>> attackerOpt, 
+void Player::deflectDamage(std::optional<CreaturePtr> attackerOpt, 
                           CombatDamage& originalDamage, 
                           int32_t percent, 
                           int32_t flat, 
@@ -6249,8 +6187,8 @@ void Player::deflectDamage(std::optional<std::reference_wrapper<Creature>> attac
         );
     	
         auto defensePos = getPosition();
-        auto attackPos = generateAttackPosition(attackerOpt, defensePos, paramOrigin);
-        auto damageArea = generateDeflectArea(attackerOpt, calculatedTargets);
+        const auto attackPos = generateAttackPosition(attackerOpt, defensePos, paramOrigin);
+        const auto damageArea = generateDeflectArea(attackerOpt, calculatedTargets);
     	
         auto deflect = CombatDamage{};
         deflect.primary.type = originalDamage.primary.type;
@@ -6271,7 +6209,7 @@ void Player::deflectDamage(std::optional<std::reference_wrapper<Creature>> attac
             "You deflected " + std::to_string(deflectDamage) + " total damage."
         );
     	
-        Combat::doAreaCombat(this, attackPos, damageArea.get(), deflect, params);
+        Combat::doAreaCombat(this->getPlayer(), attackPos, damageArea.get(), deflect, params);
     }
 }
 
@@ -6313,23 +6251,23 @@ void Player::ricochetDamage(CombatDamage& originalDamage,
 		params.targetCasterOrTopMost = true;
 		params.impactEffect = (areaEffect == CONST_ME_NONE) ? CombatTypeToAreaEffect(originalDamage.primary.type) : areaEffect;
 
-		auto damageArea = std::make_unique<AreaCombat>();
+		const auto& damageArea = std::make_unique<AreaCombat>();
 		damageArea->setupArea(Deflect1xArea, 5);
-		Combat::doAreaCombat(this, targetPos, damageArea.get(), ricochet, params);
+		Combat::doAreaCombat(this->getPlayer(), targetPos, damageArea.get(), ricochet, params);
 	}
 }
 
-void Player::convertDamage(Creature* target, CombatDamage& originalDamage, std::unordered_map<uint8_t, ModifierTotals> conversionList) {
+void Player::convertDamage(const CreaturePtr& target, CombatDamage& originalDamage, std::unordered_map<uint8_t, ModifierTotals> conversionList) {
 	auto iter = conversionList.begin();
 
 	while (originalDamage.primary.value < 0 && iter != conversionList.end()) {
 
-		CombatType_t combatType = indexToCombatType(iter->first);
-		ModifierTotals& totals = iter->second;
+		const CombatType_t combatType = indexToCombatType(iter->first);
+		const ModifierTotals& totals = iter->second;
 
 		int32_t convertedDamage = 0;
-		int32_t percent = static_cast<int32_t>(totals.percentTotal);
-		int32_t flat = static_cast<int32_t>(totals.flatTotal);
+		const int32_t percent = static_cast<int32_t>(totals.percentTotal);
+		const int32_t flat = static_cast<int32_t>(totals.flatTotal);
 		const int32_t originalDamageValue = std::abs(originalDamage.primary.value);
 		if (percent) {
 			convertedDamage += originalDamageValue  * percent / 100;
@@ -6353,19 +6291,19 @@ void Player::convertDamage(Creature* target, CombatDamage& originalDamage, std::
 			
 			auto message = "You converted " + std::to_string(convertedDamage) + " " + getCombatName(originalDamage.primary.type) + " damage to " + getCombatName(combatType) + " during an attack on " + target->getName() + ".";
 			sendTextMessage(MESSAGE_DAMAGE_DEALT, message);
-			Combat::doTargetCombat(this, target, converted, params);
+			Combat::doTargetCombat(this->getPlayer(), target, converted, params);
 		}
 		++iter;
 	}
 }
 
-void Player::reformDamage(std::optional<std::reference_wrapper<Creature>> attacker, CombatDamage& originalDamage, std::unordered_map<uint8_t, ModifierTotals> conversionList) {
+void Player::reformDamage(std::optional<CreaturePtr> attacker, CombatDamage& originalDamage, std::unordered_map<uint8_t, ModifierTotals> conversionList) {
 	auto iter = conversionList.begin();
 
 	while (originalDamage.primary.value < 0 && iter != conversionList.end()) {
 
 		CombatType_t combatType = indexToCombatType(iter->first);
-		ModifierTotals& totals = iter->second;
+		const ModifierTotals& totals = iter->second;
 
 		int32_t reformedDamage = 0;
 		int32_t percent = static_cast<int32_t>(totals.percentTotal);
@@ -6392,21 +6330,21 @@ void Player::reformDamage(std::optional<std::reference_wrapper<Creature>> attack
 			params.origin = ORIGIN_AUGMENT;
 			
 			auto message = (attacker.has_value()) ?
-				"You reformed " + std::to_string(reformedDamage) + " " + getCombatName(originalDamage.primary.type) + " damage from " + getCombatName(combatType) + " during an attack on you by " + attacker.value().get().getName() + "." :
+				"You reformed " + std::to_string(reformedDamage) + " " + getCombatName(originalDamage.primary.type) + " damage from " + getCombatName(combatType) + " during an attack on you by " + attacker.value()->getName() + "." :
 				"You reformed " + std::to_string(reformedDamage) + " " + getCombatName(originalDamage.primary.type) + " damage from " + getCombatName(combatType) + ".";
 			
 			sendTextMessage(MESSAGE_DAMAGE_DEALT, message);
-			auto target = (attacker.has_value()) ? &attacker.value().get() : nullptr;
-			Combat::doTargetCombat(target, this, reform, params);
+			auto target = (attacker.has_value()) ? attacker.value() : nullptr;
+			Combat::doTargetCombat(target, this->getPlayer(), reform, params);
 		}
 		++iter;
 	}
 }
 
-Position Player::generateAttackPosition(std::optional<std::reference_wrapper<Creature>> attacker, Position& defensePosition, CombatOrigin origin) {
+Position Player::generateAttackPosition(std::optional<CreaturePtr> attacker, Position& defensePosition, CombatOrigin origin) {
 
 	const Direction attackDirection = (attacker.has_value())
-		? getDirectionTo(defensePosition, attacker.value().get().getPosition())
+		? getDirectionTo(defensePosition, attacker.value()->getPosition())
 		: getOppositeDirection(this->getDirection());
 	
 	// Offsets
@@ -6434,7 +6372,7 @@ Position Player::generateAttackPosition(std::optional<std::reference_wrapper<Cre
 			defensePosition.z
 		};
 
-		const auto tile = g_game.map.getTile(targetLocation);
+		const auto& tile = g_game.map.getTile(targetLocation);
 		const bool isValid = tile
 			&& g_game.canThrowObjectTo(defensePosition, targetLocation)
 			&& !tile->getZone() == ZONE_PROTECTION
@@ -6459,23 +6397,23 @@ Position Player::generateAttackPosition(std::optional<std::reference_wrapper<Cre
 
 	const size_t vectorSize = possibleTargets.size();
 	const size_t index = vectorSize ? (std::rand() % vectorSize) : 0;
-	return vectorSize ? possibleTargets[index] : Spells::getCasterPosition(this, getOppositeDirection(this->getDirection()));
+	return vectorSize ? possibleTargets[index] : Spells::getCasterPosition(this->getPlayer(), getOppositeDirection(this->getDirection()));
 } 
 
-std::unique_ptr<AreaCombat> Player::generateDeflectArea(std::optional<std::reference_wrapper<Creature>> attacker, int32_t targetCount) {
+std::unique_ptr<AreaCombat> Player::generateDeflectArea(std::optional<CreaturePtr> attacker, int32_t targetCount) const
+{
 	auto combatArea = std::make_unique<AreaCombat>();
-	auto defendersPosition = this->getPosition();
-	auto direction = (attacker.has_value()) ? getDirectionTo(defendersPosition, attacker.value().get().getPosition()) : getOppositeDirection(this->getDirection());
-	
-	switch (direction) {
+	const auto defendersPosition = this->getPosition();
+
+	switch (const auto direction = (attacker.has_value()) ? getDirectionTo(defendersPosition, attacker.value()->getPosition()) : getOppositeDirection(this->getDirection())) {
 	case DIRECTION_NORTH:
 	case DIRECTION_EAST:
 	case DIRECTION_SOUTH:
 	case DIRECTION_WEST: {
-		auto targetAreas = _StandardDeflectionMap.find(targetCount)->second;
+		const auto targetAreas = _StandardDeflectionMap.find(targetCount)->second;
 			if (!targetAreas.empty()) {
-				auto index = std::rand() % targetAreas.size();
-				auto area = targetAreas[index];
+				const auto index = std::rand() % targetAreas.size();
+				const auto area = targetAreas[index];
 				combatArea->setupArea(area, 5);
 			}
 		break;
@@ -6484,15 +6422,15 @@ std::unique_ptr<AreaCombat> Player::generateDeflectArea(std::optional<std::refer
 	case DIRECTION_SOUTHEAST:
 	case DIRECTION_NORTHWEST:
 	case DIRECTION_NORTHEAST: {
-		auto targetAreas = _DiagonalDeflectionMap.find(targetCount)->second;
-		if (!targetAreas.empty()) {
-			auto index = std::rand() % targetAreas.size();
-			auto area = targetAreas[index];
+		if (const auto targetAreas = _DiagonalDeflectionMap.find(targetCount)->second; !targetAreas.empty()) {
+			const auto index = std::rand() % targetAreas.size();
+			const auto area = targetAreas[index];
 			combatArea->setupExtArea(area, 5);
 		}
 		break;
 	}
-	[[unlikely]]default:
+	[[unlikely]]
+	default:
 		std::cerr << "Deflection area attempted to be generated from unknown direction!" << std::endl;
 		break;
 	}

--- a/src/player.h
+++ b/src/player.h
@@ -1426,7 +1426,7 @@ class Player final : public Creature, public Cylinder
 		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t& maxQueryCount,
 				uint32_t flags) override;
 		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
-		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 				uint32_t& flags) override; // another optional ref wrapper
 
 		void addThing(ThingPtr) override {}

--- a/src/player.h
+++ b/src/player.h
@@ -1037,17 +1037,17 @@ class Player final : public Creature, public Cylinder
 		void onFollowCreatureDisappear(bool isLogout) override;
 
 		//container
-		void onAddContainerItem(const ItemPtr& item);
-		void onUpdateContainerItem(const ContainerPtr& container, const ItemPtr& oldItem, const ItemPtr& newItem);
-		void onRemoveContainerItem(const ContainerPtr& container, const ItemPtr& item);
+		void onAddContainerItem(ItemPtr item);
+		void onUpdateContainerItem(ContainerPtr container, ItemPtr oldItem, ItemPtr newItem);
+		void onRemoveContainerItem(ContainerPtr container, ItemPtr item);
 
-		void onCloseContainer(const ContainerConstPtr& container) const;
-		void onSendContainer(const ContainerPtr& container) const;
-		void autoCloseContainers(const ContainerConstPtr& container);
+		void onCloseContainer(ContainerPtr container);
+		void onSendContainer(ContainerPtr container);
+		void autoCloseContainers(ContainerPtr container);
 
 		//inventory
-		void onUpdateInventoryItem(const ItemPtr& oldItem, const ItemPtr& newItem);
-		void onRemoveInventoryItem(const ItemPtr& item);
+		void onUpdateInventoryItem(ItemPtr oldItem, ItemPtr newItem);
+		void onRemoveInventoryItem(ItemPtr item);
 
 		void sendCancelMessage(const std::string& msg) const {
 			if (client) {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -10,6 +10,7 @@
 class Protocol : public std::enable_shared_from_this<Protocol>
 {
 	public:
+		// todo: use reference for connections
 		explicit Protocol(Connection_ptr connection) : connection(connection) {}
 		virtual ~Protocol() = default;
 
@@ -40,7 +41,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 		OutputMessage_ptr& getCurrentBuffer() {
 			return outputBuffer;
 		}
-
+		// todo: use reference for message maybe?
 		void send(OutputMessage_ptr msg) const {
 			if (auto connection = getConnection()) {
 				connection->send(msg);
@@ -53,12 +54,15 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 				connection->close();
 			}
 		}
+	
 		void enableXTEAEncryption() {
 			encryptionEnabled = true;
 		}
+	
 		void setXTEAKey(const xtea::key& key) {
 			this->key = xtea::expand_key(key);
 		}
+	
 		void disableChecksum() {
 			checksumEnabled = false;
 		}

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -47,7 +47,7 @@ class ProtocolGame final : public Protocol
 		static const char* protocol_name() {
 			return "gameworld protocol";
 		}
-
+		// todo: use reference for connection
 		explicit ProtocolGame(Connection_ptr connection) : Protocol(connection) {}
 
 		void login(uint32_t characterId, uint32_t accountId, OperatingSystem_t operatingSystem);
@@ -70,7 +70,7 @@ class ProtocolGame final : public Protocol
 		void checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& removedKnown);
 
 		bool canSee(int32_t x, int32_t y, int32_t z) const;
-		bool canSee(const Creature*) const;
+		bool canSee(const CreatureConstPtr&) const;
 		bool canSee(const Position& pos) const;
 
 		// we have all the parse methods
@@ -156,27 +156,27 @@ class ProtocolGame final : public Protocol
 		void sendChannelsDialog();
 		void sendChannel(uint16_t channelId, const std::string& channelName, const UsersMap* channelUsers, const InvitedMap* invitedUsers);
 		void sendOpenPrivateChannel(const std::string& receiver);
-		void sendToChannel(const Creature* creature, SpeakClasses type, const std::string& text, uint16_t channelId);
-		void sendPrivateMessage(const Player* speaker, SpeakClasses type, const std::string& text);
+		void sendToChannel(const CreatureConstPtr& creature, SpeakClasses type, const std::string& text, uint16_t channelId);
+		void sendPrivateMessage(const PlayerConstPtr& speaker, SpeakClasses type, const std::string& text);
 		void sendIcons(uint16_t icons);
 		void sendFYIBox(const std::string& message);
 
 		void sendDistanceShoot(const Position& from, const Position& to, uint8_t type);
 		void sendMagicEffect(const Position& pos, uint8_t type);
-		void sendCreatureHealth(const Creature* creature);
+		void sendCreatureHealth(const CreatureConstPtr& creature);
 		void sendSkills();
 		void sendPing();
 		void sendPingBack();
-		void sendCreatureTurn(const Creature* creature, uint32_t stackPos);
-		void sendCreatureSay(const Creature* creature, SpeakClasses type, const std::string& text, const Position* pos = nullptr);
+		void sendCreatureTurn(const CreatureConstPtr& creature, uint32_t stackPos);
+		void sendCreatureSay(const CreatureConstPtr& creature, SpeakClasses type, const std::string& text, const Position* pos = nullptr);
 
 		void sendQuestLog();
 		void sendQuestLine(const Quest* quest);
 
 		void sendCancelWalk();
-		void sendChangeSpeed(const Creature* creature, uint32_t speed);
+		void sendChangeSpeed(const CreatureConstPtr& creature, uint32_t speed);
 		void sendCancelTarget();
-		void sendCreatureOutfit(const Creature* creature, const Outfit_t& outfit);
+		void sendCreatureOutfit(const CreatureConstPtr& creature, const Outfit_t& outfit);
 		void sendStats();
 		void sendBasicData();
 		void sendTextMessage(const TextMessage& message);
@@ -185,13 +185,13 @@ class ProtocolGame final : public Protocol
 		void sendTutorial(uint8_t tutorialId);
 		void sendAddMarker(const Position& pos, uint8_t markType, const std::string& desc);
 
-		void sendCreatureWalkthrough(const Creature* creature, bool walkthrough);
-		void sendCreatureShield(const Creature* creature);
-		void sendCreatureSkull(const Creature* creature);
+		void sendCreatureWalkthrough(const CreatureConstPtr& creature, bool walkthrough);
+		void sendCreatureShield(const CreatureConstPtr& creature);
+		void sendCreatureSkull(const CreatureConstPtr& creature);
 		void sendCreatureType(uint32_t creatureId, uint8_t creatureType);
 		void sendCreatureHelpers(uint32_t creatureId, uint16_t helpers);
 
-		void sendShop(Npc* npc, const ShopInfoList& itemList);
+		void sendShop(const NpcPtr& npc, const ShopInfoList& itemList);
 		void sendCloseShop();
 		void sendSaleItemList(const std::list<ShopInfo>& shop);
 		void sendMarketEnter();
@@ -202,10 +202,10 @@ class ProtocolGame final : public Protocol
 		void sendMarketCancelOffer(const MarketOfferEx& offer);
 		void sendMarketBrowseOwnHistory(const HistoryMarketOfferList& buyOffers, const HistoryMarketOfferList& sellOffers);
 		void sendMarketDetail(uint16_t itemId);
-		void sendTradeItemRequest(const std::string& traderName, const Item* item, bool ack);
+		void sendTradeItemRequest(const std::string& traderName, const ItemConstPtr& item, bool ack);
 		void sendCloseTrade();
 
-		void sendTextWindow(uint32_t windowTextId, Item* item, uint16_t maxlen, bool canWrite);
+		void sendTextWindow(uint32_t windowTextId, const ItemPtr& item, uint16_t maxlen, bool canWrite);
 		void sendTextWindow(uint32_t windowTextId, uint32_t itemId, const std::string& text);
 		void sendHouseWindow(uint32_t windowTextId, const std::string& text);
 		void sendOutfitWindow();
@@ -219,10 +219,10 @@ class ProtocolGame final : public Protocol
 
 		void sendFightModes();
 
-		void sendCreatureLight(const Creature* creature);
+		void sendCreatureLight(const CreatureConstPtr& creature);
 		void sendWorldLight(LightInfo lightInfo);
 
-		void sendCreatureSquare(const Creature* creature, SquareColor_t color);
+		void sendCreatureSquare(const CreatureConstPtr& creature, SquareColor_t color);
 
 		void sendSpellCooldown(uint8_t spellId, uint32_t time);
 		void sendSpellGroupCooldown(SpellGroup_t groupId, uint32_t time);
@@ -230,27 +230,27 @@ class ProtocolGame final : public Protocol
 		//tiles
 		void sendMapDescription(const Position& pos);
 
-		void sendAddTileItem(const Position& pos, uint32_t stackpos, const Item* item);
-		void sendUpdateTileItem(const Position& pos, uint32_t stackpos, const Item* item);
+		void sendAddTileItem(const Position& pos, uint32_t stackpos, const ItemConstPtr& item);
+		void sendUpdateTileItem(const Position& pos, uint32_t stackpos, const ItemConstPtr& item);
 		void sendRemoveTileThing(const Position& pos, uint32_t stackpos);
-		void sendUpdateTileCreature(const Position& pos, uint32_t stackpos, const Creature* creature);
-		void sendRemoveTileCreature(const Creature* creature, const Position& pos, uint32_t stackpos);
-		void sendUpdateTile(const Tile* tile, const Position& pos);
+		void sendUpdateTileCreature(const Position& pos, uint32_t stackpos, const CreatureConstPtr& creature);
+		void sendRemoveTileCreature(const CreatureConstPtr& creature, const Position& pos, uint32_t stackpos);
+		void sendUpdateTile(const TileConstPtr& tile, const Position& pos);
 
-		void sendAddCreature(const Creature* creature, const Position& pos, int32_t stackpos, MagicEffectClasses magicEffect = CONST_ME_NONE);
-		void sendMoveCreature(const Creature* creature, const Position& newPos, int32_t newStackPos,
+		void sendAddCreature(const CreatureConstPtr& creature, const Position& pos, int32_t stackpos, MagicEffectClasses magicEffect = CONST_ME_NONE);
+		void sendMoveCreature(const CreatureConstPtr& creature, const Position& newPos, int32_t newStackPos,
 		                      const Position& oldPos, int32_t oldStackPos, bool teleport);
 
 		//containers
-		void sendAddContainerItem(uint8_t cid, uint16_t slot, const Item* item);
-		void sendUpdateContainerItem(uint8_t cid, uint16_t slot, const Item* item);
-		void sendRemoveContainerItem(uint8_t cid, uint16_t slot, const Item* lastItem);
+		void sendAddContainerItem(uint8_t cid, uint16_t slot, const ItemConstPtr& item);
+		void sendUpdateContainerItem(uint8_t cid, uint16_t slot, const ItemConstPtr& item);
+		void sendRemoveContainerItem(uint8_t cid, uint16_t slot, const ItemConstPtr& lastItem);
 
-		void sendContainer(uint8_t cid, const Container* container, bool hasParent, uint16_t firstIndex);
+		void sendContainer(uint8_t cid, const ContainerConstPtr& container, bool hasParent, uint16_t firstIndex);
 		void sendCloseContainer(uint8_t cid);
 
 		//inventory
-		void sendInventoryItem(slots_t slot, const Item* item);
+		void sendInventoryItem(slots_t slot, const ItemConstPtr& item);
 		void sendItems();
 
 		//messages
@@ -259,7 +259,7 @@ class ProtocolGame final : public Protocol
 		//Help functions
 
 		// translate a tile to client-readable format
-		void GetTileDescription(const Tile* tile, NetworkMessage& msg);
+		void GetTileDescription(const TileConstPtr& tile, NetworkMessage& msg);
 
 		// translate a floor to client-readable format
 		void GetFloorDescription(NetworkMessage& msg, int32_t x, int32_t y, int32_t z,
@@ -269,19 +269,19 @@ class ProtocolGame final : public Protocol
 		void GetMapDescription(int32_t x, int32_t y, int32_t z,
 		                       int32_t width, int32_t height, NetworkMessage& msg);
 
-		void AddCreature(NetworkMessage& msg, const Creature* creature, bool known, uint32_t remove);
-		void AddPlayerStats(NetworkMessage& msg);
+		void AddCreature(NetworkMessage& msg, const CreatureConstPtr& creature, bool known, uint32_t remove);
+		void AddPlayerStats(NetworkMessage& msg) const;
 		void AddOutfit(NetworkMessage& msg, const Outfit_t& outfit);
-		void AddPlayerSkills(NetworkMessage& msg);
-		void AddWorldLight(NetworkMessage& msg, LightInfo lightInfo);
-		void AddCreatureLight(NetworkMessage& msg, const Creature* creature);
+		void AddPlayerSkills(NetworkMessage& msg) const;
+		void AddWorldLight(NetworkMessage& msg, LightInfo lightInfo) const;
+		void AddCreatureLight(NetworkMessage& msg, const CreatureConstPtr& creature) const;
 
 		//tiles
 		static void RemoveTileThing(NetworkMessage& msg, const Position& pos, uint32_t stackpos);
-		static void RemoveTileCreature(NetworkMessage& msg, const Creature* creature, const Position& pos, uint32_t stackpos);
+		static void RemoveTileCreature(NetworkMessage& msg, const CreatureConstPtr& creature, const Position& pos, uint32_t stackpos);
 
-		void MoveUpCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);
-		void MoveDownCreature(NetworkMessage& msg, const Creature* creature, const Position& newPos, const Position& oldPos);
+		void MoveUpCreature(NetworkMessage& msg, const CreatureConstPtr& creature, const Position& newPos, const Position& oldPos);
+		void MoveDownCreature(NetworkMessage& msg, const CreatureConstPtr& creature, const Position& newPos, const Position& oldPos);
 
 		//shop
 		void AddShopItem(NetworkMessage& msg, const ShopInfo& item);
@@ -303,7 +303,7 @@ class ProtocolGame final : public Protocol
 		}
 
 		std::unordered_set<uint32_t> knownCreatureSet;
-		Player* player = nullptr;
+		PlayerPtr player = nullptr;
 
 		uint32_t eventConnect = 0;
 		uint32_t challengeTimestamp = 0;

--- a/src/protocollogin.h
+++ b/src/protocollogin.h
@@ -19,7 +19,7 @@ class ProtocolLogin : public Protocol
 		static const char* protocol_name() {
 			return "login protocol";
 		}
-
+		// todo: use reference on connection
 		explicit ProtocolLogin(Connection_ptr connection) : Protocol(connection) {}
 
 		void onRecvFirstMessage(NetworkMessage& msg) override;

--- a/src/protocolold.h
+++ b/src/protocolold.h
@@ -18,7 +18,7 @@ class ProtocolOld final : public Protocol
 		static const char* protocol_name() {
 			return "old login protocol";
 		}
-
+		// todo: use reference on connection
 		explicit ProtocolOld(Connection_ptr connection) : Protocol(connection) {}
 
 		void onRecvFirstMessage(NetworkMessage& msg) override;

--- a/src/protocolstatus.h
+++ b/src/protocolstatus.h
@@ -18,6 +18,7 @@ class ProtocolStatus final : public Protocol
 			return "status protocol";
 		}
 
+		// todo: change connection to reference
 		explicit ProtocolStatus(Connection_ptr connection) : Protocol(connection) {}
 
 		void onRecvFirstMessage(NetworkMessage& msg) override;

--- a/src/quests.cpp
+++ b/src/quests.cpp
@@ -7,7 +7,7 @@
 
 #include "pugicast.h"
 
-std::string Mission::getDescription(Player* player) const
+std::string Mission::getDescription(const PlayerPtr& player) const
 {
 	int32_t value;
 	player->getStorageValue(storageID, value);
@@ -41,7 +41,7 @@ std::string Mission::getDescription(Player* player) const
 	return "An error has occurred, please contact a gamemaster.";
 }
 
-bool Mission::isStarted(Player* player) const
+bool Mission::isStarted(const PlayerPtr& player) const
 {
 	if (!player) {
 		return false;
@@ -63,7 +63,7 @@ bool Mission::isStarted(Player* player) const
 	return true;
 }
 
-bool Mission::isCompleted(Player* player) const
+bool Mission::isCompleted(const PlayerPtr& player) const
 {
 	if (!player) {
 		return false;
@@ -81,7 +81,7 @@ bool Mission::isCompleted(Player* player) const
 	return value == endValue;
 }
 
-std::string Mission::getName(Player* player) const
+std::string Mission::getName(const PlayerPtr& player) const
 {
 	if (isCompleted(player)) {
 		return name + " (completed)";
@@ -89,7 +89,7 @@ std::string Mission::getName(Player* player) const
 	return name;
 }
 
-uint16_t Quest::getMissionsCount(Player* player) const
+uint16_t Quest::getMissionsCount(const PlayerPtr& player) const
 {
 	uint16_t count = 0;
 	for (const Mission& mission : missions) {
@@ -100,7 +100,7 @@ uint16_t Quest::getMissionsCount(Player* player) const
 	return count;
 }
 
-bool Quest::isCompleted(Player* player) const
+bool Quest::isCompleted(const PlayerPtr& player) const
 {
 	for (const Mission& mission : missions) {
 		if (!mission.isCompleted(player)) {
@@ -110,7 +110,7 @@ bool Quest::isCompleted(Player* player) const
 	return true;
 }
 
-bool Quest::isStarted(Player* player) const
+bool Quest::isStarted(const PlayerPtr& player) const
 {
 	if (!player) {
 		return false;
@@ -184,7 +184,7 @@ Quest* Quests::getQuestByID(uint16_t id)
 	return nullptr;
 }
 
-uint16_t Quests::getQuestsCount(Player* player) const
+uint16_t Quests::getQuestsCount(const PlayerPtr& player) const
 {
 	uint16_t count = 0;
 	for (const Quest& quest : quests) {

--- a/src/quests.h
+++ b/src/quests.h
@@ -19,17 +19,19 @@ class Mission
 		Mission(std::string name, int32_t storageID, int32_t startValue, int32_t endValue, bool ignoreEndValue) :
 			name(std::move(name)), storageID(storageID), startValue(startValue), endValue(endValue), ignoreEndValue(ignoreEndValue) {}
 
-		bool isCompleted(Player* player) const;
-		bool isStarted(Player* player) const;
-		std::string getName(Player* player) const;
-		std::string getDescription(Player* player) const;
+		bool isCompleted(const PlayerPtr& player) const;
+		bool isStarted(const PlayerPtr& player) const;
+		std::string getName(const PlayerPtr& player) const;
+		std::string getDescription(const PlayerPtr& player) const;
 
 		uint32_t getStorageId() const {
 			return storageID;
 		}
+	
 		int32_t getStartStorageValue() const {
 			return startValue;
 		}
+	
 		int32_t getEndStorageValue() const {
 			return endValue;
 		}
@@ -50,19 +52,23 @@ class Quest
 		Quest(std::string name, uint16_t id, int32_t startStorageID, int32_t startStorageValue) :
 			name(std::move(name)), startStorageID(startStorageID), startStorageValue(startStorageValue), id(id) {}
 
-		bool isCompleted(Player* player) const;
-		bool isStarted(Player* player) const;
+		bool isCompleted(const PlayerPtr& player) const;
+		bool isStarted(const PlayerPtr& player) const;
+	
 		uint16_t getID() const {
 			return id;
 		}
+	
 		std::string getName() const {
 			return name;
 		}
-		uint16_t getMissionsCount(Player* player) const;
+	
+		uint16_t getMissionsCount(const PlayerPtr& player) const;
 
 		uint32_t getStartStorageId() const {
 			return startStorageID;
 		}
+	
 		int32_t getStartStorageValue() const {
 			return startStorageValue;
 		}
@@ -93,7 +99,7 @@ class Quests
 		bool loadFromXml();
 		Quest* getQuestByID(uint16_t id);
 		bool isQuestStorage(const uint32_t key, const int32_t value, const int32_t oldValue) const;
-		uint16_t getQuestsCount(Player* player) const;
+		uint16_t getQuestsCount(const PlayerPtr& player) const;
 		bool reload();
 
 	private:

--- a/src/raids.h
+++ b/src/raids.h
@@ -49,22 +49,26 @@ class Raids
 		bool isLoaded() const {
 			return loaded;
 		}
+	
 		bool isStarted() const {
 			return started;
 		}
 
-		Raid* getRunning() {
+		Raid* getRunning() const
+		{
 			return running;
 		}
+	
 		void setRunning(Raid* newRunning) {
 			running = newRunning;
 		}
 
-		Raid* getRaidByName(const std::string& name);
+		Raid* getRaidByName(const std::string& name) const;
 
 		uint64_t getLastRaidEnd() const {
 			return lastRaidEnd;
 		}
+	
 		void setLastRaidEnd(uint64_t newLastRaidEnd) {
 			lastRaidEnd = newLastRaidEnd;
 		}
@@ -104,10 +108,12 @@ class Raid
 		void executeRaidEvent(RaidEvent* raidEvent);
 		void resetRaid();
 
-		RaidEvent* getNextRaidEvent();
+		RaidEvent* getNextRaidEvent() const;
+	
 		void setState(RaidState_t newState) {
 			state = newState;
 		}
+	
 		const std::string& getName() const {
 			return name;
 		}
@@ -115,12 +121,15 @@ class Raid
 		bool isLoaded() const {
 			return loaded;
 		}
+	
 		uint64_t getMargin() const {
 			return margin;
 		}
+	
 		uint32_t getInterval() const {
 			return interval;
 		}
+	
 		bool canBeRepeated() const {
 			return repeat;
 		}

--- a/src/rewardchest.cpp
+++ b/src/rewardchest.cpp
@@ -8,7 +8,7 @@ RewardChest::RewardChest(uint16_t type, bool paginated /*= true*/) :
     Container{ type, items[type].maxItems, true, paginated } {
 }
 
-ReturnValue RewardChest::queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature* actor/* = nullptr*/) const
+ReturnValue RewardChest::queryAdd(int32_t, const ThingPtr&, uint32_t, uint32_t, CreaturePtr actor/* = std::nullopt*/)
 {
 	if (actor) {
 		return RETURNVALUE_NOTPOSSIBLE;
@@ -17,16 +17,16 @@ ReturnValue RewardChest::queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Cre
 	return RETURNVALUE_NOERROR;
 }
 
-void RewardChest::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)
+void RewardChest::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t)
 {
-	if (parent != nullptr) {
-		parent->postAddNotification(thing, oldParent, index, LINK_PARENT);
+	if (parent.lock()) {
+		parent.lock()->postAddNotification(thing, oldParent, index, LINK_PARENT);
 	}
 }
 
-void RewardChest::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t)
+void RewardChest::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t)
 {
-	if (parent != nullptr) {
-		parent->postRemoveNotification(thing, newParent, index, LINK_PARENT);
+	if (parent.lock()) {
+		parent.lock()->postRemoveNotification(thing, newParent, index, LINK_PARENT);
 	}
 }

--- a/src/rewardchest.h
+++ b/src/rewardchest.h
@@ -6,26 +6,25 @@
 
 #include "container.h"
 
-using RewardChest_ptr = std::shared_ptr<RewardChest>;
-
 class RewardChest final : public Container
 {
 public:
 	explicit RewardChest(uint16_t type, bool paginated = true);
 
-	RewardChest* getRewardChest() override {
-		return this;
+	RewardChestPtr getRewardChest() override {
+		return {shared_from_this(), this};
 	}
-	const RewardChest* getRewardChest() const override {
-		return this;
+	
+	RewardChestConstPtr getRewardChest() const override {
+		return dynamic_shared_this<RewardChest>();
 	}
 
 	//cylinder implementations
-	ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-		uint32_t flags, Creature* actor = nullptr) const override;
+	ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+	                     uint32_t flags, CreaturePtr actor = nullptr) override;
 
-	void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
-	void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+	void postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+	void postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 };
 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -17,6 +17,7 @@ class SchedulerTask : public Task
 		void setEventId(uint32_t id) {
 			eventId = id;
 		}
+	
 		uint32_t getEventId() const {
 			return eventId;
 		}
@@ -24,6 +25,7 @@ class SchedulerTask : public Task
 		uint32_t getDelay() const {
 			return delay;
 		}
+	
 	private:
 		SchedulerTask(uint32_t delay, TaskFunc&& f) : Task(std::move(f)), delay(delay) {}
 

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -20,7 +20,7 @@ Scripts::~Scripts()
 	scriptInterface.reInitState();
 }
 
-bool Scripts::loadScripts(std::string folderName, bool isLib, bool reload)
+bool Scripts::loadScripts(const std::string& folderName, bool isLib, bool reload)
 {
 	namespace fs = std::filesystem;
 

--- a/src/script.h
+++ b/src/script.h
@@ -13,7 +13,7 @@ class Scripts
 		Scripts();
 		~Scripts();
 
-		bool loadScripts(std::string folderName, bool isLib, bool reload);
+		bool loadScripts(const std::string& folderName, bool isLib, bool reload);
 		LuaScriptInterface& getScriptInterface() {
 			return scriptInterface;
 		}

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -86,7 +86,7 @@ void ServicePort::accept()
 	acceptor->async_accept(connection->getSocket(), [=, thisPtr = shared_from_this()](const boost::system::error_code& error) { thisPtr->onAccept(connection, error); });
 }
 
-void ServicePort::onAccept(Connection_ptr connection, const boost::system::error_code& error)
+void ServicePort::onAccept(const Connection_ptr& connection, const boost::system::error_code& error)
 {
 	if (!error) {
 		if (services.empty()) {
@@ -135,7 +135,7 @@ void ServicePort::onStopServer()
 	close();
 }
 
-void ServicePort::openAcceptor(std::weak_ptr<ServicePort> weak_service, uint16_t port)
+void ServicePort::openAcceptor(const std::weak_ptr<ServicePort>& weak_service, uint16_t port)
 {
 	if (auto service = weak_service.lock()) {
 		service->open(port);
@@ -169,7 +169,7 @@ void ServicePort::open(uint16_t port)
 	}
 }
 
-void ServicePort::close()
+void ServicePort::close() const
 {
 	if (acceptor && acceptor->is_open()) {
 		boost::system::error_code error;

--- a/src/server.h
+++ b/src/server.h
@@ -53,9 +53,9 @@ class ServicePort : public std::enable_shared_from_this<ServicePort>
 		ServicePort(const ServicePort&) = delete;
 		ServicePort& operator=(const ServicePort&) = delete;
 
-		static void openAcceptor(std::weak_ptr<ServicePort> weak_service, uint16_t port);
+		static void openAcceptor(const std::weak_ptr<ServicePort>& weak_service, uint16_t port);
 		void open(uint16_t port);
-		void close();
+		void close() const;
 		bool is_single_socket() const;
 		std::string get_protocol_names() const;
 
@@ -63,7 +63,7 @@ class ServicePort : public std::enable_shared_from_this<ServicePort>
 		Protocol_ptr make_protocol(bool checksummed, NetworkMessage& msg, const Connection_ptr& connection) const;
 
 		void onStopServer();
-		void onAccept(Connection_ptr connection, const boost::system::error_code& error);
+		void onAccept(const Connection_ptr& connection, const boost::system::error_code& error);
 
 	private:
 		void accept();

--- a/src/sharedobject.h
+++ b/src/sharedobject.h
@@ -1,0 +1,48 @@
+#ifndef BT_SHARED_OBJECT_H
+#define BT_SHARED_OBJECT_H
+
+#include <memory>
+
+class SharedObject : public std::enable_shared_from_this<SharedObject>
+{
+public:
+    virtual ~SharedObject() = default;
+
+    SharedObject& operator=(const SharedObject&) = delete;
+	
+	template <class T, class... Args>
+	static std::shared_ptr<T> Instantiate_Shared(Args... args) {
+    	//std::cout << "## Debug Info : " << typeid(T).name() << " created with Instantiate_Shared()." << "\n";
+    	return std::make_shared<T>(std::forward<Args>(args)...);
+    }
+
+	template <class T>
+	std::shared_ptr<T> static_shared_this() {
+    	//std::cout << "## Debug Info : " << typeid(T).name() << " created with static_shared_this()." << "\n";
+    	//std::cout << " # " << typeid(T).name() << " has " << (shared_from_this().use_count() - 1) << " instances." << "\n";
+		return std::static_pointer_cast<T>(shared_from_this());
+	}
+
+	template <class T>
+	std::shared_ptr<const T> static_shared_this() const {
+    	//std::cout << "## Debug Info : " << typeid(T).name() << " created with static_shared_this()." << "\n";
+    	//std::cout << " # " << typeid(T).name() << " has " << (shared_from_this().use_count() - 1) << " instances." << "\n";
+		return std::static_pointer_cast<const T>(shared_from_this());
+	}
+
+	template <class T>
+	std::shared_ptr<T> dynamic_shared_this() {
+    	//std::cout << "## Debug Info : " << typeid(T).name() << " created with dynamic_shared_this()." << "\n";
+    	//std::cout << " # " << typeid(T).name() << " has " << (shared_from_this().use_count() - 1) << " instances." << "\n";
+		return std::dynamic_pointer_cast<T>(shared_from_this());
+	}
+
+	template <class T>
+	std::shared_ptr<const T> dynamic_shared_this() const {
+    	//std::cout << "## Debug Info : " << typeid(T).name() << " created with dynamic_shared_this()." << "\n";
+    	//std::cout << " # " << typeid(T).name() << " has " << (shared_from_this().use_count() - 1) << " instances." << "\n";
+		return std::dynamic_pointer_cast<const T>(shared_from_this());
+	}
+};
+
+#endif

--- a/src/sharedobject.h
+++ b/src/sharedobject.h
@@ -2,6 +2,11 @@
 #define BT_SHARED_OBJECT_H
 
 #include <memory>
+#include "declarations.h"
+
+template <typename T>
+concept GameObject = std::is_base_of_v<Thing, T>&& std::is_class_v<T>;
+
 
 class SharedObject : public std::enable_shared_from_this<SharedObject>
 {
@@ -10,7 +15,7 @@ public:
 
     SharedObject& operator=(const SharedObject&) = delete;
 	
-	template <class T, class... Args>
+	template <GameObject T, class... Args>
 	static std::shared_ptr<T> Instantiate_Shared(Args... args) {
     	//std::cout << "## Debug Info : " << typeid(T).name() << " created with Instantiate_Shared()." << "\n";
     	return std::make_shared<T>(std::forward<Args>(args)...);

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -32,9 +32,9 @@ class Spawn
 		Spawn(const Spawn&) = delete;
 		Spawn& operator=(const Spawn&) = delete;
 
-		bool addBlock(spawnBlock_t sb);
+		bool addBlock(const spawnBlock_t& sb);
 		bool addMonster(const std::string& name, const Position& pos, Direction dir, uint32_t interval);
-		void removeMonster(Monster* monster);
+		void removeMonster(const MonsterPtr& monster);
 
 		uint32_t getInterval() const {
 			return interval;
@@ -47,7 +47,7 @@ class Spawn
 
 	private:
 		//map of the spawned creatures
-		using SpawnedMap = std::multimap<uint32_t, Monster*>;
+		using SpawnedMap = std::multimap<uint32_t, MonsterPtr>;
 		SpawnedMap spawnedMap;
 
 		//map of creatures in the spawn
@@ -60,7 +60,7 @@ class Spawn
 		uint32_t checkSpawnEvent = 0;
 
 		static bool findPlayer(const Position& pos);
-		bool spawnMonster(uint32_t spawnId, spawnBlock_t sb, bool startup = false);
+		bool spawnMonster(uint32_t spawnId, const spawnBlock_t& sb, bool startup = false);
 		bool spawnMonster(uint32_t spawnId, MonsterType* mType, const Position& pos, Direction dir, bool startup = false);
 		void checkSpawn();
 };
@@ -79,7 +79,7 @@ class Spawns
 		}
 
 	private:
-		std::forward_list<Npc*> npcList;
+		std::forward_list<NpcPtr> npcList;
 		std::forward_list<Spawn> spawnList;
 		std::string filename;
 		bool loaded = false;

--- a/src/spectators.h
+++ b/src/spectators.h
@@ -10,7 +10,7 @@ class Creature;
 
 class SpectatorVec
 {
-	using Vec = std::vector<Creature*>;
+	using Vec = std::vector<CreaturePtr>;
 	using Iterator = Vec::iterator;
 	using ConstIterator = Vec::const_iterator;
 public:
@@ -19,17 +19,16 @@ public:
 	}
 
 	void addSpectators(const SpectatorVec& spectators) {
-		for (Creature* spectator : spectators.vec) {
-			auto it = std::find(vec.begin(), vec.end(), spectator);
-			if (it != end()) {
+		for (CreaturePtr spectator : spectators.vec) {
+			if (auto it = std::ranges::find(vec, spectator); it != end()) {
 				continue;
 			}
 			vec.emplace_back(spectator);
 		}
 	}
 
-	void erase(Creature* spectator) {
-		auto it = std::find(vec.begin(), vec.end(), spectator);
+	void erase(const CreaturePtr& spectator) {
+		const auto it = std::ranges::find(vec, spectator);
 		if (it == end()) {
 			return;
 		}
@@ -37,7 +36,7 @@ public:
 		vec.pop_back();
 	}
 
-	Creature* operator[] (uint8_t index) {
+	CreaturePtr operator[] (const uint8_t index) {
 		return vec[index];
 	}
 
@@ -47,7 +46,7 @@ public:
 	ConstIterator begin() const { return vec.begin(); }
 	Iterator end() { return vec.end(); }
 	ConstIterator end() const { return vec.end(); }
-	void emplace_back(Creature* c) { vec.emplace_back(c); }
+	void emplace_back(CreaturePtr c) { vec.emplace_back(c); }
 
 private:
 	Vec vec;

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -29,7 +29,7 @@ Spells::~Spells()
 	clear(false);
 }
 
-TalkActionResult_t Spells::playerSaySpell(Player* player, std::string& words)
+TalkActionResult_t Spells::playerSaySpell(const PlayerPtr& player, std::string& words)
 {
 	std::string str_words = words;
 
@@ -255,12 +255,12 @@ InstantSpell* Spells::getInstantSpellByName(const std::string& name)
 	return nullptr;
 }
 
-Position Spells::getCasterPosition(Creature* creature, Direction dir)
+Position Spells::getCasterPosition(const CreaturePtr& creature, Direction dir)
 {
 	return getNextPosition(dir, creature->getPosition());
 }
 
-CombatSpell::CombatSpell(Combat_ptr combat, bool needTarget, bool needDirection) :
+CombatSpell::CombatSpell(const Combat_ptr& combat, bool needTarget, bool needDirection) :
 	Event(&g_spells->getScriptInterface()),
 	combat(combat),
 	needDirection(needDirection),
@@ -273,7 +273,7 @@ bool CombatSpell::loadScriptCombat()
 	return combat != nullptr;
 }
 
-bool CombatSpell::castSpell(Creature* creature)
+bool CombatSpell::castSpell(const CreaturePtr& creature)
 {
 	if (scripted) {
 		LuaVariant var;
@@ -298,7 +298,7 @@ bool CombatSpell::castSpell(Creature* creature)
 	return true;
 }
 
-bool CombatSpell::castSpell(Creature* creature, Creature* target)
+bool CombatSpell::castSpell(const CreaturePtr& creature, const CreaturePtr& target)
 {
 	if (scripted) {
 		LuaVariant var;
@@ -330,7 +330,7 @@ bool CombatSpell::castSpell(Creature* creature, Creature* target)
 	return true;
 }
 
-bool CombatSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
+bool CombatSpell::executeCastSpell(const CreaturePtr& creature, const LuaVariant& var)
 {
 	//onCastSpell(creature, var)
 	if (!scriptInterface->reserveScriptEnv()) {
@@ -345,7 +345,7 @@ bool CombatSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 
 	scriptInterface->pushFunction(scriptId);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
 	LuaScriptInterface::pushVariant(L, var);
@@ -546,7 +546,7 @@ bool Spell::configureSpell(const pugi::xml_node& node)
 	return true;
 }
 
-bool Spell::playerSpellCheck(Player* player) const
+bool Spell::playerSpellCheck(const PlayerPtr& player) const
 {
 	if (player->hasFlag(PlayerFlag_CannotUseSpells)) {
 		return false;
@@ -646,7 +646,7 @@ bool Spell::playerSpellCheck(Player* player) const
 	return true;
 }
 
-bool Spell::playerInstantSpellCheck(Player* player, const Position& toPos)
+bool Spell::playerInstantSpellCheck(const PlayerPtr& player, const Position& toPos)
 {
 	if (toPos.x == 0xFFFF) {
 		return true;
@@ -663,9 +663,9 @@ bool Spell::playerInstantSpellCheck(Player* player, const Position& toPos)
 		return false;
 	}
 
-	Tile* tile = g_game.map.getTile(toPos);
+	auto tile = g_game.map.getTile(toPos);
 	if (!tile) {
-		tile = new StaticTile(toPos.x, toPos.y, toPos.z);
+		tile = std::make_shared<StaticTile>(toPos.x, toPos.y, toPos.z);
 		g_game.map.setTile(toPos, tile);
 	}
 
@@ -688,7 +688,7 @@ bool Spell::playerInstantSpellCheck(Player* player, const Position& toPos)
 	return true;
 }
 
-bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
+bool Spell::playerRuneSpellCheck(const PlayerPtr& player, const Position& toPos)
 {
 	if (!playerSpellCheck(player)) {
 		return false;
@@ -709,7 +709,7 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 		return false;
 	}
 
-	Tile* tile = g_game.map.getTile(toPos);
+	auto tile = g_game.map.getTile(toPos);
 	if (!tile) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -729,7 +729,7 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 		return false;
 	}
 
-	const Creature* topVisibleCreature = tile->getBottomVisibleCreature(player);
+	const auto& topVisibleCreature = tile->getBottomVisibleCreature(player);
 	if (blockingCreature && topVisibleCreature) {
 		player->sendCancelMessage(RETURNVALUE_NOTENOUGHROOM);
 		g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -747,7 +747,7 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 	}
 
 	if (aggressive && needTarget && topVisibleCreature && player->hasSecureMode()) {
-		const Player* targetPlayer = topVisibleCreature->getPlayer();
+		const auto& targetPlayer = topVisibleCreature->getPlayer();
 		if (targetPlayer && targetPlayer != player && player->getSkullClient(targetPlayer) == SKULL_NONE && !Combat::isInPvpZone(player, targetPlayer)) {
 			player->sendCancelMessage(RETURNVALUE_TURNSECUREMODETOATTACKUNMARKEDPLAYERS);
 			g_game.addMagicEffect(player->getPosition(), CONST_ME_POFF);
@@ -762,7 +762,7 @@ bool Spell::playerRuneSpellCheck(Player* player, const Position& toPos)
 	return true;
 }
 
-void Spell::addCooldowns(Player* player) const
+void Spell::addCooldowns(const PlayerPtr& player) const
 {
 	if (cooldown > 0) {
 		Condition* condition = Condition::createCondition(CONDITIONID_DEFAULT, CONDITION_SPELLCOOLDOWN, cooldown, 0, false, spellId);
@@ -780,7 +780,7 @@ void Spell::addCooldowns(Player* player) const
 	}
 }
 
-void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool payCost /*= true*/) const
+void Spell::postCastSpell(const PlayerPtr& player, bool finishedCast /*= true*/, bool payCost /*= true*/) const
 {
 	if (finishedCast) {
 		if (!player->hasFlag(PlayerFlag_HasNoExhaustion)) {
@@ -797,7 +797,7 @@ void Spell::postCastSpell(Player* player, bool finishedCast /*= true*/, bool pay
 	}
 }
 
-void Spell::postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost)
+void Spell::postCastSpell(const PlayerPtr& player, uint32_t manaCost, uint32_t soulCost)
 {
 	if (manaCost > 0) {
 		player->addManaSpent(manaCost);
@@ -811,7 +811,7 @@ void Spell::postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost)
 	}
 }
 
-uint32_t Spell::getManaCost(const Player* player) const
+uint32_t Spell::getManaCost(const PlayerConstPtr& player) const
 {
 	if (mana != 0) {
 		return mana;
@@ -859,7 +859,7 @@ bool InstantSpell::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-bool InstantSpell::playerCastInstant(Player* player, std::string& param)
+bool InstantSpell::playerCastInstant(const PlayerPtr& player, std::string& param)
 {
 	if (!playerSpellCheck(player)) {
 		return false;
@@ -870,12 +870,12 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 	if (selfTarget) {
 		var.setNumber(player->getID());
 	} else if (needTarget || casterTargetOrDirection) {
-		Creature* target = nullptr;
+		CreaturePtr target = nullptr;
 		bool useDirection = false;
 
 		if (hasParam) {
-			Player* playerTarget = nullptr;
-			ReturnValue ret = g_game.getPlayerByNameWildcard(param, playerTarget);
+			PlayerPtr playerTarget = nullptr;
+			ReturnValue ret = g_game.getPlayerByNameWildcard(param);
 
 			if (playerTarget && playerTarget->isAccessPlayer() && !player->isAccessPlayer()) {
 				playerTarget = nullptr;
@@ -927,8 +927,8 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 		}
 	} else if (hasParam) {
 		if (getHasPlayerNameParam()) {
-			Player* playerTarget = nullptr;
-			ReturnValue ret = g_game.getPlayerByNameWildcard(param, playerTarget);
+			PlayerPtr playerTarget = nullptr;
+			ReturnValue ret = g_game.getPlayerByNameWildcard(param);
 
 			if (ret != RETURNVALUE_NOERROR) {
 				addCooldowns(player);
@@ -964,7 +964,7 @@ bool InstantSpell::playerCastInstant(Player* player, std::string& param)
 	return result;
 }
 
-bool InstantSpell::canThrowSpell(const Creature* creature, const Creature* target) const
+bool InstantSpell::canThrowSpell(const CreatureConstPtr& creature, const CreatureConstPtr& target) const
 {
 	const Position& fromPos = creature->getPosition();
 	const Position& toPos = target->getPosition();
@@ -976,12 +976,12 @@ bool InstantSpell::canThrowSpell(const Creature* creature, const Creature* targe
 	return true;
 }
 
-bool InstantSpell::castSpell(Creature* creature)
+bool InstantSpell::castSpell(const CreaturePtr& creature)
 {
 	LuaVariant var;
 
 	if (casterTargetOrDirection) {
-		Creature* target = creature->getAttackedCreature();
+		const auto& target = creature->getAttackedCreature();
 		if (target && target->getHealth() > 0) {
 			if (!canThrowSpell(creature, target)) {
 				return false;
@@ -1001,7 +1001,7 @@ bool InstantSpell::castSpell(Creature* creature)
 	return internalCastSpell(creature, var);
 }
 
-bool InstantSpell::castSpell(Creature* creature, Creature* target)
+bool InstantSpell::castSpell(const CreaturePtr& creature, const CreaturePtr& target)
 {
 	if (needTarget) {
 		LuaVariant var;
@@ -1012,12 +1012,12 @@ bool InstantSpell::castSpell(Creature* creature, Creature* target)
 	}
 }
 
-bool InstantSpell::internalCastSpell(Creature* creature, const LuaVariant& var)
+bool InstantSpell::internalCastSpell(const CreaturePtr& creature, const LuaVariant& var)
 {
 	return executeCastSpell(creature, var);
 }
 
-bool InstantSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
+bool InstantSpell::executeCastSpell(const CreaturePtr& creature, const LuaVariant& var)
 {
 	//onCastSpell(creature, var)
 	if (!scriptInterface->reserveScriptEnv()) {
@@ -1032,7 +1032,7 @@ bool InstantSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 
 	scriptInterface->pushFunction(scriptId);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
 	LuaScriptInterface::pushVariant(L, var);
@@ -1040,7 +1040,7 @@ bool InstantSpell::executeCastSpell(Creature* creature, const LuaVariant& var)
 	return scriptInterface->callFunction(2);
 }
 
-bool InstantSpell::canCast(const Player* player) const
+bool InstantSpell::canCast(const PlayerConstPtr& player) const
 {
 	if (player->hasFlag(PlayerFlag_CannotUseSpells)) {
 		return false;
@@ -1055,7 +1055,7 @@ bool InstantSpell::canCast(const Player* player) const
 			return true;
 		}
 	} else {
-		if (vocSpellMap.empty() || vocSpellMap.find(player->getVocationId()) != vocSpellMap.end()) {
+		if (vocSpellMap.empty() || vocSpellMap.contains(player->getVocationId())) {
 			return true;
 		}
 	}
@@ -1100,7 +1100,7 @@ bool RuneSpell::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-ReturnValue RuneSpell::canExecuteAction(const Player* player, const Position& toPos)
+ReturnValue RuneSpell::canExecuteAction(const PlayerConstPtr& player, const Position& toPos)
 {
 	if (player->hasFlag(PlayerFlag_CannotUseSpells)) {
 		return RETURNVALUE_CANNOTUSETHISOBJECT;
@@ -1122,7 +1122,7 @@ ReturnValue RuneSpell::canExecuteAction(const Player* player, const Position& to
 	return RETURNVALUE_NOERROR;
 }
 
-bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* target, const Position& toPosition, bool isHotkey)
+bool RuneSpell::executeUse(const PlayerPtr& player, const ItemPtr& item, const Position&, const ThingPtr& target, const Position& toPosition, bool isHotkey)
 {
 	if (!playerRuneSpellCheck(player, toPosition)) {
 		return false;
@@ -1137,10 +1137,8 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 	if (needTarget) {
 
 		if (target == nullptr) {
-			Tile* toTile = g_game.map.getTile(toPosition);
-			if (toTile) {
-				const Creature* visibleCreature = toTile->getBottomVisibleCreature(player);
-				if (visibleCreature) {
+			if (const auto& toTile = g_game.map.getTile(toPosition)) {
+				if (const auto& visibleCreature = toTile->getBottomVisibleCreature(player)) {
 					var.setNumber(visibleCreature->getID());
 				}
 			}
@@ -1158,9 +1156,9 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 	postCastSpell(player);
 
 	if (var.isNumber()) {
-		target = g_game.getCreatureByID(var.getNumber());
-		if (getPzLock() && target) {
-			player->onAttackedCreature(target->getCreature());
+		auto n_target = g_game.getCreatureByID(var.getNumber());
+		if (getPzLock() && n_target) {
+			player->onAttackedCreature(n_target->getCreature());
 		}
 	}
 
@@ -1171,21 +1169,21 @@ bool RuneSpell::executeUse(Player* player, Item* item, const Position&, Thing* t
 	return true;
 }
 
-bool RuneSpell::castSpell(Creature* creature)
+bool RuneSpell::castSpell(const CreaturePtr& creature)
 {
 	LuaVariant var;
 	var.setNumber(creature->getID());
 	return internalCastSpell(creature, var, false);
 }
 
-bool RuneSpell::castSpell(Creature* creature, Creature* target)
+bool RuneSpell::castSpell(const CreaturePtr& creature, const CreaturePtr& target)
 {
 	LuaVariant var;
 	var.setNumber(target->getID());
 	return internalCastSpell(creature, var, false);
 }
 
-bool RuneSpell::internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey)
+bool RuneSpell::internalCastSpell(const CreaturePtr& creature, const LuaVariant& var, bool isHotkey)
 {
 	bool result;
 	if (scripted) {
@@ -1196,7 +1194,7 @@ bool RuneSpell::internalCastSpell(Creature* creature, const LuaVariant& var, boo
 	return result;
 }
 
-bool RuneSpell::executeCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey)
+bool RuneSpell::executeCastSpell(const CreaturePtr& creature, const LuaVariant& var, bool isHotkey)
 {
 	//onCastSpell(creature, var, isHotkey)
 	if (!scriptInterface->reserveScriptEnv()) {
@@ -1211,7 +1209,7 @@ bool RuneSpell::executeCastSpell(Creature* creature, const LuaVariant& var, bool
 
 	scriptInterface->pushFunction(scriptId);
 
-	LuaScriptInterface::pushUserdata<Creature>(L, creature);
+	LuaScriptInterface::pushSharedPtr(L, creature);
 	LuaScriptInterface::setCreatureMetatable(L, -1, creature);
 
 	LuaScriptInterface::pushVariant(L, var);

--- a/src/spells.h
+++ b/src/spells.h
@@ -34,9 +34,9 @@ class Spells final : public BaseEvents
 		InstantSpell* getInstantSpell(const std::string& words);
 		InstantSpell* getInstantSpellByName(const std::string& name);
 
-		TalkActionResult_t playerSaySpell(Player* player, std::string& words);
+		TalkActionResult_t playerSaySpell(const PlayerPtr& player, std::string& words);
 
-		static Position getCasterPosition(Creature* creature, Direction dir);
+		static Position getCasterPosition(const CreaturePtr& creature, Direction dir);
 		std::string_view getScriptBaseName() const override { return "spells"; }
 
 		const std::map<std::string, InstantSpell>& getInstantSpells() const {
@@ -66,27 +66,27 @@ class BaseSpell
 		constexpr BaseSpell() = default;
 		virtual ~BaseSpell() = default;
 
-		virtual bool castSpell(Creature* creature) = 0;
-		virtual bool castSpell(Creature* creature, Creature* target) = 0;
+		virtual bool castSpell(const CreaturePtr& creature) = 0;
+		virtual bool castSpell(const CreaturePtr& creature, const CreaturePtr& target) = 0;
 };
 
 class CombatSpell final : public Event, public BaseSpell
 {
 	public:
-		CombatSpell(Combat_ptr combat, bool needTarget, bool needDirection);
+		CombatSpell(const Combat_ptr& combat, bool needTarget, bool needDirection);
 
 		// non-copyable
 		CombatSpell(const CombatSpell&) = delete;
 		CombatSpell& operator=(const CombatSpell&) = delete;
 
-		bool castSpell(Creature* creature) override;
-		bool castSpell(Creature* creature, Creature* target) override;
+		bool castSpell(const CreaturePtr& creature) override;
+		bool castSpell(const CreaturePtr& creature, const CreaturePtr& target) override;
 		bool configureEvent(const pugi::xml_node&) override {
 			return true;
 		}
 
 		//scripting
-		bool executeCastSpell(Creature* creature, const LuaVariant& var);
+		bool executeCastSpell(const CreaturePtr& creature, const LuaVariant& var);
 
 		bool loadScriptCombat();
 		Combat_ptr getCombat() {
@@ -111,67 +111,85 @@ class Spell : public BaseSpell
 		const std::string& getName() const {
 			return name;
 		}
-		void setName(std::string n) {
+	
+		void setName(const std::string& n) {
 			name = n;
 		}
+	
 		uint8_t getId() const {
 			return spellId;
 		}
+	
 		void setId(uint8_t id) {
 			spellId = id;
 		}
 
-		void postCastSpell(Player* player, bool finishedCast = true, bool payCost = true) const;
-		static void postCastSpell(Player* player, uint32_t manaCost, uint32_t soulCost);
+		void postCastSpell(const PlayerPtr& player, bool finishedCast = true, bool payCost = true) const;
+		static void postCastSpell(const PlayerPtr& player, uint32_t manaCost, uint32_t soulCost);
 
-		uint32_t getManaCost(const Player* player) const;
+		uint32_t getManaCost(const PlayerConstPtr& player) const;
 		uint32_t getSoulCost() const {
 			return soul;
 		}
+	
 		void setSoulCost(uint32_t s) {
 			soul = s;
 		}
+	
 		uint32_t getLevel() const {
 			return level;
 		}
+	
 		void setLevel(uint32_t lvl) {
 			level = lvl;
 		}
+	
 		uint32_t getMagicLevel() const {
 			return magLevel;
 		}
+	
 		void setMagicLevel(uint32_t lvl) {
 			magLevel = lvl;
 		}
+	
 		uint32_t getMana() const {
 			return mana;
 		}
+	
 		void setMana(uint32_t m) {
 			mana = m;
 		}
+	
 		uint32_t getManaPercent() const {
 			return manaPercent;
 		}
+	
 		void setManaPercent(uint32_t m) {
 			manaPercent = m;
 		}
+	
 		bool isPremium() const {
 			return premium;
 		}
+	
 		void setPremium(bool p) {
 			premium = p;
 		}
+	
 		bool isEnabled() const {
 			return enabled;
 		}
+	
 		void setEnabled(bool e) {
 			enabled = e;
 		}
 
 		virtual bool isInstant() const = 0;
+	
 		bool isLearnable() const {
 			return learnable;
 		}
+	
 		void setLearnable(bool l) {
 			learnable = l;
 		}
@@ -179,6 +197,7 @@ class Spell : public BaseSpell
 		const VocSpellMap& getVocMap() const {
 			return vocSpellMap;
 		}
+	
 		void addVocMap(uint16_t n, bool b) {
 			vocSpellMap[n] = b;
 		}
@@ -186,15 +205,18 @@ class Spell : public BaseSpell
 		SpellGroup_t getGroup() const {
 			return group;
 		}
+	
 		void setGroup(SpellGroup_t g) {
 			group = g;
 			if(group == SPELLGROUP_NONE) {
 				groupCooldown = 0;
 			}
 		}
+	
 		SpellGroup_t getSecondaryGroup() const {
 			return secondaryGroup;
 		}
+	
 		void setSecondaryGroup(SpellGroup_t g) {
 			secondaryGroup = g;
 		}
@@ -202,18 +224,23 @@ class Spell : public BaseSpell
 		uint32_t getCooldown() const {
 			return cooldown;
 		}
+	
 		void setCooldown(uint32_t cd) {
 			cooldown = cd;
 		}
+	
 		uint32_t getSecondaryCooldown() const {
 			return secondaryGroupCooldown;
 		}
+	
 		void setSecondaryCooldown(uint32_t cd) {
 			secondaryGroupCooldown = cd;
 		}
+	
 		uint32_t getGroupCooldown() const {
 			return groupCooldown;
 		}
+	
 		void setGroupCooldown(uint32_t cd) {
 			groupCooldown = cd;
 		}
@@ -221,6 +248,7 @@ class Spell : public BaseSpell
 		int32_t getRange() const {
 			return range;
 		}
+	
 		void setRange(int32_t r) {
 			range = r;
 		}
@@ -228,48 +256,62 @@ class Spell : public BaseSpell
 		bool getNeedTarget() const {
 			return needTarget;
 		}
+	
 		void setNeedTarget(bool n) {
 			needTarget = n;
 		}
+	
 		bool getNeedWeapon() const {
 			return needWeapon;
 		}
+	
 		void setNeedWeapon(bool n) {
 			needWeapon = n;
 		}
+	
 		bool getNeedLearn() const {
 			return learnable;
 		}
+	
 		void setNeedLearn(bool n) {
 			learnable = n;
 		}
+	
 		bool getSelfTarget() const {
 			return selfTarget;
 		}
+	
 		void setSelfTarget(bool s) {
 			selfTarget = s;
 		}
+	
 		bool getBlockingSolid() const {
 			return blockingSolid;
 		}
+	
 		void setBlockingSolid(bool b) {
 			blockingSolid = b;
 		}
+	
 		bool getBlockingCreature() const {
 			return blockingCreature;
 		}
+	
 		void setBlockingCreature(bool b) {
 			blockingCreature = b;
 		}
 		bool getAggressive() const {
 			return aggressive;
 		}
+	
 		void setAggressive(bool a) {
 			aggressive = a;
 		}
+	
 		bool getPzLock() const {
 			return pzLock;
 		}
+	
 		void setPzLock(bool pzLock) {
 			this->pzLock = pzLock;
 		}
@@ -277,10 +319,10 @@ class Spell : public BaseSpell
 		SpellType_t spellType = SPELL_UNDEFINED;
 
 	protected:
-		bool playerSpellCheck(Player* player) const;
-		bool playerInstantSpellCheck(Player* player, const Position& toPos);
-		bool playerRuneSpellCheck(Player* player, const Position& toPos);
-		void addCooldowns(Player* player) const;
+		bool playerSpellCheck(const PlayerPtr& player) const;
+		bool playerInstantSpellCheck(const PlayerPtr& player, const Position& toPos);
+		bool playerRuneSpellCheck(const PlayerPtr& player, const Position& toPos);
+		void addCooldowns(const PlayerPtr& player) const;
 
 		VocSpellMap vocSpellMap;
 
@@ -323,54 +365,65 @@ class InstantSpell final : public TalkAction, public Spell
 
 		bool configureEvent(const pugi::xml_node& node) override;
 
-		virtual bool playerCastInstant(Player* player, std::string& param);
+		bool playerCastInstant(const PlayerPtr& player, std::string& param);
 
-		bool castSpell(Creature* creature) override;
-		bool castSpell(Creature* creature, Creature* target) override;
+		bool castSpell(const CreaturePtr& creature) override;
+		bool castSpell(const CreaturePtr& creature, const CreaturePtr& target) override;
 
 		//scripting
-		bool executeCastSpell(Creature* creature, const LuaVariant& var);
+		bool executeCastSpell(const CreaturePtr& creature, const LuaVariant& var);
 
 		bool isInstant() const override {
 			return true;
 		}
+	
 		bool getHasParam() const {
 			return hasParam;
 		}
+	
 		void setHasParam(bool p) {
 			hasParam = p;
 		}
+	
 		bool getHasPlayerNameParam() const {
 			return hasPlayerNameParam;
 		}
+	
 		void setHasPlayerNameParam(bool p) {
 			hasPlayerNameParam = p;
 		}
+	
 		bool getNeedDirection() const {
 			return needDirection;
 		}
+	
 		void setNeedDirection(bool n) {
 			needDirection = n;
 		}
+	
 		bool getNeedCasterTargetOrDirection() const {
 			return casterTargetOrDirection;
 		}
+	
 		void setNeedCasterTargetOrDirection(bool d) {
 			casterTargetOrDirection = d;
 		}
+	
 		bool getBlockWalls() const {
 			return checkLineOfSight;
 		}
+	
 		void setBlockWalls(bool w) {
 			checkLineOfSight = w;
 		}
-		bool canCast(const Player* player) const;
-		bool canThrowSpell(const Creature* creature, const Creature* target) const;
+	
+		bool canCast(const PlayerConstPtr& player) const;
+		bool canThrowSpell(const CreatureConstPtr& creature, const CreatureConstPtr& target) const;
 
 	private:
 		std::string_view getScriptEventName() const override { return "onCastSpell"; }
 
-		bool internalCastSpell(Creature* creature, const LuaVariant& var);
+		bool internalCastSpell(const CreaturePtr& creature, const LuaVariant& var);
 
 		bool needDirection = false;
 		bool hasParam = false;
@@ -386,34 +439,40 @@ class RuneSpell final : public Action, public Spell
 
 		bool configureEvent(const pugi::xml_node& node) override;
 
-		ReturnValue canExecuteAction(const Player* player, const Position& toPos) override;
+		ReturnValue canExecuteAction(const PlayerConstPtr& player, const Position& toPos) override;
+	
 		bool hasOwnErrorHandler() override {
 			return true;
 		}
-		Thing* getTarget(Player*, Creature* targetCreature, const Position&, uint8_t) const override {
-			return targetCreature;
+	
+		ThingPtr getTarget(const PlayerPtr&, const CreaturePtr& targetCreature, const Position&, uint8_t) const override {
+			return targetCreature; // implicit upcasts are handled automatically
 		}
 
-		bool executeUse(Player* player, Item* item, const Position& fromPosition, Thing* target, const Position& toPosition, bool isHotkey) override;
+		bool executeUse(const PlayerPtr& player, const ItemPtr& item, const Position& fromPosition, const ThingPtr& target, const Position& toPosition, bool isHotkey) override;
 
-		bool castSpell(Creature* creature) override;
-		bool castSpell(Creature* creature, Creature* target) override;
+		bool castSpell(const CreaturePtr& creature) override;
+		bool castSpell(const CreaturePtr& creature, const CreaturePtr& target) override;
 
 		//scripting
-		bool executeCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
+		bool executeCastSpell(const CreaturePtr& creature, const LuaVariant& var, bool isHotkey);
 
 		bool isInstant() const override {
 			return false;
 		}
+	
 		uint16_t getRuneItemId() const {
 			return runeId;
 		}
+	
 		void setRuneItemId(uint16_t i) {
 			runeId = i;
 		}
+	
 		uint32_t getCharges() const {
 			return charges;
 		}
+	
 		void setCharges(uint32_t c) {
 			if (c > 0) {
 				hasCharges = true;
@@ -424,7 +483,7 @@ class RuneSpell final : public Action, public Spell
 	private:
 		std::string_view getScriptEventName() const override { return "onCastSpell"; }
 
-		bool internalCastSpell(Creature* creature, const LuaVariant& var, bool isHotkey);
+		bool internalCastSpell(const CreaturePtr& creature, const LuaVariant& var, bool isHotkey);
 
 		uint16_t runeId = 0;
 		uint32_t charges = 0;

--- a/src/storeinbox.cpp
+++ b/src/storeinbox.cpp
@@ -7,14 +7,14 @@
 
 StoreInbox::StoreInbox(uint16_t type) : Container(type, 20, true, true) {}
 
-ReturnValue StoreInbox::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags, Creature*) const
+ReturnValue StoreInbox::queryAdd(int32_t, const ThingPtr& thing, uint32_t, uint32_t flags, CreaturePtr)
 {
-	const Item* item = thing.getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	if (item == this) {
+	if (item == this->getItem()) {
 		return RETURNVALUE_THISISIMPOSSIBLE;
 	}
 
@@ -27,8 +27,7 @@ ReturnValue StoreInbox::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t
 			return RETURNVALUE_CANNOTMOVEITEMISNOTSTOREITEM;
 		}
 
-		const Container* container = item->getContainer();
-		if (container && !container->empty()) {
+		if (const auto& container = item->getContainer(); container && !container->empty()) {
 			return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
 		}
 	}
@@ -36,17 +35,17 @@ ReturnValue StoreInbox::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t
 	return RETURNVALUE_NOERROR;
 }
 
-void StoreInbox::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)
+void StoreInbox::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t)
 {
-	if (parent != nullptr) {
-		parent->postAddNotification(thing, oldParent, index, LINK_TOPPARENT);
+	if (parent.lock()) {
+		parent.lock()->postAddNotification(thing, oldParent, index, LINK_TOPPARENT);
 	}
 }
 
-void StoreInbox::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t)
+void StoreInbox::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t)
 {
-	if (parent != nullptr) {
-		parent->postRemoveNotification(thing, newParent, index, LINK_TOPPARENT);
+	if (parent.lock()) {
+		parent.lock()->postRemoveNotification(thing, newParent, index, LINK_TOPPARENT);
 	}
 }
 

--- a/src/storeinbox.h
+++ b/src/storeinbox.h
@@ -11,19 +11,20 @@ class StoreInbox final : public Container
 	public:
 		explicit StoreInbox(uint16_t type);
 
-		StoreInbox* getStoreInbox() override {
-			return this;
+		StoreInboxPtr getStoreInbox() override {
+			return dynamic_shared_this<StoreInbox>();
 		}
-		const StoreInbox* getStoreInbox() const override {
-			return this;
+	
+		StoreInboxConstPtr getStoreInbox() const override {
+			return dynamic_shared_this<StoreInbox>();
 		}
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-			uint32_t flags, Creature* actor = nullptr) const override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                     uint32_t flags, CreaturePtr actor = nullptr) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 		bool canRemove() const override {
 			return false;

--- a/src/talkaction.cpp
+++ b/src/talkaction.cpp
@@ -76,7 +76,7 @@ bool TalkActions::registerLuaEvent(TalkAction* event)
 	return true;
 }
 
-TalkActionResult_t TalkActions::playerSaySpell(Player* player, SpeakClasses type, const std::string& words) const
+TalkActionResult_t TalkActions::playerSaySpell(const PlayerPtr& player, SpeakClasses type, const std::string& words) const
 {
 	size_t wordsLength = words.length();
 	for (auto it = talkActions.begin(); it != talkActions.end(); ) {
@@ -146,7 +146,7 @@ bool TalkAction::configureEvent(const pugi::xml_node& node)
 	return true;
 }
 
-bool TalkAction::executeSay(Player* player, const std::string& words, const std::string& param, SpeakClasses type) const
+bool TalkAction::executeSay(const PlayerPtr& player, const std::string& words, const std::string& param, SpeakClasses type) const
 {
 	//onSay(player, words, param, type)
 	if (!scriptInterface->reserveScriptEnv()) {
@@ -161,7 +161,7 @@ bool TalkAction::executeSay(Player* player, const std::string& words, const std:
 
 	scriptInterface->pushFunction(scriptId);
 
-	LuaScriptInterface::pushUserdata<Player>(L, player);
+	LuaScriptInterface::pushSharedPtr(L, player);
 	LuaScriptInterface::setMetatable(L, -1, "Player");
 
 	LuaScriptInterface::pushString(L, words);

--- a/src/talkaction.h
+++ b/src/talkaction.h
@@ -37,12 +37,12 @@ class TalkAction : public Event
 		std::string getSeparator() const {
 			return separator;
 		}
-		void setSeparator(std::string sep) {
+		void setSeparator(const std::string& sep) {
 			separator = sep;
 		}
 
 		//scripting
-		bool executeSay(Player* player, const std::string& words, const std::string& param, SpeakClasses type) const;
+		bool executeSay(const PlayerPtr& player, const std::string& words, const std::string& param, SpeakClasses type) const;
 
 		AccountType_t getRequiredAccountType() const {
 			return requiredAccountType;
@@ -74,13 +74,13 @@ class TalkActions final : public BaseEvents
 {
 	public:
 		TalkActions();
-		~TalkActions();
+		~TalkActions() override;
 
 		// non-copyable
 		TalkActions(const TalkActions&) = delete;
 		TalkActions& operator=(const TalkActions&) = delete;
 
-		TalkActionResult_t playerSaySpell(Player* player, SpeakClasses type, const std::string& words) const;
+		TalkActionResult_t playerSaySpell(const PlayerPtr& player, SpeakClasses type, const std::string& words) const;
 
 		bool registerLuaEvent(TalkAction* event);
 		void clear(bool fromLua) override final;

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -21,7 +21,8 @@ class Task
 			expiration(std::chrono::system_clock::now() + std::chrono::milliseconds(ms)), func(std::move(f)) {}
 
 		virtual ~Task() = default;
-		void operator()() {
+		void operator()() const
+		{
 			func();
 		}
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -44,7 +44,7 @@ ReturnValue Teleport::queryRemove(const ThingPtr&, uint32_t, uint32_t, CreatureP
 	return RETURNVALUE_NOERROR;
 }
 
-CylinderPtr Teleport::queryDestination(int32_t&, const ThingPtr&, ItemPtr*, uint32_t&)
+CylinderPtr Teleport::queryDestination(int32_t&, const ThingPtr&, ItemPtr&, uint32_t&)
 {
 	return this->getTile();
 }
@@ -103,7 +103,7 @@ void Teleport::addThing(int32_t, ThingPtr thing)
 		}
 		CylinderPtr f_cylinder = getTile();
 		CylinderPtr t_cylinder = destTile;
-		g_game.internalMoveItem(f_cylinder, t_cylinder, INDEX_WHEREEVER, item, item->getItemCount(), nullptr, FLAG_NOLIMIT);
+		g_game.internalMoveItem(f_cylinder, t_cylinder, INDEX_WHEREEVER, item, item->getItemCount(), std::nullopt, FLAG_NOLIMIT);
 	}
 }
 

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -11,11 +11,12 @@ class Teleport final : public Item, public Cylinder
 	public:
 		explicit Teleport(uint16_t type) : Item(type) {};
 
-		Teleport* getTeleport() override {
-			return this;
+		TeleportPtr getTeleport() override {
+			return {shared_from_this(), this};
 		}
-		const Teleport* getTeleport() const override {
-			return this;
+	
+		TeleportConstPtr getTeleport() const override {
+			return {shared_from_this(), this};
 		}
 
 		//serialization
@@ -25,29 +26,30 @@ class Teleport final : public Item, public Cylinder
 		const Position& getDestPos() const {
 			return destPos;
 		}
+	
 		void setDestPos(const Position& pos) {
 			destPos = pos;
 		}
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const override;
-		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t& maxQueryCount, uint32_t flags) const override;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
-		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem,
-				uint32_t& flags) override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                     uint32_t flags, CreaturePtr actor = nullptr) override;
+		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count,
+				uint32_t& maxQueryCount, uint32_t flags) override;
+		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+				uint32_t& flags) override; // again optional ref wrapper
 
-		void addThing(Thing* thing) override;
-		void addThing(int32_t index, Thing* thing) override;
+		void addThing(ThingPtr thing) override;
+		void addThing(int32_t index, ThingPtr thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
-		void replaceThing(uint32_t index, Thing* thing) override;
+		void updateThing(ThingPtr thing, uint16_t itemId, uint32_t count) override;
+		void replaceThing(uint32_t index, ThingPtr thing) override;
 
-		void removeThing(Thing* thing, uint32_t count) override;
+		void removeThing(ThingPtr thing, uint32_t count) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postAddNotification(ThingPtr thing,  CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(ThingPtr thing,  CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
 	private:
 		Position destPos;

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -37,7 +37,7 @@ class Teleport final : public Item, public Cylinder
 		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count,
 				uint32_t& maxQueryCount, uint32_t flags) override;
 		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
-		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem,
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem,
 				uint32_t& flags) override; // again optional ref wrapper
 
 		void addThing(ThingPtr thing) override;

--- a/src/thing.cpp
+++ b/src/thing.cpp
@@ -10,15 +10,16 @@ const Position& Thing::getPosition() const
 {
 	const auto tile = getTile();
 	if (!tile) {
-		return std::make_shared<StaticTile>(0xFFFF, 0xFFFF, 0xFF)->getPosition();
+		static Position null_position(0xFFFF, 0xFFFF, 0xFF);
+		return null_position;
 	}
 	return tile->getPosition();
 }
 
-TilePtr Thing::getTile() {
+std::shared_ptr<Tile> Thing::getTile() {
 	return nullptr;
 }
 
-TileConstPtr Thing::getTile() const {
+std::shared_ptr<const Tile> Thing::getTile() const {
 	return nullptr;
 }

--- a/src/thing.cpp
+++ b/src/thing.cpp
@@ -8,19 +8,17 @@
 
 const Position& Thing::getPosition() const
 {
-	const Tile* tile = getTile();
+	const auto tile = getTile();
 	if (!tile) {
-		return Tile::nullptr_tile.getPosition();
+		return std::make_shared<StaticTile>(0xFFFF, 0xFFFF, 0xFF)->getPosition();
 	}
 	return tile->getPosition();
 }
 
-Tile* Thing::getTile()
-{
-	return dynamic_cast<Tile*>(this);
+TilePtr Thing::getTile() {
+	return nullptr;
 }
 
-const Tile* Thing::getTile() const
-{
-	return dynamic_cast<const Tile*>(this);
+TileConstPtr Thing::getTile() const {
+	return nullptr;
 }

--- a/src/thing.cpp
+++ b/src/thing.cpp
@@ -16,10 +16,10 @@ const Position& Thing::getPosition() const
 	return tile->getPosition();
 }
 
-std::shared_ptr<Tile> Thing::getTile() {
+TilePtr Thing::getTile() {
 	return nullptr;
 }
 
-std::shared_ptr<const Tile> Thing::getTile() const {
+TileConstPtr Thing::getTile() const {
 	return nullptr;
 }

--- a/src/thing.h
+++ b/src/thing.h
@@ -5,6 +5,10 @@
 #define FS_THING_H
 
 #include "position.h"
+#include <memory>
+#include <string>
+#include "sharedobject.h"
+
 
 class Tile;
 class Cylinder;
@@ -12,58 +16,96 @@ class Item;
 class Creature;
 class Container;
 
+using ThingPtr = std::shared_ptr<class Thing>;
+using ThingConstPtr = std::shared_ptr<const Thing>;
+
+using TilePtr = std::shared_ptr<Tile>;
+using TileConstPtr = std::shared_ptr<const Tile>;
+using TileWeakPtr = std::weak_ptr<Tile>;
+
+using CylinderPtr = std::shared_ptr<Cylinder>;
+using CylinderConstPtr = std::shared_ptr<const Cylinder>;
+using CylinderWeakPtr = std::weak_ptr<Cylinder>;
+
+using ItemPtr = std::shared_ptr<Item>;
+using ItemConstPtr = std::shared_ptr<const Item>;
+
+using CreaturePtr = std::shared_ptr<Creature>;
+using CreatureConstPtr = std::shared_ptr<const Creature>;
+
+using ContainerPtr = std::shared_ptr<Container>;
+using ContainerConstPtr = std::shared_ptr<const Container>;
+
 class Thing
 {
-	public:
-		constexpr Thing() = default;
-		virtual ~Thing() = default;
+    public:
+        virtual ~Thing() = default;
 
-		// non-copyable
-		Thing(const Thing&) = delete;
-		Thing& operator=(const Thing&) = delete;
+        // non-copyable
+        Thing(const Thing&) = delete;
+        Thing& operator=(const Thing&) = delete;
 
-		virtual std::string getDescription(int32_t lookDistance) const = 0;
+        // Factory method to create shared instances
+        template<typename T, typename... Args>
+        static std::shared_ptr<T> createThing(Args&&... args) {
+            return std::make_shared<T>(std::forward<Args>(args)...);
+        }
 
-		virtual Cylinder* getParent() const {
-			return nullptr;
-		}
-		virtual Cylinder* getRealParent() const {
-			return getParent();
-		}
+        virtual std::string getDescription(int32_t lookDistance) const = 0;
 
-		virtual void setParent(Cylinder*) {
-			//
-		}
+        virtual CylinderPtr getParent() {
+            return nullptr;
+        }
+    
+        virtual CylinderPtr getRealParent() {
+            return getParent();
+        }
 
-		virtual Tile* getTile();
-		virtual const Tile* getTile() const;
+        virtual void setParent(std::weak_ptr<Cylinder> cylinder) {
+            // Implementation in derived classes
+        }
 
-		virtual const Position& getPosition() const;
-		virtual int32_t getThrowRange() const = 0;
-		virtual bool isPushable() const = 0;
+        virtual void clearParent() {
 
-		virtual Container* getContainer() {
-			return nullptr;
-		}
-		virtual const Container* getContainer() const {
-			return nullptr;
-		}
-		virtual Item* getItem() {
-			return nullptr;
-		}
-		virtual const Item* getItem() const {
-			return nullptr;
-		}
-		virtual Creature* getCreature() {
-			return nullptr;
-		}
-		virtual const Creature* getCreature() const {
-			return nullptr;
-		}
+        }
 
-		virtual bool isRemoved() const {
-			return true;
-		}
+        virtual TilePtr getTile();
+        virtual TileConstPtr getTile() const;
+
+        virtual const Position& getPosition() const;
+        virtual int32_t getThrowRange() const = 0;
+        virtual bool isPushable() const = 0;
+
+        virtual ContainerPtr getContainer() {
+            return nullptr;
+        }
+    
+        virtual ContainerConstPtr getContainer() const {
+            return nullptr;
+        }
+    
+        virtual ItemPtr getItem() {
+            return nullptr;
+        }
+    
+        virtual ItemConstPtr getItem() const {
+            return nullptr;
+        }
+    
+        virtual CreaturePtr getCreature() {
+            return nullptr;
+        }
+    
+        virtual CreatureConstPtr getCreature() const {
+            return nullptr;
+        }
+
+        virtual bool isRemoved() const {
+            return true;
+        }
+    
+    protected:
+        constexpr Thing() = default;
 };
 
 #endif

--- a/src/thing.h
+++ b/src/thing.h
@@ -10,7 +10,6 @@
 #include "sharedobject.h"
 #include "declarations.h"
 
-class ObjectHandle;
 
 class Thing
 {
@@ -20,15 +19,14 @@ class Thing
         // non-copyable
         Thing(const Thing&) = delete;
         Thing& operator=(const Thing&) = delete;
-
-        template <class T>
-        static ObjectHandle _Self_Index() {
-
-        }
        
         virtual std::string getDescription(int32_t lookDistance) const = 0;
 
         virtual CylinderPtr getParent() {
+            return nullptr;
+        }
+
+        virtual CylinderConstPtr getParent() const {
             return nullptr;
         }
     

--- a/src/thing.h
+++ b/src/thing.h
@@ -8,33 +8,7 @@
 #include <memory>
 #include <string>
 #include "sharedobject.h"
-
-
-class Tile;
-class Cylinder;
-class Item;
-class Creature;
-class Container;
-
-using ThingPtr = std::shared_ptr<class Thing>;
-using ThingConstPtr = std::shared_ptr<const Thing>;
-
-using TilePtr = std::shared_ptr<Tile>;
-using TileConstPtr = std::shared_ptr<const Tile>;
-using TileWeakPtr = std::weak_ptr<Tile>;
-
-using CylinderPtr = std::shared_ptr<Cylinder>;
-using CylinderConstPtr = std::shared_ptr<const Cylinder>;
-using CylinderWeakPtr = std::weak_ptr<Cylinder>;
-
-using ItemPtr = std::shared_ptr<Item>;
-using ItemConstPtr = std::shared_ptr<const Item>;
-
-using CreaturePtr = std::shared_ptr<Creature>;
-using CreatureConstPtr = std::shared_ptr<const Creature>;
-
-using ContainerPtr = std::shared_ptr<Container>;
-using ContainerConstPtr = std::shared_ptr<const Container>;
+#include "declarations.h"
 
 class Thing
 {

--- a/src/thing.h
+++ b/src/thing.h
@@ -10,6 +10,8 @@
 #include "sharedobject.h"
 #include "declarations.h"
 
+class ObjectHandle;
+
 class Thing
 {
     public:
@@ -19,12 +21,11 @@ class Thing
         Thing(const Thing&) = delete;
         Thing& operator=(const Thing&) = delete;
 
-        // Factory method to create shared instances
-        template<typename T, typename... Args>
-        static std::shared_ptr<T> createThing(Args&&... args) {
-            return std::make_shared<T>(std::forward<Args>(args)...);
-        }
+        template <class T>
+        static ObjectHandle _Self_Index() {
 
+        }
+       
         virtual std::string getDescription(int32_t lookDistance) const = 0;
 
         virtual CylinderPtr getParent() {

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -789,8 +789,6 @@ ReturnValue Tile::queryRemove(const ThingPtr& thing, const uint32_t count, uint3
 	return RETURNVALUE_NOERROR;
 }
 
-#include <iostream> // For debug output
-
 CylinderPtr Tile::queryDestination(int32_t& someInt, const ThingPtr& thingPtr, ItemPtr& destItem, uint32_t& flags) {
 	TilePtr destTile = nullptr;
 	destItem = nullptr;
@@ -840,7 +838,6 @@ CylinderPtr Tile::queryDestination(int32_t& someInt, const ThingPtr& thingPtr, I
 	if (destTile == nullptr) {
 		TilePtr temp = this->getTile();
 		if (!temp) {
-			std::cerr << "Fallback also returned nullptr!" << std::endl;
 		}
 		destTile = temp;
 	} else {
@@ -849,8 +846,6 @@ CylinderPtr Tile::queryDestination(int32_t& someInt, const ThingPtr& thingPtr, I
 
 	if (destTile) {
 		if (auto destThing = destTile->getTopDownItem()) {
-			std::cout << "assigning the destItem \n";
-			std::cout << "destItem is : " << destThing->getItem()->getName() << " \n";
 			destItem = destThing->getItem();
 		}
 	}
@@ -901,7 +896,6 @@ void Tile::addThing(int32_t, ThingPtr thing)
 			}
 		} else if (itemType.alwaysOnTop) {
 			if (itemType.isSplash() && items) {
-				//remove old splash if exists
 				for (ItemVector::const_iterator it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 					const auto oldSplash = *it;
 					if (!Item::items[oldSplash->getID()].isSplash()) {
@@ -910,7 +904,6 @@ void Tile::addThing(int32_t, ThingPtr thing)
 
 					removeThing(oldSplash, 1);
 					oldSplash->clearParent();
-					// g_game.ReleaseItem(oldSplash);
 					postRemoveNotification(oldSplash, nullptr, 0);
 					break;
 				}
@@ -928,7 +921,7 @@ void Tile::addThing(int32_t, ThingPtr thing)
 					}
 				}
 			} else {
-				std::cout << "Hitting where should be unreachable in tile addthing!" << std::endl;
+				// std::unreachable()
 			}
 
 			if (!isInserted) {
@@ -944,24 +937,17 @@ void Tile::addThing(int32_t, ThingPtr thing)
 						if (const auto oldField = (*it)->getMagicField()) {
 							if (oldField->isReplaceable()) {
 								removeThing(oldField, 1);
-
 								oldField->clearParent();
-								// g_game.ReleaseItem(oldField);
 								postRemoveNotification(oldField, nullptr, 0);
 								break;
 							} else {
 								//This magic field cannot be replaced.
 								item->clearParent();
-								// g_game.ReleaseItem(item);
 								return;
 							}
 						}
 					}
 				}
-			}
-
-			if (!items) {
-				std::cout << "Getting to end of tile add thing and still not items list!" << std::endl;
 			}
 
 			items->insert(items->getBeginDownItem(), item);
@@ -1398,7 +1384,6 @@ void Tile::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t
 
 	for (auto spectator : spectators) {
 		assert(std::dynamic_pointer_cast<Player>(spectator) != nullptr);
-		std::cout << "Found a player spectator " << std::static_pointer_cast<Player>(spectator)->getName() << " for tile:postRemoveNotification  \n";
 		std::static_pointer_cast<Player>(spectator)->postRemoveNotification(thing, newParent, index, LINK_NEAR);
 	}
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -791,9 +791,9 @@ ReturnValue Tile::queryRemove(const ThingPtr& thing, const uint32_t count, uint3
 
 #include <iostream> // For debug output
 
-CylinderPtr Tile::queryDestination(int32_t& someInt, const ThingPtr& thingPtr, ItemPtr* destItem, uint32_t& flags) {
+CylinderPtr Tile::queryDestination(int32_t& someInt, const ThingPtr& thingPtr, ItemPtr& destItem, uint32_t& flags) {
 	TilePtr destTile = nullptr;
-	*destItem = nullptr;
+	destItem = nullptr;
 	
 	if (hasFlag(TILESTATE_FLOORCHANGE_DOWN)) {
 		uint16_t dx = tilePos.x;
@@ -851,7 +851,7 @@ CylinderPtr Tile::queryDestination(int32_t& someInt, const ThingPtr& thingPtr, I
 		if (auto destThing = destTile->getTopDownItem()) {
 			std::cout << "assigning the destItem \n";
 			std::cout << "destItem is : " << destThing->getItem()->getName() << " \n";
-			*destItem = destThing->getItem();
+			destItem = destThing->getItem();
 		}
 	}
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -22,7 +22,6 @@ extern MoveEvents* g_moveEvents;
 extern ConfigManager g_config;
 
 StaticTile real_nullptr_tile(0xFFFF, 0xFFFF, 0xFF);
-Tile& Tile::nullptr_tile = real_nullptr_tile;
 
 bool Tile::hasProperty(ITEMPROPERTY prop) const
 {
@@ -30,8 +29,8 @@ bool Tile::hasProperty(ITEMPROPERTY prop) const
 		return true;
 	}
 
-	if (const TileItemVector* items = getItemList()) {
-		for (const Item* item : *items) {
+	if (const auto items = getItemList()) {
+		for (const auto item : *items) {
 			if (item->hasProperty(prop)) {
 				return true;
 			}
@@ -40,7 +39,7 @@ bool Tile::hasProperty(ITEMPROPERTY prop) const
 	return false;
 }
 
-bool Tile::hasProperty(const Item* exclude, ITEMPROPERTY prop) const
+bool Tile::hasProperty(const ItemPtr& exclude, ITEMPROPERTY prop) const
 {
 	assert(exclude);
 
@@ -48,8 +47,8 @@ bool Tile::hasProperty(const Item* exclude, ITEMPROPERTY prop) const
 		return true;
 	}
 
-	if (const TileItemVector* items = getItemList()) {
-		for (const Item* item : *items) {
+	if (const auto items = getItemList()) {
+		for (const auto item : *items) {
 			if (item != exclude && item->hasProperty(prop)) {
 				return true;
 			}
@@ -59,7 +58,7 @@ bool Tile::hasProperty(const Item* exclude, ITEMPROPERTY prop) const
 	return false;
 }
 
-bool Tile::hasHeight(uint32_t n) const
+bool Tile::hasHeight(const uint32_t n) const
 {
 	uint32_t height = 0;
 
@@ -73,8 +72,8 @@ bool Tile::hasHeight(uint32_t n) const
 		}
 	}
 
-	if (const TileItemVector* items = getItemList()) {
-		for (const Item* item : *items) {
+	if (const auto items = getItemList()) {
+		for (const auto item : *items) {
 			if (item->hasProperty(CONST_PROP_HASHEIGHT)) {
 				++height;
 			}
@@ -89,7 +88,7 @@ bool Tile::hasHeight(uint32_t n) const
 
 size_t Tile::getCreatureCount() const
 {
-	if (const CreatureVector* creatures = getCreatures()) {
+	if (const auto creatures = getCreatures()) {
 		return creatures->size();
 	}
 	return 0;
@@ -97,7 +96,7 @@ size_t Tile::getCreatureCount() const
 
 size_t Tile::getItemCount() const
 {
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		return items->size();
 	}
 	return 0;
@@ -105,7 +104,7 @@ size_t Tile::getItemCount() const
 
 uint32_t Tile::getTopItemCount() const
 {
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		return items->getTopItemCount();
 	}
 	return 0;
@@ -113,7 +112,7 @@ uint32_t Tile::getTopItemCount() const
 
 uint32_t Tile::getDownItemCount() const
 {
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		return items->getDownItemCount();
 	}
 	return 0;
@@ -124,13 +123,13 @@ std::string Tile::getDescription(int32_t) const
 	return "You dont know why, but you cant see anything!";
 }
 
-Teleport* Tile::getTeleportItem() const
+TeleportPtr Tile::getTeleportItem() const
 {
 	if (!hasFlag(TILESTATE_TELEPORT)) {
 		return nullptr;
 	}
 
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getTeleport()) {
 				return (*it)->getTeleport();
@@ -140,7 +139,7 @@ Teleport* Tile::getTeleportItem() const
 	return nullptr;
 }
 
-MagicField* Tile::getFieldItem() const
+MagicFieldPtr Tile::getFieldItem() const
 {
 	if (!hasFlag(TILESTATE_MAGICFIELD)) {
 		return nullptr;
@@ -150,7 +149,7 @@ MagicField* Tile::getFieldItem() const
 		return ground->getMagicField();
 	}
 
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getMagicField()) {
 				return (*it)->getMagicField();
@@ -160,7 +159,7 @@ MagicField* Tile::getFieldItem() const
 	return nullptr;
 }
 
-TrashHolder* Tile::getTrashHolder() const
+TrashHolderPtr Tile::getTrashHolder() const
 {
 	if (!hasFlag(TILESTATE_TRASHHOLDER)) {
 		return nullptr;
@@ -170,7 +169,7 @@ TrashHolder* Tile::getTrashHolder() const
 		return ground->getTrashHolder();
 	}
 
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getTrashHolder()) {
 				return (*it)->getTrashHolder();
@@ -180,7 +179,7 @@ TrashHolder* Tile::getTrashHolder() const
 	return nullptr;
 }
 
-Mailbox* Tile::getMailbox() const
+MailboxPtr Tile::getMailbox() const
 {
 	if (!hasFlag(TILESTATE_MAILBOX)) {
 		return nullptr;
@@ -190,7 +189,7 @@ Mailbox* Tile::getMailbox() const
 		return ground->getMailbox();
 	}
 
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getMailbox()) {
 				return (*it)->getMailbox();
@@ -200,7 +199,7 @@ Mailbox* Tile::getMailbox() const
 	return nullptr;
 }
 
-BedItem* Tile::getBedItem() const
+BedItemPtr Tile::getBedItem() const
 {
 	if (!hasFlag(TILESTATE_BED)) {
 		return nullptr;
@@ -210,7 +209,7 @@ BedItem* Tile::getBedItem() const
 		return ground->getBed();
 	}
 
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 			if ((*it)->getBed()) {
 				return (*it)->getBed();
@@ -220,9 +219,9 @@ BedItem* Tile::getBedItem() const
 	return nullptr;
 }
 
-Creature* Tile::getTopCreature() const
+CreaturePtr Tile::getTopCreature() const
 {
-	if (const CreatureVector* creatures = getCreatures()) {
+	if (const auto creatures = getCreatures()) {
 		if (!creatures->empty()) {
 			return *creatures->begin();
 		}
@@ -230,9 +229,9 @@ Creature* Tile::getTopCreature() const
 	return nullptr;
 }
 
-const Creature* Tile::getBottomCreature() const
+CreatureConstPtr Tile::getBottomCreature() const
 {
-	if (const CreatureVector* creatures = getCreatures()) {
+	if (const auto creatures = getCreatures()) {
 		if (!creatures->empty()) {
 			return *creatures->rbegin();
 		}
@@ -240,19 +239,19 @@ const Creature* Tile::getBottomCreature() const
 	return nullptr;
 }
 
-Creature* Tile::getTopVisibleCreature(const Creature* creature) const
+CreaturePtr Tile::getTopVisibleCreature(const CreaturePtr creature) const
 {
-	if (const CreatureVector* creatures = getCreatures()) {
+	if (const auto creatures = getCreatures()) {
 		if (creature) {
-			for (Creature* tileCreature : *creatures) {
+			for (const auto tileCreature : *creatures) {
 				if (creature->canSeeCreature(tileCreature)) {
 					return tileCreature;
 				}
 			}
 		} else {
-			for (Creature* tileCreature : *creatures) {
+			for (const auto tileCreature : *creatures) {
 				if (!tileCreature->isInvisible()) {
-					const Player* player = tileCreature->getPlayer();
+					const auto player = tileCreature->getPlayer();
 					if (!player || !player->isInGhostMode()) {
 						return tileCreature;
 					}
@@ -263,9 +262,9 @@ Creature* Tile::getTopVisibleCreature(const Creature* creature) const
 	return nullptr;
 }
 
-const Creature* Tile::getBottomVisibleCreature(const Creature* creature) const
+CreatureConstPtr Tile::getBottomVisibleCreature(const CreatureConstPtr& creature) const
 {
-	if (const CreatureVector* creatures = getCreatures()) {
+	if (const auto creatures = getCreatures()) {
 		if (creature) {
 			for (auto it = creatures->rbegin(), end = creatures->rend(); it != end; ++it) {
 				if (creature->canSeeCreature(*it)) {
@@ -275,8 +274,7 @@ const Creature* Tile::getBottomVisibleCreature(const Creature* creature) const
 		} else {
 			for (auto it = creatures->rbegin(), end = creatures->rend(); it != end; ++it) {
 				if (!(*it)->isInvisible()) {
-					const Player* player = (*it)->getPlayer();
-					if (!player || !player->isInGhostMode()) {
+					if (const auto player = (*it)->getPlayer(); !player || !player->isInGhostMode()) {
 						return *it;
 					}
 				}
@@ -286,30 +284,30 @@ const Creature* Tile::getBottomVisibleCreature(const Creature* creature) const
 	return nullptr;
 }
 
-Item* Tile::getTopDownItem() const
+ItemPtr Tile::getTopDownItem() const
 {
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		return items->getTopDownItem();
 	}
 	return nullptr;
 }
 
-Item* Tile::getTopTopItem() const
+ItemPtr Tile::getTopTopItem() const
 {
-	if (const TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		return items->getTopTopItem();
 	}
 	return nullptr;
 }
 
-Item* Tile::getItemByTopOrder(int32_t topOrder)
+ItemPtr Tile::getItemByTopOrder(int32_t topOrder)
 {
 	//topOrder:
 	//1: borders
 	//2: ladders, signs, splashes
 	//3: doors etc
 	//4: creatures
-	if (TileItemVector* items = getItemList()) {
+	if (const auto items = getItemList()) {
 		for (auto it = ItemVector::const_reverse_iterator(items->getEndTopItem()), end = ItemVector::const_reverse_iterator(items->getBeginTopItem()); it != end; ++it) {
 			if (Item::items[(*it)->getID()].alwaysOnTopOrder == topOrder) {
 				return (*it);
@@ -319,25 +317,21 @@ Item* Tile::getItemByTopOrder(int32_t topOrder)
 	return nullptr;
 }
 
-Thing* Tile::getTopVisibleThing(const Creature* creature)
+ThingPtr Tile::getTopVisibleThing(const CreaturePtr creature)
 {
-	Thing* thing = getTopVisibleCreature(creature);
-	if (thing) {
+	if (const auto thing = getTopVisibleCreature(creature)) {
 		return thing;
 	}
 
-	TileItemVector* items = getItemList();
-	if (items) {
+	if (const auto items = getItemList()) {
 		for (ItemVector::const_iterator it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
-			const ItemType& iit = Item::items[(*it)->getID()];
-			if (!iit.lookThrough) {
+			if (const ItemType& iit = Item::items[(*it)->getID()]; !iit.lookThrough) {
 				return (*it);
 			}
 		}
 
 		for (auto it = ItemVector::const_reverse_iterator(items->getEndTopItem()), end = ItemVector::const_reverse_iterator(items->getBeginTopItem()); it != end; ++it) {
-			const ItemType& iit = Item::items[(*it)->getID()];
-			if (!iit.lookThrough) {
+			if (const ItemType& iit = Item::items[(*it)->getID()]; !iit.lookThrough) {
 				return (*it);
 			}
 		}
@@ -346,11 +340,10 @@ Thing* Tile::getTopVisibleThing(const Creature* creature)
 	return ground;
 }
 
-void Tile::onAddTileItem(Item* item)
+void Tile::onAddTileItem(ItemPtr& item)
 {
 	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->getContainer()) {
-		auto it = g_game.browseFields.find(this);
-		if (it != g_game.browseFields.end()) {
+		if (const auto it = g_game.browseFields.find(getTile()); it != g_game.browseFields.end()) {
 			it->second->addItemBack(item);
 			item->setParent(it->second);
 		}
@@ -364,41 +357,39 @@ void Tile::onAddTileItem(Item* item)
 	g_game.map.getSpectators(spectators, cylinderMapPos, true);
 
 	//send to client
-	for (Creature* spectator : spectators) {
-		if (Player* spectatorPlayer = spectator->getPlayer()) {
-			spectatorPlayer->sendAddTileItem(this, cylinderMapPos, item);
+	for (const auto spectator : spectators) {
+		if (const auto spectatorPlayer = spectator->getPlayer()) {
+			spectatorPlayer->sendAddTileItem(getTile(), cylinderMapPos, item);
 		}
 	}
 
 	//event methods
-	for (Creature* spectator : spectators) {
-		spectator->onAddTileItem(this, cylinderMapPos);
+	for (const auto spectator : spectators) {
+		TilePtr tp = this->getTile();
+		spectator->onAddTileItem(tp, cylinderMapPos);
 	}
 
 	if ((!hasFlag(TILESTATE_PROTECTIONZONE) || g_config.getBoolean(ConfigManager::CLEAN_PROTECTION_ZONES)) && item->isCleanable()) {
 		if (!dynamic_cast<HouseTile*>(this)) {
-			g_game.addTileToClean(this);
+			g_game.addTileToClean(getTile());
 		}
 	}
 }
 
-void Tile::onUpdateTileItem(Item* oldItem, const ItemType& oldType, Item* newItem, const ItemType& newType)
+void Tile::onUpdateTileItem(const ItemPtr& oldItem, const ItemType& oldType, const ItemPtr& newItem, const ItemType& newType)
 {
 	if (newItem->hasProperty(CONST_PROP_MOVEABLE) || newItem->getContainer()) {
-		auto it = g_game.browseFields.find(this);
-		if (it != g_game.browseFields.end()) {
-			int32_t index = it->second->getThingIndex(oldItem);
-			if (index != -1) {
+		if (const auto it = g_game.browseFields.find(getTile()); it != g_game.browseFields.end()) {
+			if (int32_t index = it->second->getThingIndex(oldItem); index != -1) {
 				it->second->replaceThing(index, newItem);
 				newItem->setParent(it->second);
 			}
 		}
 	} else if (oldItem->hasProperty(CONST_PROP_MOVEABLE) || oldItem->getContainer()) {
-		auto it = g_game.browseFields.find(this);
+		auto it = g_game.browseFields.find(getTile());
 		if (it != g_game.browseFields.end()) {
-			Cylinder* oldParent = oldItem->getParent();
 			it->second->removeThing(oldItem, oldItem->getItemCount());
-			oldItem->setParent(oldParent);
+			oldItem->setParent(oldItem->getParent());
 		}
 	}
 
@@ -408,23 +399,22 @@ void Tile::onUpdateTileItem(Item* oldItem, const ItemType& oldType, Item* newIte
 	g_game.map.getSpectators(spectators, cylinderMapPos, true);
 
 	//send to client
-	for (Creature* spectator : spectators) {
-		if (Player* spectatorPlayer = spectator->getPlayer()) {
-			spectatorPlayer->sendUpdateTileItem(this, cylinderMapPos, newItem);
+	for (const auto spectator : spectators) {
+		if (const auto spectatorPlayer = spectator->getPlayer()) {
+			spectatorPlayer->sendUpdateTileItem(getTile(), cylinderMapPos, newItem);
 		}
 	}
 
 	//event methods
-	for (Creature* spectator : spectators) {
-		spectator->onUpdateTileItem(this, cylinderMapPos, oldItem, oldType, newItem, newType);
+	for (const auto spectator : spectators) {
+		spectator->onUpdateTileItem(getTile(), cylinderMapPos, oldItem, oldType, newItem, newType);
 	}
 }
 
-void Tile::onRemoveTileItem(const SpectatorVec& spectators, const std::vector<int32_t>& oldStackPosVector, Item* item)
+void Tile::onRemoveTileItem(const SpectatorVec& spectators, const std::vector<int32_t>& oldStackPosVector, const ItemPtr& item)
 {
 	if (item->hasProperty(CONST_PROP_MOVEABLE) || item->getContainer()) {
-		auto it = g_game.browseFields.find(this);
-		if (it != g_game.browseFields.end()) {
+		if (const auto it = g_game.browseFields.find(getTile()); it != g_game.browseFields.end()) {
 			it->second->removeThing(item, item->getItemCount());
 		}
 	}
@@ -436,26 +426,26 @@ void Tile::onRemoveTileItem(const SpectatorVec& spectators, const std::vector<in
 
 	//send to client
 	size_t i = 0;
-	for (Creature* spectator : spectators) {
-		if (Player* tmpPlayer = spectator->getPlayer()) {
+	for (const auto spectator : spectators) {
+		if (const auto tmpPlayer = spectator->getPlayer()) {
 			tmpPlayer->sendRemoveTileThing(cylinderMapPos, oldStackPosVector[i++]);
 		}
 	}
 
 	//event methods
-	for (Creature* spectator : spectators) {
-		spectator->onRemoveTileItem(this, cylinderMapPos, iType, item);
+	for (const auto spectator : spectators) {
+		spectator->onRemoveTileItem(getTile(), cylinderMapPos, iType, item);
 	}
 
 	if (!hasFlag(TILESTATE_PROTECTIONZONE) || g_config.getBoolean(ConfigManager::CLEAN_PROTECTION_ZONES)) {
-		auto items = getItemList();
+		const auto items = getItemList();
 		if (!items || items->empty()) {
-			g_game.removeTileToClean(this);
+			g_game.removeTileToClean(getTile());
 			return;
 		}
 
 		bool ret = false;
-		for (auto toCheck : *items) {
+		for (const auto toCheck : *items) {
 			if (toCheck->isCleanable()) {
 				ret = true;
 				break;
@@ -463,7 +453,7 @@ void Tile::onRemoveTileItem(const SpectatorVec& spectators, const std::vector<in
 		}
 
 		if (!ret) {
-			g_game.removeTileToClean(this);
+			g_game.removeTileToClean(getTile());
 		}
 	}
 }
@@ -473,13 +463,13 @@ void Tile::onUpdateTile(const SpectatorVec& spectators)
 	const Position& cylinderMapPos = getPosition();
 
 	//send to clients
-	for (Creature* spectator : spectators) {
-		assert(dynamic_cast<Player*>(spectator) != nullptr);
-		static_cast<Player*>(spectator)->sendUpdateTile(this, cylinderMapPos);
+	for (const auto spectator : spectators) {
+		assert(std::dynamic_pointer_cast<Player>(spectator) != nullptr);
+		std::static_pointer_cast<Player>(spectator)->sendUpdateTile(getTile(), cylinderMapPos);
 	}
 }
 
-ReturnValue Tile::queryAdd(const Creature& creature, uint32_t flags) const
+ReturnValue Tile::queryAdd(CreaturePtr creature, uint32_t flags)
 {
     ReturnValue results = RETURNVALUE_NOERROR;
 
@@ -495,12 +485,12 @@ ReturnValue Tile::queryAdd(const Creature& creature, uint32_t flags) const
         return RETURNVALUE_NOTPOSSIBLE;
     }
 
-	const CreatureVector* creatures = getCreatures();
+	const auto creatures = getCreatures();
 
 	if (creatures && !creatures->empty() && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags)) {
-		for (const Creature* tileCreature : *creatures) {
+		for (const auto tileCreature : *creatures) {
 			if (!tileCreature->isInGhostMode() && (tileCreature->getPlayer() && !tileCreature->getPlayer()->isAccessPlayer() )) {
-				if (creature.getPlayer() && !creature.getPlayer()->isAccessPlayer() && !creature.getPlayer()->canWalkthrough(tileCreature)) {
+				if (creature->getPlayer() && !creature->getPlayer()->isAccessPlayer() && !creature->getPlayer()->canWalkthrough(tileCreature)) {
 					return RETURNVALUE_NOTENOUGHROOM;
 				}
 			}
@@ -515,47 +505,45 @@ ReturnValue Tile::queryAdd(const Creature& creature, uint32_t flags) const
     } else {
         //FLAG_IGNOREBLOCKITEM is set
         if (ground) {
-            const ItemType& iiType = Item::items[ground->getID()];
-            if (iiType.blockSolid && (!iiType.moveable || ground->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID))) {
+	        if (const ItemType& iiType = Item::items[ground->getID()]; iiType.blockSolid && (!iiType.moveable || ground->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID))) {
                 return RETURNVALUE_NOTPOSSIBLE;
             }
         }
 
         if (const auto items = getItemList()) {
-            for (const Item* item : *items) {
-                const ItemType& iiType = Item::items[item->getID()];
-                if (iiType.blockSolid && (!iiType.moveable || item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID))) {
+            for (const auto item : *items) {
+	            if (const ItemType& iiType = Item::items[item->getID()]; iiType.blockSolid && (!iiType.moveable || item->hasAttribute(ITEM_ATTRIBUTE_UNIQUEID))) {
                     return RETURNVALUE_NOTPOSSIBLE;
                 }
             }
         }
     }
 
-	if (const Player* player = dynamic_cast<const Player*>(&creature)) {
-		results = queryAdd(*player, flags);
-	} else if (const Monster* monster = dynamic_cast<const Monster*>(&creature)) {
-		results = queryAdd(*monster, flags);
+	if (auto player = std::dynamic_pointer_cast<Player>(creature)) {
+		results = queryAdd(player, flags);
+	} else if (auto monster = std::dynamic_pointer_cast<Monster>(creature)) {
+		results = queryAdd(monster, flags);
 	}
 
 	return results;
 }
 
 
-ReturnValue Tile::queryAdd(const Player& player, uint32_t flags) const {
+ReturnValue Tile::queryAdd(PlayerPtr player, uint32_t flags) {
 
-	const CreatureVector* creatures = getCreatures();
+	const auto creatures = getCreatures();
 
 	// If we aren't a GM/Admin can't walk on a tile that has a creature, if we don't have walkthrough enabled.
-	if (creatures && !creatures->empty() && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags) && !player.isAccessPlayer()) {
-		for (const Creature* tileCreature : *creatures) {
-			if (!player.canWalkthrough(tileCreature)) {
+	if (creatures && !creatures->empty() && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags) && !player->isAccessPlayer()) {
+		for (const auto tileCreature : *creatures) {
+			if (!player->canWalkthrough(tileCreature)) {
 				return RETURNVALUE_NOTPOSSIBLE;
 			}
 		}
 	}
 
 	// We are auto-walking, lets not step on a field that would hurt us.
-	if (MagicField* field = getFieldItem()) {
+	if (const auto field = getFieldItem()) {
 		if (field->getDamage() != 0 && hasBitSet(FLAG_PATHFINDING, flags) &&
 			!hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags)) {
 			return RETURNVALUE_NOTPOSSIBLE;
@@ -563,13 +551,14 @@ ReturnValue Tile::queryAdd(const Player& player, uint32_t flags) const {
 	}
 
 	// Player is trying to login to a "no logout" tile.
-	if (player.getParent() == nullptr && hasFlag(TILESTATE_NOLOGOUT)) {
+	// note: might need to check for std::nullopt here as well actually.
+	if (player->getParent() == nullptr && hasFlag(TILESTATE_NOLOGOUT)) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
 	// Player is pz'd, let do some checks.
-	const Tile* playerTile = player.getTile();
-	if (playerTile && player.isPzLocked()) {
+	const auto playerTile = player->getTile();
+	if (playerTile && player->isPzLocked()) {
 		if (!playerTile->hasFlag(TILESTATE_PVPZONE)) {
 			//player is trying to enter a pvp zone while being pz-locked
 			if (hasFlag(TILESTATE_PVPZONE)) {
@@ -591,7 +580,7 @@ ReturnValue Tile::queryAdd(const Player& player, uint32_t flags) const {
 }
 
 
-ReturnValue Tile::queryAdd(const Monster& monster, uint32_t flags) const {
+ReturnValue Tile::queryAdd(MonsterPtr monster, uint32_t flags) {
 	// Monsters
 	// Monsters cannot enter pz, jump floors, or step into teleports
 	if (hasFlag(TILESTATE_PROTECTIONZONE | TILESTATE_FLOORCHANGE | TILESTATE_TELEPORT)) {
@@ -610,28 +599,28 @@ ReturnValue Tile::queryAdd(const Monster& monster, uint32_t flags) const {
 
 	// Monster is looking for a clear path, some stuff is blocking it.
 	if (hasFlag(TILESTATE_BLOCKSOLID) || (hasBitSet(FLAG_PATHFINDING, flags) && hasFlag(TILESTATE_NOFIELDBLOCKPATH))) {
-		if (!(monster.canPushItems() || hasBitSet(FLAG_IGNOREBLOCKITEM, flags))) {
+		if (!(monster->canPushItems() || hasBitSet(FLAG_IGNOREBLOCKITEM, flags))) {
 			return RETURNVALUE_NOTPOSSIBLE;
 		}
 	}
 
-	const CreatureVector* creatures = getCreatures();
+	const auto creatures = getCreatures();
 
 	// We have creatures on the tile we are trying to step on
 	if (creatures && !creatures->empty()) {
-		for (const Creature* tileCreature : *creatures) {
+		for (const auto tileCreature : *creatures) {
 			// creature is not in ghost mode
 			if (!tileCreature->isInGhostMode()) {
 				return RETURNVALUE_NOTENOUGHROOM;
 			}
 			
-			if (monster.canPushCreatures() && !monster.isSummon()) {
+			if (monster->canPushCreatures() && !monster->isSummon()) {
 				// the creature is a player in ghost mode.
 				if (tileCreature->getPlayer() && tileCreature->getPlayer()->isInGhostMode()) {
 					continue;
 				}
 				// the creature is a monster this monster can't push.
-				const Monster* creatureMonster = tileCreature->getMonster();
+				const auto creatureMonster = tileCreature->getMonster();
 				if (!creatureMonster || !tileCreature->isPushable() || (creatureMonster->isSummon() && creatureMonster->getMaster()->getPlayer())) {
 					return RETURNVALUE_NOTPOSSIBLE;
 				}
@@ -640,7 +629,7 @@ ReturnValue Tile::queryAdd(const Monster& monster, uint32_t flags) const {
 	}
 
 	// If the magic field is safe, return early
-    MagicField* field = getFieldItem();
+    const auto field = getFieldItem();
     if (!field || field->isBlocking() || field->getDamage() == 0) {
         return RETURNVALUE_NOERROR;
     }
@@ -649,11 +638,11 @@ ReturnValue Tile::queryAdd(const Monster& monster, uint32_t flags) const {
 
     //There is 3 options for a monster to enter a magic field
     //1) Monster is immune
-    if (!monster.isImmune(combatType)) {
+    if (!monster->isImmune(combatType)) {
         //1) Monster is able to walk over field type
         //2) Being attacked while random stepping will make it ignore field damages
         if (hasBitSet(FLAG_IGNOREFIELDDAMAGE, flags)) {
-            if (!(monster.canWalkOnFieldType(combatType) || monster.isIgnoringFieldDamage())) {
+            if (!(monster->canWalkOnFieldType(combatType) || monster->isIgnoringFieldDamage())) {
                 return RETURNVALUE_NOTPOSSIBLE;
             }
         } else {
@@ -664,9 +653,9 @@ ReturnValue Tile::queryAdd(const Monster& monster, uint32_t flags) const {
     return RETURNVALUE_NOERROR;
 }
 
-ReturnValue Tile::queryAdd(const Item& item, uint32_t flags) const {
+ReturnValue Tile::queryAdd(ItemPtr item, uint32_t flags) {
     // Tile's item stack is at its numeric limit can't add anything
-    const TileItemVector* items = getItemList();
+    const auto items = getItemList();
     if (items && items->size() >= 0xFFFF) {
         return RETURNVALUE_NOTPOSSIBLE;
     }
@@ -677,20 +666,20 @@ ReturnValue Tile::queryAdd(const Item& item, uint32_t flags) const {
     }
 
     // Can't move store items to tiles
-    if (item.isStoreItem()) {
+    if (item->isStoreItem()) {
         return RETURNVALUE_ITEMCANNOTBEMOVEDTHERE;
     }
 
     // If its a wall, but not a hangable item.
-    bool itemIsHangable = item.isHangable();
+    bool itemIsHangable = item->isHangable();
     if (ground == nullptr && !itemIsHangable) {
         return RETURNVALUE_NOTPOSSIBLE;
     }
 
     // If there is any creature there, who is not in ghost mode... don't think this should be here...
-    const CreatureVector* creatures = getCreatures();
-    if (creatures && !creatures->empty() && item.isBlocking() && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags)) {
-        for (const Creature* tileCreature : *creatures) {
+    const auto creatures = getCreatures();
+    if (creatures && !creatures->empty() && item->isBlocking() && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags)) {
+        for (const auto tileCreature : *creatures) {
             if (!tileCreature->isInGhostMode()) {
                 return RETURNVALUE_NOTENOUGHROOM;
             }
@@ -704,7 +693,7 @@ ReturnValue Tile::queryAdd(const Item& item, uint32_t flags) const {
     // If we have a hangable item and the tile supports hangables
     if (itemIsHangable && hasFlag(TILESTATE_SUPPORTS_HANGABLE)) {
         if (items) {
-            for (const Item* tileItem : *items) {
+            for (const auto tileItem : *items) {
 				// there is already a hangable there
                 if (tileItem->isHangable()) {
                     return RETURNVALUE_NEEDEXCHANGE;
@@ -716,8 +705,8 @@ ReturnValue Tile::queryAdd(const Item& item, uint32_t flags) const {
         if (ground) {
             const ItemType& iiType = Item::items[ground->getID()];
             if (iiType.blockSolid) {
-                if (!iiType.allowPickupable || item.isMagicField() || item.isBlocking()) {
-                    if (!item.isPickupable()) {
+                if (!iiType.allowPickupable || item->isMagicField() || item->isBlocking()) {
+                    if (!item->isPickupable()) {
                         return RETURNVALUE_NOTENOUGHROOM;
                     }
 
@@ -729,17 +718,17 @@ ReturnValue Tile::queryAdd(const Item& item, uint32_t flags) const {
         }
 		// We can move this into the previous check and combine the loops. 
         if (items) {
-            for (const Item* tileItem : *items) {
+            for (const auto tileItem : *items) {
                 const ItemType& iiType = Item::items[tileItem->getID()];
                 if (!iiType.blockSolid) {
                     continue;
                 }
 
-                if (iiType.allowPickupable && !item.isMagicField() && !item.isBlocking()) {
+                if (iiType.allowPickupable && !item->isMagicField() && !item->isBlocking()) {
                     continue;
                 }
 
-                if (!item.isPickupable()) {
+                if (!item->isPickupable()) {
                     return RETURNVALUE_NOTENOUGHROOM;
                 }
 
@@ -752,13 +741,13 @@ ReturnValue Tile::queryAdd(const Item& item, uint32_t flags) const {
     return RETURNVALUE_NOERROR;
 }
 
-ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags, Creature*) const {
-	if (const Creature* creature = dynamic_cast<const Creature*>(&thing)) {
-		return queryAdd(*creature, flags);
+ReturnValue Tile::queryAdd(int32_t, const ThingPtr& thing, uint32_t, uint32_t flags, CreaturePtr) {
+	if (auto creature = std::dynamic_pointer_cast<Creature>(thing)) {
+		return queryAdd(creature, flags);
 	}
 
-	if (const Item* item = dynamic_cast<const Item*>(&thing)) {
-		return queryAdd(*item, flags);
+	if (auto item = std::dynamic_pointer_cast<Item>(thing)) {
+		return queryAdd(item, flags);
 	}
 
 	std::cout << "|| WARNING || Tile::queryAdd() passed the object "<< typeid(thing).name() << ", that is not a creature or item! " << "\n";
@@ -766,20 +755,20 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue Tile::queryMaxCount(int32_t, const Thing&, uint32_t count, uint32_t& maxQueryCount, uint32_t) const
+ReturnValue Tile::queryMaxCount(int32_t, const ThingPtr&, const uint32_t count, uint32_t& maxQueryCount, uint32_t)
 {
 	maxQueryCount = std::max<uint32_t>(1, count);
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue Tile::queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* /*= nullptr */) const
+ReturnValue Tile::queryRemove(const ThingPtr& thing, const uint32_t count, uint32_t flags, CreaturePtr /*= nullptr */)
 {
-	int32_t index = getThingIndex(&thing);
+	int32_t index = getThingIndex(thing);
 	if (index == -1) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
 
-	const Item* item = thing.getItem();
+	const auto item = thing->getItem();
 	if (item == nullptr) {
 		return RETURNVALUE_NOTPOSSIBLE;
 	}
@@ -795,129 +784,96 @@ ReturnValue Tile::queryRemove(const Thing& thing, uint32_t count, uint32_t flags
 	return RETURNVALUE_NOERROR;
 }
 
-Tile* Tile::queryDestination(int32_t&, const Thing&, Item** destItem, uint32_t& flags)
-{
-	Tile* destTile = nullptr;
-	*destItem = nullptr;
+#include <iostream> // For debug output
 
+CylinderPtr Tile::queryDestination(int32_t& someInt, const ThingPtr& thingPtr, ItemPtr* destItem, uint32_t& flags) {
+	TilePtr destTile = nullptr;
+	*destItem = nullptr;
+	
 	if (hasFlag(TILESTATE_FLOORCHANGE_DOWN)) {
 		uint16_t dx = tilePos.x;
 		uint16_t dy = tilePos.y;
 		uint8_t dz = tilePos.z + 1;
-
-		Tile* southDownTile = g_game.map.getTile(dx, dy - 1, dz);
-		if (southDownTile && southDownTile->hasFlag(TILESTATE_FLOORCHANGE_SOUTH_ALT)) {
+		
+		if (const auto southDownTile = g_game.map.getTile(dx, dy - 1, dz); southDownTile && southDownTile->hasFlag(TILESTATE_FLOORCHANGE_SOUTH_ALT)) {
 			dy -= 2;
 			destTile = g_game.map.getTile(dx, dy, dz);
-		} else {
-			Tile* eastDownTile = g_game.map.getTile(dx - 1, dy, dz);
-			if (eastDownTile && eastDownTile->hasFlag(TILESTATE_FLOORCHANGE_EAST_ALT)) {
-				dx -= 2;
+		}
+		else if (const auto eastDownTile = g_game.map.getTile(dx - 1, dy, dz); eastDownTile && eastDownTile->hasFlag(TILESTATE_FLOORCHANGE_EAST_ALT)) {
+			dx -= 2;
+			destTile = g_game.map.getTile(dx, dy, dz);
+		}
+		else {
+			if (const auto downTile = g_game.map.getTile(dx, dy, dz)) {
+
+				if (downTile->hasFlag(TILESTATE_FLOORCHANGE_NORTH)) ++dy;
+				if (downTile->hasFlag(TILESTATE_FLOORCHANGE_SOUTH)) --dy;
+				if (downTile->hasFlag(TILESTATE_FLOORCHANGE_SOUTH_ALT)) dy -= 2;
+				if (downTile->hasFlag(TILESTATE_FLOORCHANGE_EAST)) --dx;
+				if (downTile->hasFlag(TILESTATE_FLOORCHANGE_EAST_ALT)) dx -= 2;
+				if (downTile->hasFlag(TILESTATE_FLOORCHANGE_WEST)) ++dx;
+
 				destTile = g_game.map.getTile(dx, dy, dz);
-			} else {
-				Tile* downTile = g_game.map.getTile(dx, dy, dz);
-				if (downTile) {
-					if (downTile->hasFlag(TILESTATE_FLOORCHANGE_NORTH)) {
-						++dy;
-					}
-
-					if (downTile->hasFlag(TILESTATE_FLOORCHANGE_SOUTH)) {
-						--dy;
-					}
-
-					if (downTile->hasFlag(TILESTATE_FLOORCHANGE_SOUTH_ALT)) {
-						dy -= 2;
-					}
-
-					if (downTile->hasFlag(TILESTATE_FLOORCHANGE_EAST)) {
-						--dx;
-					}
-
-					if (downTile->hasFlag(TILESTATE_FLOORCHANGE_EAST_ALT)) {
-						dx -= 2;
-					}
-
-					if (downTile->hasFlag(TILESTATE_FLOORCHANGE_WEST)) {
-						++dx;
-					}
-
-					destTile = g_game.map.getTile(dx, dy, dz);
-				}
 			}
 		}
-	} else if (hasFlag(TILESTATE_FLOORCHANGE)) {
+	}
+	else if (hasFlag(TILESTATE_FLOORCHANGE)) {
 		uint16_t dx = tilePos.x;
 		uint16_t dy = tilePos.y;
 		uint8_t dz = tilePos.z - 1;
-
-		if (hasFlag(TILESTATE_FLOORCHANGE_NORTH)) {
-			--dy;
-		}
-
-		if (hasFlag(TILESTATE_FLOORCHANGE_SOUTH)) {
-			++dy;
-		}
-
-		if (hasFlag(TILESTATE_FLOORCHANGE_EAST)) {
-			++dx;
-		}
-
-		if (hasFlag(TILESTATE_FLOORCHANGE_WEST)) {
-			--dx;
-		}
-
-		if (hasFlag(TILESTATE_FLOORCHANGE_SOUTH_ALT)) {
-			dy += 2;
-		}
-
-		if (hasFlag(TILESTATE_FLOORCHANGE_EAST_ALT)) {
-			dx += 2;
-		}
+		
+		if (hasFlag(TILESTATE_FLOORCHANGE_NORTH)) --dy;
+		if (hasFlag(TILESTATE_FLOORCHANGE_SOUTH)) ++dy;
+		if (hasFlag(TILESTATE_FLOORCHANGE_EAST)) ++dx;
+		if (hasFlag(TILESTATE_FLOORCHANGE_WEST)) --dx;
+		if (hasFlag(TILESTATE_FLOORCHANGE_SOUTH_ALT)) dy += 2;
+		if (hasFlag(TILESTATE_FLOORCHANGE_EAST_ALT)) dx += 2;
 
 		destTile = g_game.map.getTile(dx, dy, dz);
 	}
 
 	if (destTile == nullptr) {
-		destTile = this;
+		TilePtr temp = this->getTile();
+		if (!temp) {
+			std::cerr << "Fallback also returned nullptr!" << std::endl;
+		}
+		destTile = temp;
 	} else {
-		flags |= FLAG_NOLIMIT; //Will ignore that there is blocking items/creatures
+		flags |= FLAG_NOLIMIT;
 	}
 
 	if (destTile) {
-		Thing* destThing = destTile->getTopDownItem();
-		if (destThing) {
+		if (const auto& destThing = destTile->getTopDownItem()) {
 			*destItem = destThing->getItem();
 		}
 	}
+
 	return destTile;
 }
 
-void Tile::addThing(Thing* thing)
+void Tile::addThing(ThingPtr thing)
 {
 	addThing(0, thing);
 }
 
-void Tile::addThing(int32_t, Thing* thing)
+void Tile::addThing(int32_t, ThingPtr thing)
 {
-	Creature* creature = thing->getCreature();
-	if (creature) {
+	if (const auto& creature = thing->getCreature()) {
 		g_game.map.clearChunkSpectatorCache();
-
-		creature->setParent(this);
-		CreatureVector* creatures = makeCreatures();
+		creature->setParent(getTile());
+		const auto& creatures = getCreatures();
 		creatures->insert(creatures->begin(), creature);
 	} else {
-		Item* item = thing->getItem();
+		auto item = thing->getItem();
 		if (item == nullptr) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
 		}
 
-		TileItemVector* items = getItemList();
+		TileItemsPtr items = getItemList();
 		if (items && items->size() >= 0xFFFF) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
 		}
-
-		item->setParent(this);
+		item->setParent(getTile());
 
 		const ItemType& itemType = Item::items[item->getID()];
 		if (itemType.isGroundTile()) {
@@ -927,9 +883,9 @@ void Tile::addThing(int32_t, Thing* thing)
 			} else {
 				const ItemType& oldType = Item::items[ground->getID()];
 
-				Item* oldGround = ground;
-				ground->setParent(nullptr);
-				g_game.ReleaseItem(ground);
+				const auto oldGround = ground;
+				ground->clearParent();
+				// g_game.ReleaseItem(ground);
 				ground = item;
 				resetTileFlags(oldGround);
 				setTileFlags(item);
@@ -940,14 +896,14 @@ void Tile::addThing(int32_t, Thing* thing)
 			if (itemType.isSplash() && items) {
 				//remove old splash if exists
 				for (ItemVector::const_iterator it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
-					Item* oldSplash = *it;
+					const auto oldSplash = *it;
 					if (!Item::items[oldSplash->getID()].isSplash()) {
 						continue;
 					}
 
 					removeThing(oldSplash, 1);
-					oldSplash->setParent(nullptr);
-					g_game.ReleaseItem(oldSplash);
+					oldSplash->clearParent();
+					// g_game.ReleaseItem(oldSplash);
 					postRemoveNotification(oldSplash, nullptr, 0);
 					break;
 				}
@@ -965,7 +921,7 @@ void Tile::addThing(int32_t, Thing* thing)
 					}
 				}
 			} else {
-				items = makeItemList();
+				std::cout << "Hitting where should be unreachable in tile addthing!" << std::endl;
 			}
 
 			if (!isInserted) {
@@ -978,19 +934,18 @@ void Tile::addThing(int32_t, Thing* thing)
 				//remove old field item if exists
 				if (items) {
 					for (ItemVector::const_iterator it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
-						MagicField* oldField = (*it)->getMagicField();
-						if (oldField) {
+						if (const auto oldField = (*it)->getMagicField()) {
 							if (oldField->isReplaceable()) {
 								removeThing(oldField, 1);
 
-								oldField->setParent(nullptr);
-								g_game.ReleaseItem(oldField);
+								oldField->clearParent();
+								// g_game.ReleaseItem(oldField);
 								postRemoveNotification(oldField, nullptr, 0);
 								break;
 							} else {
 								//This magic field cannot be replaced.
-								item->setParent(nullptr);
-								g_game.ReleaseItem(item);
+								item->clearParent();
+								// g_game.ReleaseItem(item);
 								return;
 							}
 						}
@@ -998,7 +953,10 @@ void Tile::addThing(int32_t, Thing* thing)
 				}
 			}
 
-			items = makeItemList();
+			if (!items) {
+				std::cout << "Getting to end of tile add thing and still not items list!" << std::endl;
+			}
+
 			items->insert(items->getBeginDownItem(), item);
 			items->addDownItemCount(1);
 			onAddTileItem(item);
@@ -1006,14 +964,14 @@ void Tile::addThing(int32_t, Thing* thing)
 	}
 }
 
-void Tile::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
+void Tile::updateThing(ThingPtr thing, uint16_t itemId, uint32_t count)
 {
 	int32_t index = getThingIndex(thing);
 	if (index == -1) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* item = thing->getItem();
+	const auto item = thing->getItem();
 	if (item == nullptr) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
@@ -1027,16 +985,16 @@ void Tile::updateThing(Thing* thing, uint16_t itemId, uint32_t count)
 	onUpdateTileItem(item, oldType, item, newType);
 }
 
-void Tile::replaceThing(uint32_t index, Thing* thing)
+void Tile::replaceThing(uint32_t index, ThingPtr thing)
 {
 	int32_t pos = index;
 
-	Item* item = thing->getItem();
+	const auto item = thing->getItem();
 	if (item == nullptr) {
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	Item* oldItem = nullptr;
+	ItemPtr oldItem = nullptr;
 	bool isInserted = false;
 
 	if (ground) {
@@ -1049,7 +1007,7 @@ void Tile::replaceThing(uint32_t index, Thing* thing)
 		--pos;
 	}
 
-	TileItemVector* items = getItemList();
+	const auto items = getItemList();
 	if (items && !isInserted) {
 		int32_t topItemSize = getTopItemCount();
 		if (pos < topItemSize) {
@@ -1065,8 +1023,7 @@ void Tile::replaceThing(uint32_t index, Thing* thing)
 		pos -= topItemSize;
 	}
 
-	CreatureVector* creatures = getCreatures();
-	if (creatures) {
+	if (const auto creatures = getCreatures()) {
 		if (!isInserted && pos < static_cast<int32_t>(creatures->size())) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
 		}
@@ -1086,7 +1043,7 @@ void Tile::replaceThing(uint32_t index, Thing* thing)
 	}
 
 	if (isInserted) {
-		item->setParent(this);
+		item->setParent(getTile());
 
 		resetTileFlags(oldItem);
 		setTileFlags(item);
@@ -1094,19 +1051,16 @@ void Tile::replaceThing(uint32_t index, Thing* thing)
 		const ItemType& newType = Item::items[item->getID()];
 		onUpdateTileItem(oldItem, oldType, item, newType);
 
-		oldItem->setParent(nullptr);
+		oldItem->clearParent();
 		return /*RETURNVALUE_NOERROR*/;
 	}
 }
 
-void Tile::removeThing(Thing* thing, uint32_t count)
+void Tile::removeThing(ThingPtr thing, uint32_t count)
 {
-	Creature* creature = thing->getCreature();
-	if (creature) {
-		CreatureVector* creatures = getCreatures();
-		if (creatures) {
-			auto it = std::find(creatures->begin(), creatures->end(), thing);
-			if (it != creatures->end()) {
+	if (const auto creature = thing->getCreature()) {
+		if (const auto creatures = getCreatures()) {
+			if (const auto it = std::ranges::find(*creatures, thing); it != creatures->end()) {
 				g_game.map.clearChunkSpectatorCache();
 
 				creatures->erase(it);
@@ -1115,18 +1069,18 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 		return;
 	}
 
-	Item* item = thing->getItem();
+	const auto item = thing->getItem();
 	if (!item) {
 		return;
 	}
 
-	int32_t index = getThingIndex(item);
+	const int32_t index = getThingIndex(item);
 	if (index == -1) {
 		return;
 	}
 
 	if (item == ground) {
-		ground->setParent(nullptr);
+		ground->clearParent();
 		ground = nullptr;
 
 		SpectatorVec spectators;
@@ -1135,14 +1089,14 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 		return;
 	}
 
-	TileItemVector* items = getItemList();
+	const auto items = getItemList();
 	if (!items) {
 		return;
 	}
 
 	const ItemType& itemType = Item::items[item->getID()];
 	if (itemType.alwaysOnTop) {
-		auto it = std::find(items->getBeginTopItem(), items->getEndTopItem(), item);
+		const auto it = std::find(items->getBeginTopItem(), items->getEndTopItem(), item);
 		if (it == items->getEndTopItem()) {
 			return;
 		}
@@ -1151,23 +1105,23 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 
 		SpectatorVec spectators;
 		g_game.map.getSpectators(spectators, getPosition(), true);
-		for (Creature* spectator : spectators) {
-			if (Player* spectatorPlayer = spectator->getPlayer()) {
+		for (const auto& spectator : spectators) {
+			if (const auto& spectatorPlayer = spectator->getPlayer()) {
 				oldStackPosVector.push_back(getStackposOfItem(spectatorPlayer, item));
 			}
 		}
 
-		item->setParent(nullptr);
+		item->clearParent();
 		items->erase(it);
 		onRemoveTileItem(spectators, oldStackPosVector, item);
 	} else {
-		auto it = std::find(items->getBeginDownItem(), items->getEndDownItem(), item);
+		const auto it = std::find(items->getBeginDownItem(), items->getEndDownItem(), item);
 		if (it == items->getEndDownItem()) {
 			return;
 		}
 
 		if (itemType.stackable && count != item->getItemCount()) {
-			uint8_t newCount = static_cast<uint8_t>(std::max<int32_t>(0, static_cast<int32_t>(item->getItemCount() - count)));
+			const uint8_t newCount = static_cast<uint8_t>(std::max<int32_t>(0, static_cast<int32_t>(item->getItemCount() - count)));
 			item->setItemCount(newCount);
 			onUpdateTileItem(item, itemType, item, itemType);
 		} else {
@@ -1175,13 +1129,13 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 
 			SpectatorVec spectators;
 			g_game.map.getSpectators(spectators, getPosition(), true);
-			for (Creature* spectator : spectators) {
-				if (Player* spectatorPlayer = spectator->getPlayer()) {
+			for (const auto& spectator : spectators) {
+				if (const auto& spectatorPlayer = spectator->getPlayer()) {
 					oldStackPosVector.push_back(getStackposOfItem(spectatorPlayer, item));
 				}
 			}
 
-			item->setParent(nullptr);
+			item->clearParent();
 			items->erase(it);
 			items->addDownItemCount(-1);
 			onRemoveTileItem(spectators, oldStackPosVector, item);
@@ -1189,21 +1143,21 @@ void Tile::removeThing(Thing* thing, uint32_t count)
 	}
 }
 
-bool Tile::hasCreature(Creature* creature) const
+bool Tile::hasCreature(CreaturePtr& creature)
 {
-	if (const CreatureVector* creatures = getCreatures()) {
-		return std::find(creatures->begin(), creatures->end(), creature) != creatures->end();
+	if (const auto& creatures = getCreatures()) {
+		return std::ranges::find(*creatures, creature) != creatures->end();
 	}
 	return false;
 }
 
-void Tile::removeCreature(Creature* creature)
+void Tile::removeCreature(CreaturePtr& creature)
 {
 	g_game.map.getQTNode(tilePos.x, tilePos.y)->removeCreature(creature);
 	removeThing(creature, 0);
 }
 
-int32_t Tile::getThingIndex(const Thing* thing) const
+int32_t Tile::getThingIndex(ThingPtr thing)
 {
 	int32_t n = -1;
 	if (ground) {
@@ -1213,10 +1167,9 @@ int32_t Tile::getThingIndex(const Thing* thing) const
 		++n;
 	}
 
-	const TileItemVector* items = getItemList();
+	const auto items = getItemList();
 	if (items) {
-		const Item* item = thing->getItem();
-		if (item && item->isAlwaysOnTop()) {
+		if (const auto& item = thing->getItem(); item && item->isAlwaysOnTop()) {
 			for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
 				++n;
 				if (*it == item) {
@@ -1228,9 +1181,9 @@ int32_t Tile::getThingIndex(const Thing* thing) const
 		}
 	}
 
-	if (const CreatureVector* creatures = getCreatures()) {
+	if (const auto& creatures = getCreatures()) {
 		if (thing->getCreature()) {
-			for (Creature* creature : *creatures) {
+			for (const auto& creature : *creatures) {
 				++n;
 				if (creature == thing) {
 					return n;
@@ -1242,7 +1195,7 @@ int32_t Tile::getThingIndex(const Thing* thing) const
 	}
 
 	if (items) {
-		const Item* item = thing->getItem();
+		const auto& item = thing->getItem();
 		if (item && !item->isAlwaysOnTop()) {
 			for (auto it = items->getBeginDownItem(), end = items->getEndDownItem(); it != end; ++it) {
 				++n;
@@ -1255,7 +1208,7 @@ int32_t Tile::getThingIndex(const Thing* thing) const
 	return -1;
 }
 
-int32_t Tile::getClientIndexOfCreature(const Player* player, const Creature* creature) const
+int32_t Tile::getClientIndexOfCreature(const PlayerConstPtr& player, const CreatureConstPtr& creature) const
 {
 	int32_t n;
 	if (ground) {
@@ -1264,13 +1217,12 @@ int32_t Tile::getClientIndexOfCreature(const Player* player, const Creature* cre
 		n = 0;
 	}
 
-	const TileItemVector* items = getItemList();
-	if (items) {
+	if (const auto& items = getItemList()) {
 		n += items->getTopItemCount();
 	}
 
-	if (const CreatureVector* creatures = getCreatures()) {
-		for (const Creature* c : boost::adaptors::reverse(*creatures)) {
+	if (const auto& creatures = getCreatures()) {
+		for (const auto& c : boost::adaptors::reverse(*creatures)) {
 			if (c == creature) {
 				return n;
 			} else if (player->canSeeCreature(c)) {
@@ -1281,7 +1233,7 @@ int32_t Tile::getClientIndexOfCreature(const Player* player, const Creature* cre
 	return -1;
 }
 
-int32_t Tile::getStackposOfItem(const Player* player, const Item* item) const
+int32_t Tile::getStackposOfItem(const PlayerConstPtr& player, const ItemConstPtr& item) const
 {
 	int32_t n = 0;
 	if (ground) {
@@ -1291,7 +1243,7 @@ int32_t Tile::getStackposOfItem(const Player* player, const Item* item) const
 		++n;
 	}
 
-	const TileItemVector* items = getItemList();
+	const auto& items = getItemList();
 	if (items) {
 		if (item->isAlwaysOnTop()) {
 			for (auto it = items->getBeginTopItem(), end = items->getEndTopItem(); it != end; ++it) {
@@ -1309,8 +1261,8 @@ int32_t Tile::getStackposOfItem(const Player* player, const Item* item) const
 		}
 	}
 
-	if (const CreatureVector* creatures = getCreatures()) {
-		for (const Creature* creature : *creatures) {
+	if (const auto& creatures = getCreatures()) {
+		for (const auto& creature : *creatures) {
 			if (player->canSeeCreature(creature)) {
 				if (++n >= 10) {
 					return -1;
@@ -1341,16 +1293,15 @@ size_t Tile::getLastIndex() const
 	return getThingCount();
 }
 
-uint32_t Tile::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/) const
+uint32_t Tile::getItemTypeCount(const uint16_t itemId, int32_t subType /*= -1*/) const
 {
 	uint32_t count = 0;
 	if (ground && ground->getID() == itemId) {
 		count += Item::countByType(ground, subType);
 	}
 
-	const TileItemVector* items = getItemList();
-	if (items) {
-		for (const Item* item : *items) {
+	if (const auto& items = getItemList()) {
+		for (const auto& item : *items) {
 			if (item->getID() == itemId) {
 				count += Item::countByType(item, subType);
 			}
@@ -1359,7 +1310,7 @@ uint32_t Tile::getItemTypeCount(uint16_t itemId, int32_t subType /*= -1*/) const
 	return count;
 }
 
-Thing* Tile::getThing(size_t index) const
+ThingPtr Tile::getThing(size_t index)
 {
 	if (ground) {
 		if (index == 0) {
@@ -1369,16 +1320,16 @@ Thing* Tile::getThing(size_t index) const
 		--index;
 	}
 
-	const TileItemVector* items = getItemList();
+	const auto& items = getItemList();
 	if (items) {
-		uint32_t topItemSize = items->getTopItemCount();
+		const uint32_t topItemSize = items->getTopItemCount();
 		if (index < topItemSize) {
 			return items->at(items->getDownItemCount() + index);
 		}
 		index -= topItemSize;
 	}
 
-	if (const CreatureVector* creatures = getCreatures()) {
+	if (const auto& creatures = getCreatures()) {
 		if (index < creatures->size()) {
 			return (*creatures)[index];
 		}
@@ -1391,105 +1342,83 @@ Thing* Tile::getThing(size_t index) const
 	return nullptr;
 }
 
-void Tile::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link /*= LINK_OWNER*/)
+void Tile::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link /*= LINK_OWNER*/)
 {
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), true, true);
-	for (Creature* spectator : spectators) {
-		assert(dynamic_cast<Player*>(spectator) != nullptr);
-		static_cast<Player*>(spectator)->postAddNotification(thing, oldParent, index, LINK_NEAR);
+	for (const auto& spectator : spectators) {
+		assert(std::dynamic_pointer_cast<Player>(spectator) != nullptr);
+		std::static_pointer_cast<Player>(spectator)->postAddNotification(thing, oldParent, index, LINK_NEAR);
 	}
 
 	//add a reference to this item, it may be deleted after being added (mailbox for example)
-	Creature* creature = thing->getCreature();
-	Item* item;
-	if (creature) {
-		creature->incrementReferenceCounter();
-		item = nullptr;
-	} else {
-		item = thing->getItem();
-		if (item) {
-			item->incrementReferenceCounter();
-		}
-	}
+	auto creature = thing->getCreature();
+	ItemPtr item = creature ? nullptr : thing->getItem();
 
 	if (link == LINK_OWNER) {
 		if (hasFlag(TILESTATE_TELEPORT)) {
-			Teleport* teleport = getTeleportItem();
-			if (teleport) {
+			if (const auto& teleport = getTeleportItem()) {
 				teleport->addThing(thing);
 			}
 		} else if (hasFlag(TILESTATE_TRASHHOLDER)) {
-			TrashHolder* trashholder = getTrashHolder();
-			if (trashholder) {
+			if (const auto& trashholder = getTrashHolder()) {
 				trashholder->addThing(thing);
 			}
 		} else if (hasFlag(TILESTATE_MAILBOX)) {
-			Mailbox* mailbox = getMailbox();
-			if (mailbox) {
+			if (const auto mailbox = getMailbox()) {
 				mailbox->addThing(thing);
 			}
 		}
 
 		//calling movement scripts
 		if (creature) {
-			g_moveEvents->onCreatureMove(creature, this, MOVE_EVENT_STEP_IN);
+			g_moveEvents->onCreatureMove(creature, getTile(), MOVE_EVENT_STEP_IN);
 		} else if (item) {
-			g_moveEvents->onItemMove(item, this, true);
+			TilePtr tile = item->getTile();
+			g_moveEvents->onItemMove(item, tile, true);
 		}
-	}
-
-	//release the reference to this item onces we are finished
-	if (creature) {
-		g_game.ReleaseCreature(creature);
-	} else if (item) {
-		g_game.ReleaseItem(item);
 	}
 }
 
-void Tile::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t)
+void Tile::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t)
 {
 	SpectatorVec spectators;
 	g_game.map.getSpectators(spectators, getPosition(), true, true);
-
 	if (getThingCount() > 8) {
 		onUpdateTile(spectators);
 	}
 
-	for (Creature* spectator : spectators) {
-		assert(dynamic_cast<Player*>(spectator) != nullptr);
-		static_cast<Player*>(spectator)->postRemoveNotification(thing, newParent, index, LINK_NEAR);
+	for (const auto& spectator : spectators) {
+		assert(std::dynamic_pointer_cast<Player>(spectator) != nullptr);
+		std::static_pointer_cast<Player>(spectator)->postRemoveNotification(thing, newParent, index, LINK_NEAR);
 	}
 
 	//calling movement scripts
-	Creature* creature = thing->getCreature();
-	if (creature) {
-		g_moveEvents->onCreatureMove(creature, this, MOVE_EVENT_STEP_OUT);
+	if (const auto& creature = thing->getCreature()) {
+		g_moveEvents->onCreatureMove(creature, getTile(), MOVE_EVENT_STEP_OUT);
 	} else {
-		Item* item = thing->getItem();
-		if (item) {
-			g_moveEvents->onItemMove(item, this, false);
+		if (const auto& item = thing->getItem()) {
+			g_moveEvents->onItemMove(item, getTile(), false);
 		}
 	}
 }
 
-void Tile::internalAddThing(Thing* thing)
+void Tile::internalAddThing(ThingPtr thing)
 {
 	internalAddThing(0, thing);
 }
 
-void Tile::internalAddThing(uint32_t, Thing* thing)
+void Tile::internalAddThing(uint32_t, ThingPtr thing)
 {
-	thing->setParent(this);
+	thing->setParent(getTile());
 
-	Creature* creature = thing->getCreature();
-	if (creature) {
+	if (const auto& creature = thing->getCreature()) {
 		g_game.map.clearChunkSpectatorCache();
 
-		CreatureVector* creatures = makeCreatures();
+		const auto& creatures = getCreatures();
 		creatures->insert(creatures->begin(), creature);
 	} else {
-		Item* item = thing->getItem();
+		const auto& item = thing->getItem();
 		if (item == nullptr) {
 			return;
 		}
@@ -1503,7 +1432,7 @@ void Tile::internalAddThing(uint32_t, Thing* thing)
 			return;
 		}
 
-		TileItemVector* items = makeItemList();
+		auto items = getItemList();
 		if (items->size() >= 0xFFFF) {
 			return /*RETURNVALUE_NOTPOSSIBLE*/;
 		}
@@ -1530,11 +1459,10 @@ void Tile::internalAddThing(uint32_t, Thing* thing)
 	}
 }
 
-void Tile::setTileFlags(const Item* item)
+void Tile::setTileFlags(const ItemConstPtr& item)
 {
 	if (!hasFlag(TILESTATE_FLOORCHANGE)) {
-		const ItemType& it = Item::items[item->getID()];
-		if (it.floorChange != 0) {
+		if (const ItemType& it = Item::items[item->getID()]; it.floorChange != 0) {
 			setFlag(it.floorChange);
 		}
 	}
@@ -1579,7 +1507,7 @@ void Tile::setTileFlags(const Item* item)
 		setFlag(TILESTATE_BED);
 	}
 
-	const Container* container = item->getContainer();
+	const auto& container = item->getContainer();
 	if (container && container->getDepotLocker()) {
 		setFlag(TILESTATE_DEPOT);
 	}
@@ -1589,10 +1517,9 @@ void Tile::setTileFlags(const Item* item)
 	}
 }
 
-void Tile::resetTileFlags(const Item* item)
+void Tile::resetTileFlags(const ItemPtr& item)
 {
-	const ItemType& it = Item::items[item->getID()];
-	if (it.floorChange != 0) {
+	if (const ItemType& it = Item::items[item->getID()]; it.floorChange != 0) {
 		resetFlag(TILESTATE_FLOORCHANGE);
 	}
 
@@ -1640,8 +1567,7 @@ void Tile::resetTileFlags(const Item* item)
 		resetFlag(TILESTATE_BED);
 	}
 
-	const Container* container = item->getContainer();
-	if (container && container->getDepotLocker()) {
+	if (const auto& container = item->getContainer(); container && container->getDepotLocker()) {
 		resetFlag(TILESTATE_DEPOT);
 	}
 
@@ -1655,32 +1581,30 @@ bool Tile::isMoveableBlocking() const
 	return !ground || hasFlag(TILESTATE_BLOCKSOLID);
 }
 
-Item* Tile::getUseItem(int32_t index) const
+ItemPtr Tile::getUseItem(const int32_t index)
 {
 	// no items, get ground
-	const TileItemVector* items = getItemList();
+	const auto& items = getItemList();
 	if (!items || items->size() == 0) {
 		return ground;
 	}
 
 	// try getting thing by index
-	if (Thing* thing = getThing(index)) {
-		Item* thingItem = thing->getItem();
-		if (thingItem) {
+	if (auto thing = getThing(index)) {
+		if (const auto& thingItem = thing->getItem()) {
 			return thingItem;
 		}
 	}
 
 	// try getting top usable item
-	Item* topDownItem = getTopDownItem();
-	if (topDownItem) {
+	if (const auto& topDownItem = getTopDownItem()) {
 		return topDownItem;
 	}
 
 	// try getting door
 	for (auto it = items->rbegin(), end = items->rend(); it != end; ++it) {
 		if ((*it)->getDoor()) {
-			return (*it)->getDoor();
+			return *it;
 		}
 	}
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -8,62 +8,7 @@
 #include "item.h"
 #include "tools.h"
 #include "spectators.h"
-
-class Creature;
-class Teleport;
-class TrashHolder;
-class Mailbox;
-class MagicField;
-class QTreeLeafNode;
-class BedItem;
-class TileItemVector;
-
-class Creature;
-using CreaturePtr = std::shared_ptr<Creature>;
-using CreatureConstPtr = std::shared_ptr<const Creature>;
-class Player;
-using PlayerPtr = std::shared_ptr<Player>;
-using PlayerConstPtr = std::shared_ptr<const Player>;
-class Monster;
-using MonsterPtr = std::shared_ptr<Monster>;
-using MonsterConstPtr = std::shared_ptr<const Monster>;
-class Npc;
-using NpcPtr = std::shared_ptr<Npc>;
-using NpcConstPtr = std::shared_ptr<const Npc>;
-
-using CreatureVector = std::vector<CreaturePtr>;
-using ItemVector = std::vector<ItemPtr>;
-
-using TileItemsPtr = std::shared_ptr<TileItemVector>;
-using TileItemsConstPtr = std::shared_ptr<const TileItemVector>;
-using TileCreaturesPtr = std::shared_ptr<CreatureVector>;
-using TileCreaturesConstPtr = std::shared_ptr<const CreatureVector>;
-
-class Depot;
-using DepotPtr = std::shared_ptr<Depot>;
-using DepotConstPtr = std::shared_ptr<const Depot>;
-class Teleport;
-using TeleportPtr = std::shared_ptr<Teleport>;
-using TeleportConstPtr = std::shared_ptr<const Teleport>;
-class TrashHolder;
-using TrashHolderPtr = std::shared_ptr<TrashHolder>;
-using TrashHolderConstPtr = std::shared_ptr<const TrashHolder>;
-
-using MailboxPtr = std::shared_ptr<Mailbox>;
-using MailboxConstPtr = std::shared_ptr<const Mailbox>;
-class Door;
-using DoorPtr = std::shared_ptr<Door>;
-using DoorConstPtr = std::shared_ptr<const Door>;
-
-using MagicFieldPtr = std::shared_ptr<MagicField>;
-using MagicFieldConstPtr = std::shared_ptr<const MagicField>;
-
-using BedItemPtr = std::shared_ptr<BedItem>;
-using BedItemConstPtr = std::shared_ptr<const BedItem>;
-
-class HouseTile;
-using HouseTilePtr = std::shared_ptr<HouseTile>;
-using HouseTileConstPtr = std::shared_ptr<const HouseTile>;
+#include "declarations.h"
 
 enum tileflags_t : uint32_t {
 	TILESTATE_NONE = 0,

--- a/src/tile.h
+++ b/src/tile.h
@@ -378,12 +378,12 @@ class StaticTile final : public Tile
 			return creatures;
 		}
 
-	void postAddNotification(ThingPtr, CylinderPtr, int32_t, cylinderlink_t) override {
-			
+	void postAddNotification(ThingPtr thing, CylinderPtr parent, int32_t index, cylinderlink_t link) override {
+			Tile::postAddNotification(thing, parent, index, link);
 		}
 
-	void postRemoveNotification(ThingPtr, CylinderPtr, int32_t, cylinderlink_t) override {
-			
+	void postRemoveNotification(ThingPtr thing, CylinderPtr parent, int32_t index, cylinderlink_t link) override {
+			Tile::postRemoveNotification(thing, parent, index, link);
 		}
 
 };

--- a/src/tile.h
+++ b/src/tile.h
@@ -273,7 +273,7 @@ class Tile : public Cylinder, public SharedObject
 			return ground;
 		}
 
-		std::shared_ptr<Tile> getTile() final {
+		TilePtr getTile() final {
 			return static_shared_this<Tile>();
 		}
 	

--- a/src/tile.h
+++ b/src/tile.h
@@ -230,7 +230,7 @@ class Tile : public Cylinder, public SharedObject
 		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count,
 				uint32_t& maxQueryCount, uint32_t flags) override final;
 		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
-		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem, uint32_t& flags) override; // another optional wrap ref
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem, uint32_t& flags) override; // another optional wrap ref
 
 		ReturnValue queryAdd(CreaturePtr creature, uint32_t flags);
 		ReturnValue queryAdd(ItemPtr item, uint32_t flags);

--- a/src/tile.h
+++ b/src/tile.h
@@ -16,9 +16,54 @@ class Mailbox;
 class MagicField;
 class QTreeLeafNode;
 class BedItem;
+class TileItemVector;
 
-using CreatureVector = std::vector<Creature*>;
-using ItemVector = std::vector<Item*>;
+class Creature;
+using CreaturePtr = std::shared_ptr<Creature>;
+using CreatureConstPtr = std::shared_ptr<const Creature>;
+class Player;
+using PlayerPtr = std::shared_ptr<Player>;
+using PlayerConstPtr = std::shared_ptr<const Player>;
+class Monster;
+using MonsterPtr = std::shared_ptr<Monster>;
+using MonsterConstPtr = std::shared_ptr<const Monster>;
+class Npc;
+using NpcPtr = std::shared_ptr<Npc>;
+using NpcConstPtr = std::shared_ptr<const Npc>;
+
+using CreatureVector = std::vector<CreaturePtr>;
+using ItemVector = std::vector<ItemPtr>;
+
+using TileItemsPtr = std::shared_ptr<TileItemVector>;
+using TileItemsConstPtr = std::shared_ptr<const TileItemVector>;
+using TileCreaturesPtr = std::shared_ptr<CreatureVector>;
+using TileCreaturesConstPtr = std::shared_ptr<const CreatureVector>;
+
+class Depot;
+using DepotPtr = std::shared_ptr<Depot>;
+using DepotConstPtr = std::shared_ptr<const Depot>;
+class Teleport;
+using TeleportPtr = std::shared_ptr<Teleport>;
+using TeleportConstPtr = std::shared_ptr<const Teleport>;
+class TrashHolder;
+using TrashHolderPtr = std::shared_ptr<TrashHolder>;
+using TrashHolderConstPtr = std::shared_ptr<const TrashHolder>;
+
+using MailboxPtr = std::shared_ptr<Mailbox>;
+using MailboxConstPtr = std::shared_ptr<const Mailbox>;
+class Door;
+using DoorPtr = std::shared_ptr<Door>;
+using DoorConstPtr = std::shared_ptr<const Door>;
+
+using MagicFieldPtr = std::shared_ptr<MagicField>;
+using MagicFieldConstPtr = std::shared_ptr<const MagicField>;
+
+using BedItemPtr = std::shared_ptr<BedItem>;
+using BedItemConstPtr = std::shared_ptr<const BedItem>;
+
+class HouseTile;
+using HouseTilePtr = std::shared_ptr<HouseTile>;
+using HouseTileConstPtr = std::shared_ptr<const HouseTile>;
 
 enum tileflags_t : uint32_t {
 	TILESTATE_NONE = 0,
@@ -59,7 +104,7 @@ enum ZoneType_t {
 	ZONE_NORMAL,
 };
 
-class TileItemVector : private ItemVector
+class TileItemVector : public ItemVector
 {
 	public:
 		using ItemVector::begin;
@@ -82,24 +127,31 @@ class TileItemVector : private ItemVector
 		iterator getBeginDownItem() {
 			return begin();
 		}
+	
 		const_iterator getBeginDownItem() const {
 			return begin();
 		}
+	
 		iterator getEndDownItem() {
 			return begin() + downItemCount;
 		}
+	
 		const_iterator getEndDownItem() const {
 			return begin() + downItemCount;
 		}
+	
 		iterator getBeginTopItem() {
 			return getEndDownItem();
 		}
+	
 		const_iterator getBeginTopItem() const {
 			return getEndDownItem();
 		}
+	
 		iterator getEndTopItem() {
 			return end();
 		}
+	
 		const_iterator getEndTopItem() const {
 			return end();
 		}
@@ -107,21 +159,25 @@ class TileItemVector : private ItemVector
 		uint32_t getTopItemCount() const {
 			return size() - downItemCount;
 		}
+	
 		uint32_t getDownItemCount() const {
 			return downItemCount;
 		}
-		inline Item* getTopTopItem() const {
+	
+		ItemPtr getTopTopItem() const {
 			if (getTopItemCount() == 0) {
 				return nullptr;
 			}
 			return *(getEndTopItem() - 1);
 		}
-		inline Item* getTopDownItem() const {
+	
+		ItemPtr getTopDownItem() const {
 			if (downItemCount == 0) {
 				return nullptr;
 			}
 			return *getBeginDownItem();
 		}
+	
 		void addDownItemCount(int32_t increment) {
 			downItemCount += increment;
 		}
@@ -130,49 +186,48 @@ class TileItemVector : private ItemVector
 		uint16_t downItemCount = 0;
 };
 
-class Tile : public Cylinder
+
+class Tile : public Cylinder, public SharedObject
 {
 	public:
-		static Tile& nullptr_tile;
 		Tile(uint16_t x, uint16_t y, uint8_t z) : tilePos(x, y, z) {}
 		virtual ~Tile() {
-			delete ground;
+			ground.reset();
 		};
 
 		// non-copyable
 		Tile(const Tile&) = delete;
 		Tile& operator=(const Tile&) = delete;
 
-		virtual TileItemVector* getItemList() = 0;
-		virtual const TileItemVector* getItemList() const = 0;
-		virtual TileItemVector* makeItemList() = 0;
+		virtual TileItemsPtr getItemList() = 0;
+		virtual TileItemsConstPtr getItemList() const = 0;
 
-		virtual CreatureVector* getCreatures() = 0;
-		virtual const CreatureVector* getCreatures() const = 0;
-		virtual CreatureVector* makeCreatures() = 0;
+		virtual TileCreaturesPtr getCreatures() = 0;
+		virtual TileCreaturesConstPtr getCreatures() const = 0;
 
 		int32_t getThrowRange() const override final {
 			return 0;
 		}
+	
 		bool isPushable() const override final {
 			return false;
 		}
 
-		MagicField* getFieldItem() const;
-		Teleport* getTeleportItem() const;
-		TrashHolder* getTrashHolder() const;
-		Mailbox* getMailbox() const;
-		BedItem* getBedItem() const;
+		MagicFieldPtr getFieldItem() const;
+		TeleportPtr getTeleportItem() const;
+		TrashHolderPtr getTrashHolder() const;
+		MailboxPtr getMailbox() const;
+		BedItemPtr getBedItem() const;
 
-		Creature* getTopCreature() const;
-		const Creature* getBottomCreature() const;
-		Creature* getTopVisibleCreature(const Creature* creature) const;
-		const Creature* getBottomVisibleCreature(const Creature* creature) const;
-		Item* getTopTopItem() const;
-		Item* getTopDownItem() const;
+		CreaturePtr getTopCreature() const;
+		CreatureConstPtr getBottomCreature() const;
+		CreaturePtr getTopVisibleCreature(const CreaturePtr creature) const;
+		CreatureConstPtr getBottomVisibleCreature(const CreatureConstPtr& creature) const;
+		ItemPtr getTopTopItem() const;
+		ItemPtr getTopDownItem() const;
 		bool isMoveableBlocking() const;
-		Thing* getTopVisibleThing(const Creature* creature);
-		Item* getItemByTopOrder(int32_t topOrder);
+		ThingPtr getTopVisibleThing(const CreaturePtr creature);
+		ItemPtr getItemByTopOrder(int32_t topOrder);
 
 		size_t getThingCount() const {
 			size_t thingCount = getCreatureCount() + getItemCount();
@@ -181,6 +236,7 @@ class Tile : public Cylinder
 			}
 			return thingCount;
 		}
+	
 		// If these return != 0 the associated vectors are guaranteed to exists
 		size_t getCreatureCount() const;
 		size_t getItemCount() const;
@@ -188,14 +244,16 @@ class Tile : public Cylinder
 		uint32_t getDownItemCount() const;
 
 		bool hasProperty(ITEMPROPERTY prop) const;
-		bool hasProperty(const Item* exclude, ITEMPROPERTY prop) const;
+		bool hasProperty(const ItemPtr& exclude, ITEMPROPERTY prop) const;
 
 		bool hasFlag(uint32_t flag) const {
-			return hasBitSet(flag, this->flags);
+			return hasBitSet(flag, flags);
 		}
+
 		void setFlag(uint32_t flag) {
 			this->flags |= flag;
 		}
+
 		void resetFlag(uint32_t flag) {
 			this->flags &= ~flag;
 		}
@@ -218,43 +276,43 @@ class Tile : public Cylinder
 
 		std::string getDescription(int32_t lookDistance) const override final;
 
-		int32_t getClientIndexOfCreature(const Player* player, const Creature* creature) const;
-		int32_t getStackposOfItem(const Player* player, const Item* item) const;
+		int32_t getClientIndexOfCreature(const PlayerConstPtr& player, const CreatureConstPtr& creature) const;
+		int32_t getStackposOfItem(const PlayerConstPtr& player, const ItemConstPtr& item) const;
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t flags, Creature* actor = nullptr) const override;
-		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count,
-				uint32_t& maxQueryCount, uint32_t flags) const override final;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
-		Tile* queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags) override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count,
+		                     uint32_t flags, CreaturePtr actor = nullptr) override;
+		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count,
+				uint32_t& maxQueryCount, uint32_t flags) override final;
+		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem, uint32_t& flags) override; // another optional wrap ref
 
-		ReturnValue queryAdd(const Creature& creature, uint32_t flags) const;
-		ReturnValue queryAdd(const Item& item, uint32_t flags) const;
-		ReturnValue queryAdd(const Player& player, uint32_t flags) const;
-		ReturnValue queryAdd(const Monster& monster, uint32_t flags) const;
+		ReturnValue queryAdd(CreaturePtr creature, uint32_t flags);
+		ReturnValue queryAdd(ItemPtr item, uint32_t flags);
+		ReturnValue queryAdd(PlayerPtr player, uint32_t flags);
+		ReturnValue queryAdd(MonsterPtr monster, uint32_t flags);
 
-		void addThing(Thing* thing) override final;
-		void addThing(int32_t index, Thing* thing) override;
+		void addThing(ThingPtr thing) override final;
+		void addThing(int32_t index, ThingPtr thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override final;
-		void replaceThing(uint32_t index, Thing* thing) override final;
+		void updateThing(ThingPtr thing, uint16_t itemId, uint32_t count) override final;
+		void replaceThing(uint32_t index, ThingPtr thing) override final;
 
-		void removeThing(Thing* thing, uint32_t count) override final;
-		bool hasCreature(Creature* creature) const;
-		void removeCreature(Creature* creature);
+		void removeThing(ThingPtr thing, uint32_t count) override final;
+		bool hasCreature(CreaturePtr& creature);
+		void removeCreature(CreaturePtr& creature);
 
-		int32_t getThingIndex(const Thing* thing) const override final;
+		int32_t getThingIndex(ThingPtr thing) override final;
 		size_t getFirstIndex() const override final;
 		size_t getLastIndex() const override final;
 		uint32_t getItemTypeCount(uint16_t itemId, int32_t subType = -1) const override final;
-		Thing* getThing(size_t index) const override final;
+		ThingPtr getThing(size_t index) override final;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override final;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override final;
+		void postAddNotification(ThingPtr thing,  CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(ThingPtr thing,  CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 
-		void internalAddThing(Thing* thing) override final;
-		void internalAddThing(uint32_t index, Thing* thing) override;
+		void internalAddThing(ThingPtr thing) override final;
+		void internalAddThing(uint32_t index, ThingPtr thing) override;
 
 		const Position& getPosition() const override final {
 			return tilePos;
@@ -264,25 +322,30 @@ class Tile : public Cylinder
 			return false;
 		}
 
-		Item* getUseItem(int32_t index) const;
+		ItemPtr getUseItem(int32_t index);
 
-		Item* getGround() const {
+		ItemPtr getGround() const {
 			return ground;
 		}
-		void setGround(Item* item) {
+
+		std::shared_ptr<Tile> getTile() final {
+			return static_shared_this<Tile>();
+		}
+	
+		void setGround(const ItemPtr& item) {
 			ground = item;
 		}
 
 	private:
-		void onAddTileItem(Item* item);
-		void onUpdateTileItem(Item* oldItem, const ItemType& oldType, Item* newItem, const ItemType& newType);
-		void onRemoveTileItem(const SpectatorVec& spectators, const std::vector<int32_t>& oldStackPosVector, Item* item);
+		void onAddTileItem(ItemPtr& item);
+		void onUpdateTileItem(const ItemPtr& oldItem, const ItemType& oldType, const ItemPtr& newItem, const ItemType& newType);
+		void onRemoveTileItem(const SpectatorVec& spectators, const std::vector<int32_t>& oldStackPosVector, const ItemPtr& item);
 		void onUpdateTile(const SpectatorVec& spectators);
 
-		void setTileFlags(const Item* item);
-		void resetTileFlags(const Item* item);
+		void setTileFlags(const ItemConstPtr& item);
+		void resetTileFlags(const ItemPtr& item);
 
-		Item* ground = nullptr;
+		ItemPtr ground = nullptr;
 		Position tilePos;
 		uint32_t flags = 0;
 };
@@ -291,56 +354,61 @@ class Tile : public Cylinder
 // items being added/removed
 class DynamicTile : public Tile
 {
-		// By allocating the vectors in-house, we avoid some memory fragmentation
-		TileItemVector items;
-		CreatureVector creatures;
+	TileItemsPtr items;
+	TileCreaturesPtr creatures;
 
-	public:
-		DynamicTile(uint16_t x, uint16_t y, uint8_t z) : Tile(x, y, z) {}
-		~DynamicTile() {
-			for (Item* item : items) {
-				item->decrementReferenceCounter();
-			}
-		}
+public:
+	DynamicTile(uint16_t x, uint16_t y, uint8_t z) : Tile(x, y, z)
+	{
+		items = std::make_shared<TileItemVector>();
+		creatures = std::make_shared<CreatureVector>();
+	}
 
-		// non-copyable
-		DynamicTile(const DynamicTile&) = delete;
-		DynamicTile& operator=(const DynamicTile&) = delete;
+	~DynamicTile() {
+		for (auto& item : *items) {
+			item.reset();
+		}
+	}
 
-		TileItemVector* getItemList() override {
-			return &items;
-		}
-		const TileItemVector* getItemList() const override {
-			return &items;
-		}
-		TileItemVector* makeItemList() override {
-			return &items;
-		}
+	// non-copyable
+	DynamicTile(const DynamicTile&) = delete;
+	DynamicTile& operator=(const DynamicTile&) = delete;
 
-		CreatureVector* getCreatures() override {
-			return &creatures;
-		}
-		const CreatureVector* getCreatures() const override {
-			return &creatures;
-		}
-		CreatureVector* makeCreatures() override {
-			return &creatures;
-		}
+	TileItemsPtr getItemList() override {
+		return items;
+	}
+
+	TileItemsConstPtr getItemList() const override {
+		return items;
+	}
+
+	TileCreaturesPtr getCreatures() override {
+		return creatures;
+	}
+
+
+	TileCreaturesConstPtr getCreatures() const override {
+		return creatures;
+	}
 };
 
 // For blocking tiles, where we very rarely actually have items
 class StaticTile final : public Tile
 {
-	// We very rarely even need the vectors, so don't keep them in memory
-	std::unique_ptr<TileItemVector> items;
-	std::unique_ptr<CreatureVector> creatures;
+	TileItemsPtr items;
+	TileCreaturesPtr creatures;
 
 	public:
-		StaticTile(uint16_t x, uint16_t y, uint8_t z) : Tile(x, y, z) {}
+		StaticTile(uint16_t x, uint16_t y, uint8_t z) : Tile(x, y, z) 
+		{
+			items = std::make_shared<TileItemVector>();
+			creatures = std::make_shared<CreatureVector>();
+		}
+
 		~StaticTile() {
 			if (items) {
-				for (Item* item : *items) {
-					item->decrementReferenceCounter();
+				for (auto& item : *items) {
+					item.reset();
 				}
 			}
 		}
@@ -349,31 +417,30 @@ class StaticTile final : public Tile
 		StaticTile(const StaticTile&) = delete;
 		StaticTile& operator=(const StaticTile&) = delete;
 
-		TileItemVector* getItemList() override {
-			return items.get();
+		TileItemsPtr getItemList() override {
+			return items;
 		}
-		const TileItemVector* getItemList() const override {
-			return items.get();
+	
+		TileItemsConstPtr getItemList() const override {
+			return items;
 		}
-		TileItemVector* makeItemList() override {
-			if (!items) {
-				items.reset(new TileItemVector);
-			}
-			return items.get();
+	
+		TileCreaturesPtr getCreatures() override {
+			return creatures;
+		}
+	
+		TileCreaturesConstPtr getCreatures() const override {
+			return creatures;
 		}
 
-		CreatureVector* getCreatures() override {
-			return creatures.get();
+	void postAddNotification(ThingPtr, CylinderPtr, int32_t, cylinderlink_t) override {
+			
 		}
-		const CreatureVector* getCreatures() const override {
-			return creatures.get();
+
+	void postRemoveNotification(ThingPtr, CylinderPtr, int32_t, cylinderlink_t) override {
+			
 		}
-		CreatureVector* makeCreatures() override {
-			if (!creatures) {
-				creatures.reset(new CreatureVector);
-			}
-			return creatures.get();
-		}
+
 };
 
 #endif

--- a/src/trashholder.cpp
+++ b/src/trashholder.cpp
@@ -24,7 +24,7 @@ ReturnValue TrashHolder::queryRemove(const ThingPtr&, uint32_t, uint32_t, Creatu
 	return RETURNVALUE_NOTPOSSIBLE;
 }
 
-CylinderPtr TrashHolder::queryDestination(int32_t&, const ThingPtr&, ItemPtr*, uint32_t&)
+CylinderPtr TrashHolder::queryDestination(int32_t&, const ThingPtr&, ItemPtr&, uint32_t&)
 {
 	return CylinderPtr(this);
 }

--- a/src/trashholder.cpp
+++ b/src/trashholder.cpp
@@ -8,46 +8,46 @@
 
 extern Game g_game;
 
-ReturnValue TrashHolder::queryAdd(int32_t, const Thing&, uint32_t, uint32_t, Creature*) const
+ReturnValue TrashHolder::queryAdd(int32_t, const ThingPtr&, uint32_t, uint32_t, CreaturePtr)
 {
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue TrashHolder::queryMaxCount(int32_t, const Thing&, uint32_t count, uint32_t& maxQueryCount, uint32_t) const
+ReturnValue TrashHolder::queryMaxCount(int32_t, const ThingPtr&, uint32_t count, uint32_t& maxQueryCount, uint32_t)
 {
 	maxQueryCount = std::max<uint32_t>(1, count);
 	return RETURNVALUE_NOERROR;
 }
 
-ReturnValue TrashHolder::queryRemove(const Thing&, uint32_t, uint32_t, Creature* /*= nullptr*/) const
+ReturnValue TrashHolder::queryRemove(const ThingPtr&, uint32_t, uint32_t, CreaturePtr /*= nullptr*/)
 {
 	return RETURNVALUE_NOTPOSSIBLE;
 }
 
-Cylinder* TrashHolder::queryDestination(int32_t&, const Thing&, Item**, uint32_t&)
+CylinderPtr TrashHolder::queryDestination(int32_t&, const ThingPtr&, ItemPtr*, uint32_t&)
 {
-	return this;
+	return CylinderPtr(this);
 }
 
-void TrashHolder::addThing(Thing* thing)
+void TrashHolder::addThing(ThingPtr thing)
 {
 	return addThing(0, thing);
 }
 
-void TrashHolder::addThing(int32_t, Thing* thing)
+void TrashHolder::addThing(int32_t, ThingPtr thing)
 {
-	Item* item = thing->getItem();
+	const auto& item = thing->getItem();
 	if (!item) {
 		return;
 	}
 
-	if (item == this || !item->hasProperty(CONST_PROP_MOVEABLE)) {
+	if (item == this->getItem() || !item->hasProperty(CONST_PROP_MOVEABLE)) {
 		return;
 	}
 
 	const ItemType& it = Item::items[id];
 	if (item->isHangable() && it.isGroundTile()) {
-		Tile* tile = dynamic_cast<Tile*>(getParent());
+		const auto& tile = std::dynamic_pointer_cast<Tile>(getParent());
 		if (tile && tile->hasFlag(TILESTATE_SUPPORTS_HANGABLE)) {
 			return;
 		}
@@ -60,27 +60,31 @@ void TrashHolder::addThing(int32_t, Thing* thing)
 	}
 }
 
-void TrashHolder::updateThing(Thing*, uint16_t, uint32_t)
+void TrashHolder::updateThing(ThingPtr, uint16_t, uint32_t)
 {
 	//
 }
 
-void TrashHolder::replaceThing(uint32_t, Thing*)
+void TrashHolder::replaceThing(uint32_t, ThingPtr)
 {
 	//
 }
 
-void TrashHolder::removeThing(Thing*, uint32_t)
+void TrashHolder::removeThing(ThingPtr, uint32_t)
 {
 	//
 }
 
-void TrashHolder::postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t)
+void TrashHolder::postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t)
 {
-	getParent()->postAddNotification(thing, oldParent, index, LINK_PARENT);
+	if (parent.lock()) {
+		parent.lock()->postAddNotification(thing, oldParent, index, LINK_PARENT);
+	}
 }
 
-void TrashHolder::postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t)
+void TrashHolder::postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t)
 {
-	getParent()->postRemoveNotification(thing, newParent, index, LINK_PARENT);
+	if (parent.lock()) {
+		parent.lock()->postRemoveNotification(thing, newParent, index, LINK_PARENT);
+	}
 }

--- a/src/trashholder.h
+++ b/src/trashholder.h
@@ -13,29 +13,30 @@ class TrashHolder final : public Item, public Cylinder
 	public:
 		explicit TrashHolder(uint16_t itemId) : Item(itemId) {}
 
-		TrashHolder* getTrashHolder() override {
-			return this;
+		TrashHolderPtr getTrashHolder() override {
+			return dynamic_shared_this<TrashHolder>();
 		}
-		const TrashHolder* getTrashHolder() const override {
-			return this;
+	
+		TrashHolderConstPtr getTrashHolder() const override {
+			return dynamic_shared_this<const TrashHolder>();
 		}
 
 		//cylinder implementations
-		ReturnValue queryAdd(int32_t index, const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
-		ReturnValue queryMaxCount(int32_t index, const Thing& thing, uint32_t count, uint32_t& maxQueryCount, uint32_t flags) const override;
-		ReturnValue queryRemove(const Thing& thing, uint32_t count, uint32_t flags, Creature* actor = nullptr) const override;
-		Cylinder* queryDestination(int32_t& index, const Thing& thing, Item** destItem, uint32_t& flags) override;
+		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
+		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t& maxQueryCount, uint32_t flags) override;
+		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem, uint32_t& flags) override; // another place to put a ref wrapper or optional or both
 
-		void addThing(Thing* thing) override;
-		void addThing(int32_t index, Thing* thing) override;
+		void addThing(ThingPtr thing) override;
+		void addThing(int32_t index, ThingPtr thing) override;
 
-		void updateThing(Thing* thing, uint16_t itemId, uint32_t count) override;
-		void replaceThing(uint32_t index, Thing* thing) override;
+		void updateThing(ThingPtr thing, uint16_t itemId, uint32_t count) override;
+		void replaceThing(uint32_t index, ThingPtr thing) override;
 
-		void removeThing(Thing* thing, uint32_t count) override;
+		void removeThing(ThingPtr thing, uint32_t count) override;
 
-		void postAddNotification(Thing* thing, const Cylinder* oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
-		void postRemoveNotification(Thing* thing, const Cylinder* newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postAddNotification(ThingPtr thing, CylinderPtr oldParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
+		void postRemoveNotification(ThingPtr thing, CylinderPtr newParent, int32_t index, cylinderlink_t link = LINK_OWNER) override;
 };
 
 #endif

--- a/src/trashholder.h
+++ b/src/trashholder.h
@@ -25,7 +25,7 @@ class TrashHolder final : public Item, public Cylinder
 		ReturnValue queryAdd(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
 		ReturnValue queryMaxCount(int32_t index, const ThingPtr& thing, uint32_t count, uint32_t& maxQueryCount, uint32_t flags) override;
 		ReturnValue queryRemove(const ThingPtr& thing, uint32_t count, uint32_t flags, CreaturePtr actor = nullptr) override;
-		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr* destItem, uint32_t& flags) override; // another place to put a ref wrapper or optional or both
+		CylinderPtr queryDestination(int32_t& index, const ThingPtr& thing, ItemPtr& destItem, uint32_t& flags) override; // another place to put a ref wrapper or optional or both
 
 		void addThing(ThingPtr thing) override;
 		void addThing(int32_t index, ThingPtr thing) override;

--- a/src/vocation.cpp
+++ b/src/vocation.cpp
@@ -151,7 +151,7 @@ uint16_t Vocations::getPromotedVocation(uint16_t id) const
 
 static const uint32_t skillBase[SKILL_LAST + 1] = {50, 50, 50, 50, 30, 100, 20};
 
-uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
+uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level) const
 {
 	if (skill > SKILL_LAST) {
 		return 0;
@@ -159,7 +159,7 @@ uint64_t Vocation::getReqSkillTries(uint8_t skill, uint16_t level)
 	return skillBase[skill] * std::pow(skillMultipliers[skill], static_cast<int32_t>(level - (MINIMUM_SKILL_LEVEL + 1)));
 }
 
-uint64_t Vocation::getReqMana(uint32_t magLevel)
+uint64_t Vocation::getReqMana(uint32_t magLevel) const
 {
 	if (magLevel == 0) {
 		return 0;

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -15,11 +15,13 @@ class Vocation
 		const std::string& getVocName() const {
 			return name;
 		}
+	
 		const std::string& getVocDescription() const {
 			return description;
 		}
-		uint64_t getReqSkillTries(uint8_t skill, uint16_t level);
-		uint64_t getReqMana(uint32_t magLevel);
+	
+		uint64_t getReqSkillTries(uint8_t skill, uint16_t level) const;
+		uint64_t getReqMana(uint32_t magLevel) const;
 
 		uint16_t getId() const {
 			return id;
@@ -32,9 +34,11 @@ class Vocation
 		uint32_t getHPGain() const {
 			return gainHP;
 		}
+	
 		uint32_t getManaGain() const {
 			return gainMana;
 		}
+	
 		uint32_t getCapGain() const {
 			return gainCap;
 		}
@@ -42,12 +46,15 @@ class Vocation
 		uint32_t getManaGainTicks() const {
 			return gainManaTicks;
 		}
+	
 		uint32_t getManaGainAmount() const {
 			return gainManaAmount;
 		}
+	
 		uint32_t getHealthGainTicks() const {
 			return gainHealthTicks;
 		}
+	
 		uint32_t getHealthGainAmount() const {
 			return gainHealthAmount;
 		}
@@ -55,6 +62,7 @@ class Vocation
 		uint8_t getSoulMax() const {
 			return soulMax;
 		}
+	
 		uint16_t getSoulGainTicks() const {
 			return gainSoulTicks;
 		}
@@ -62,6 +70,7 @@ class Vocation
 		uint32_t getAttackSpeed() const {
 			return attackSpeed;
 		}
+	
 		uint32_t getBaseSpeed() const {
 			return baseSpeed;
 		}

--- a/src/weapons.cpp
+++ b/src/weapons.cpp
@@ -455,7 +455,7 @@ void Weapon::onUsedWeapon(const PlayerPtr& player, const ItemPtr& item, const Ti
 		}
 
 		case WEAPONACTION_MOVE:
-			g_game.internalMoveItem(f_holder, t_holder, INDEX_WHEREEVER, item, 1, nullptr, FLAG_NOLIMIT);
+			g_game.internalMoveItem(f_holder, t_holder, INDEX_WHEREEVER, item, 1, std::nullopt, FLAG_NOLIMIT);
 			break;
 
 		default:

--- a/src/weapons.h
+++ b/src/weapons.h
@@ -30,7 +30,7 @@ class Weapons final : public BaseEvents
 		Weapons& operator=(const Weapons&) = delete;
 
 		void loadDefaults();
-		const Weapon* getWeapon(const Item* item) const;
+		const Weapon* getWeapon(const ItemConstPtr& item) const;
 
 		static int32_t getMaxMeleeDamage(int32_t attackSkill, int32_t attackValue);
 		static int32_t getMaxWeaponDamage(uint32_t level, int32_t attackSkill, int32_t attackValue, float attackFactor);
@@ -62,19 +62,20 @@ class Weapon : public Event
 		virtual bool interruptSwing() const {
 			return false;
 		}
-		bool ammoCheck(const Player* player) const;
+		bool ammoCheck(const PlayerConstPtr& player) const;
 
-		int32_t playerWeaponCheck(Player* player, Creature* target, uint8_t shootRange) const;
-		static bool useFist(Player* player, Creature* target);
-		virtual bool useWeapon(Player* player, Item* item, Creature* target) const;
+		int32_t playerWeaponCheck(const PlayerConstPtr& player,const CreatureConstPtr& target, uint8_t shootRange) const;
+		static bool useFist(const PlayerPtr& player, const CreaturePtr& target);
+		virtual bool useWeapon(PlayerPtr player, ItemPtr item, CreaturePtr target) const;
 
-		virtual int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const = 0;
-		virtual int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const = 0;
+		virtual int32_t getWeaponDamage(const PlayerConstPtr& player, const CreatureConstPtr& target, const ItemConstPtr& item, bool maxDamage = false) const = 0;
+		virtual int32_t getElementDamage(const PlayerConstPtr& player, const CreatureConstPtr& target, const ItemConstPtr& item) const = 0;
 		virtual CombatType_t getElementType() const = 0;
 
 		uint16_t getID() const {
 			return id;
 		}
+	
 		void setID(uint16_t newId) {
 			id = newId;
 		}
@@ -82,6 +83,7 @@ class Weapon : public Event
 		uint32_t getReqLevel() const {
 			return level;
 		}
+	
 		void setRequiredLevel(uint32_t reqlvl) {
 			level = reqlvl;
 		}
@@ -89,6 +91,7 @@ class Weapon : public Event
 		uint32_t getReqMagLv() const {
 			return magLevel;
 		}
+	
 		void setRequiredMagLevel(uint32_t reqlvl) {
 			magLevel = reqlvl;
 		}
@@ -96,6 +99,7 @@ class Weapon : public Event
 		bool isPremium() const {
 			return premium;
 		}
+	
 		void setNeedPremium(bool prem) {
 			premium = prem;
 		}
@@ -103,6 +107,7 @@ class Weapon : public Event
 		bool isWieldedUnproperly() const {
 			return wieldUnproperly;
 		}
+	
 		void setWieldUnproperly(bool unproperly) {
 			wieldUnproperly = unproperly;
 		}
@@ -110,6 +115,7 @@ class Weapon : public Event
 		uint32_t getMana() const {
 			return mana;
 		}
+	
 		void setMana(uint32_t m) {
 			mana = m;
 		}
@@ -117,6 +123,7 @@ class Weapon : public Event
 		uint32_t getManaPercent() const {
 			return manaPercent;
 		}
+	
 		void setManaPercent(uint32_t m) {
 			manaPercent = m;
 		}
@@ -124,6 +131,7 @@ class Weapon : public Event
 		int32_t getHealth() const {
 			return health;
 		}
+	
 		void setHealth(int32_t h) {
 			health = h;
 		}
@@ -131,6 +139,7 @@ class Weapon : public Event
 		uint32_t getHealthPercent() const {
 			return healthPercent;
 		}
+	
 		void setHealthPercent(uint32_t m) {
 			healthPercent = m;
 		}
@@ -138,6 +147,7 @@ class Weapon : public Event
 		uint32_t getSoul() const {
 			return soul;
 		}
+	
 		void setSoul(uint32_t s) {
 			soul = s;
 		}
@@ -145,6 +155,7 @@ class Weapon : public Event
 		uint8_t getBreakChance() const {
 			return breakChance;
 		}
+	
 		void setBreakChance(uint8_t b) {
 			breakChance = b;
 		}
@@ -152,6 +163,7 @@ class Weapon : public Event
 		bool isEnabled() const {
 			return enabled;
 		}
+	
 		void setIsEnabled(bool e) {
 			enabled = e;
 		}
@@ -159,11 +171,12 @@ class Weapon : public Event
 		uint32_t getWieldInfo() const {
 			return wieldInfo;
 		}
+	
 		void setWieldInfo(uint32_t info) {
 			wieldInfo |= info;
 		}
 
-		void addVocWeaponMap(std::string vocName) {
+		void addVocWeaponMap(const std::string& vocName) {
 			int32_t vocationId = g_vocations.getVocationId(vocName);
 			if (vocationId != -1) {
 				vocWeaponMap[vocationId] = true;
@@ -173,6 +186,7 @@ class Weapon : public Event
 		const std::string& getVocationString() const {
 			return vocationString;
 		}
+	
 		void setVocationString(const std::string& str) {
 			vocationString = str;
 		}
@@ -183,18 +197,18 @@ class Weapon : public Event
 		std::map<uint16_t, bool> vocWeaponMap;
 
 	protected:
-		void internalUseWeapon(Player* player, Item* item, Creature* target, int32_t damageModifier) const;
-		void internalUseWeapon(Player* player, Item* item, Tile* tile) const;
+		void internalUseWeapon(const PlayerPtr& player, const ItemPtr& item, const CreaturePtr& target, int32_t damageModifier) const;
+		void internalUseWeapon(const PlayerPtr& player, const ItemPtr& item, const TilePtr& tile) const;
 
 		uint16_t id = 0;
 
 	private:
-		virtual bool getSkillType(const Player*, const Item*, skills_t&, uint32_t&) const {
+		virtual bool getSkillType(const PlayerConstPtr&, const ItemConstPtr&, skills_t&, uint32_t&) const {
 			return false;
 		}
 
-		uint32_t getManaCost(const Player* player) const;
-		int32_t getHealthCost(const Player* player) const;
+		uint32_t getManaCost(const PlayerConstPtr& player) const;
+		int32_t getHealthCost(const PlayerConstPtr& player) const;
 
 		uint32_t level = 0;
 		uint32_t magLevel = 0;
@@ -212,10 +226,10 @@ class Weapon : public Event
 
 		std::string_view getScriptEventName() const override final { return "onUseWeapon"; }
 
-		bool executeUseWeapon(Player* player, const LuaVariant& var) const;
-		void onUsedWeapon(Player* player, Item* item, Tile* destTile) const;
+		bool executeUseWeapon(const PlayerPtr& player, const LuaVariant& var) const;
+		void onUsedWeapon(const PlayerPtr& player, const ItemPtr& item, const TilePtr& destTile) const;
 
-		static void decrementItemCount(Item* item);
+		static void decrementItemCount(const ItemPtr& item);
 
 		friend class Combat;
 };
@@ -227,14 +241,14 @@ class WeaponMelee final : public Weapon
 
 		void configureWeapon(const ItemType& it) override;
 
-		bool useWeapon(Player* player, Item* item, Creature* target) const override;
+		bool useWeapon(const PlayerPtr player, const ItemPtr item, const CreaturePtr target) const override;
 
-		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const override;
-		int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const override;
+		int32_t getWeaponDamage(const PlayerConstPtr& player, const CreatureConstPtr& target, const ItemConstPtr& item, bool maxDamage = false) const override;
+		int32_t getElementDamage(const PlayerConstPtr& player, const CreatureConstPtr& target, const ItemConstPtr& item) const override;
 		CombatType_t getElementType() const override { return elementType; }
 
 	private:
-		bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const override;
+		bool getSkillType(const PlayerConstPtr& player, const ItemConstPtr& item, skills_t& skill, uint32_t& skillpoint) const override;
 
 		CombatType_t elementType = COMBAT_NONE;
 		uint16_t elementDamage = 0;
@@ -250,14 +264,14 @@ class WeaponDistance final : public Weapon
 			return true;
 		}
 
-		bool useWeapon(Player* player, Item* item, Creature* target) const override;
+		bool useWeapon(PlayerPtr player, ItemPtr item, CreaturePtr target) const override;
 
-		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const override;
-		int32_t getElementDamage(const Player* player, const Creature* target, const Item* item) const override;
+		int32_t getWeaponDamage(const PlayerConstPtr& player, const CreatureConstPtr& target, const ItemConstPtr& item, bool maxDamage = false) const override;
+		int32_t getElementDamage(const PlayerConstPtr& player, const CreatureConstPtr& target, const ItemConstPtr& item) const override;
 		CombatType_t getElementType() const override { return elementType; }
 
 	private:
-		bool getSkillType(const Player* player, const Item* item, skills_t& skill, uint32_t& skillpoint) const override;
+		bool getSkillType(const PlayerConstPtr& player, const ItemConstPtr& item, skills_t& skill, uint32_t& skillpoint) const override;
 
 		CombatType_t elementType = COMBAT_NONE;
 		uint16_t elementDamage = 0;
@@ -271,8 +285,8 @@ class WeaponWand final : public Weapon
 		bool configureEvent(const pugi::xml_node& node) override;
 		void configureWeapon(const ItemType& it) override;
 
-		int32_t getWeaponDamage(const Player* player, const Creature* target, const Item* item, bool maxDamage = false) const override;
-		int32_t getElementDamage(const Player*, const Creature*, const Item*) const override { return 0; }
+		int32_t getWeaponDamage(const PlayerConstPtr& player, const CreatureConstPtr& target, const ItemConstPtr& item, bool maxDamage = false) const override;
+		int32_t getElementDamage(const PlayerConstPtr&, const CreatureConstPtr&, const ItemConstPtr&) const override { return 0; }
 		CombatType_t getElementType() const override { return COMBAT_NONE; }
 
 		void setMinChange(int32_t change) {
@@ -284,7 +298,7 @@ class WeaponWand final : public Weapon
 		}
 
 	private:
-		bool getSkillType(const Player*, const Item*, skills_t&, uint32_t&) const override {
+		bool getSkillType(const PlayerConstPtr&, const ItemConstPtr&, skills_t&, uint32_t&) const override {
 			return false;
 		}
 


### PR DESCRIPTION
This PR removes the manual references and raw pointers that the Thing class and all the classes that inherit from thing suchas (but not limited to) item, player, monster, tile, ect, and replaces them with the usage of the std::shared_ptr. Along the way I did quite a bit of optimizing with const, pass by ref, views, ranges, ect. There are still many places that I would like to improve, such as the get methods, I would like to be using static casts when going up, dynamic when going down and alias constructors on the call on the class that is itself, if that makes any sense to you all. All in all its ready for merger, it's not perfect but this is a massive step in the right direction. 