### PR TITLE
Small Refactor of Combat Event Handling

### DIFF
--- a/src/bed.cpp
+++ b/src/bed.cpp
@@ -218,8 +218,11 @@ void BedItem::regeneratePlayer(const PlayerPtr& player) const
 			regen = sleptTime / 30;
 		}
 
-		player->changeHealth(regen, false);
-		player->changeMana(regen);
+		CombatDamage statchange;
+		statchange.primary.value = static_cast<int32_t>(regen);
+		statchange.primary.type = COMBAT_HEALING;
+		g_game.combatChangeMana(nullptr, player, statchange);
+		g_game.combatChangeHealth(nullptr, player, statchange);
 	}
 
 	const int32_t soulRegen = sleptTime / (60 * 15);

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -880,69 +880,20 @@ bool ConditionRegeneration::executeCondition(const CreaturePtr creature, int32_t
 
 	if (internalHealthTicks >= healthTicks) {
 		internalHealthTicks = 0;
-
-		int32_t realHealthGain = creature->getHealth();
-		creature->changeHealth(healthGain);
-		realHealthGain = creature->getHealth() - realHealthGain;
-
-		if (isBuff && realHealthGain > 0) {
-			if (const auto player = creature->getPlayer()) {
-				std::string healString = std::to_string(realHealthGain) + (realHealthGain != 1 ? " hitpoints." : " hitpoint.");
-
-				TextMessage message(MESSAGE_HEALED, "You were healed for " + healString);
-				message.position = player->getPosition();
-				message.primary.value = realHealthGain;
-				message.primary.color = TEXTCOLOR_MAYABLUE;
-				player->sendTextMessage(message);
-
-				SpectatorVec spectators;
-				g_game.map.getSpectators(spectators, player->getPosition(), false, true);
-				spectators.erase(player);
-				if (!spectators.empty()) {
-					message.type = MESSAGE_HEALED_OTHERS;
-					message.text = player->getName() + " was healed for " + healString;
-					for (auto spectator : spectators) {
-						if (auto t_player = spectator->getPlayer())
-						{
-							t_player->sendTextMessage(message);
-						}
-					}
-				}
-			}
-		}
+		CombatDamage regen;
+		regen.primary.value = static_cast<int32_t>(healthGain);
+		regen.primary.type = COMBAT_HEALING;
+		g_game.combatChangeHealth(nullptr, creature, regen);
 	}
 
 	if (internalManaTicks >= manaTicks) {
 		internalManaTicks = 0;
 
 		if (auto player = creature->getPlayer()) {
-			int32_t realManaGain = player->getMana();
-			player->changeMana(manaGain);
-			realManaGain = player->getMana() - realManaGain;
-
-			if (isBuff && realManaGain > 0) {
-				std::string manaGainString = std::to_string(realManaGain);
-
-				TextMessage message(MESSAGE_HEALED, "You gained " + manaGainString + " mana.");
-				message.position = player->getPosition();
-				message.primary.value = realManaGain;
-				message.primary.color = TEXTCOLOR_MAYABLUE;
-				player->sendTextMessage(message);
-
-				SpectatorVec spectators;
-				g_game.map.getSpectators(spectators, player->getPosition(), false, true);
-				spectators.erase(player);
-				if (!spectators.empty()) {
-					message.type = MESSAGE_HEALED_OTHERS;
-					message.text = player->getName() + " gained " + manaGainString + " mana.";
-					for (auto spectator : spectators) {
-						if (auto t_player = spectator->getPlayer())
-						{
-							t_player->sendTextMessage(message);
-						}
-					}
-				}
-			}
+			CombatDamage regen;
+			regen.primary.value = static_cast<int32_t>(manaGain);
+			regen.primary.type = COMBAT_HEALING;
+			g_game.combatChangeMana(nullptr, player, regen);
 		}
 	}
 

--- a/src/damagemodifier.h
+++ b/src/damagemodifier.h
@@ -1,7 +1,7 @@
 // Credits: BlackTek Server Creator Codinablack@github.com.
 // This project is based of otland's The Forgottenserver.
 // Any and all code taken from otland's The Forgottenserver is licensed under GPL 2.0
-// Any code Authored by: Codinablack or BlackTek contributers, that is not already licensed, is hereby licesned MIT. 
+// Any code Authored by: Codinablack or BlackTek contributers, that is not already licensed, is hereby licensed MIT. 
 // The GPL 2.0 License that can be found in the LICENSE file.
 // All code found in this file is licensed under MIT and can be found in the LICENSE file.
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4111,51 +4111,49 @@ void Game::combatGetTypeInfo(const CombatType_t combatType, const CreaturePtr& t
 
 bool Game::combatChangeHealth(const CreaturePtr& attacker, const CreaturePtr& target, CombatDamage& damage)
 {
-	// Get the position of the target for later use in displaying messages and effects
+	// Target should always exist when calling this function, otherwise its pretty pointless..
+
+	// we can say true and do nothing with 0 damage, but maybe it should be false.. need to investigate further, later.
+	if (damage.primary.value == 0 and damage.secondary.value == 0) {
+		return true; 
+	}
+
+	const auto attackerPlayer = attacker and attacker->getPlayer() ? attacker->getPlayer() : nullptr;
+	auto targetPlayer = target and target->getPlayer() ? target->getPlayer() : nullptr;
+
+	// If the attacker is a player with a black skull and the target is not marked with a skull,
+	// the attack should not proceed.
+	if (attackerPlayer && targetPlayer && attackerPlayer->getSkull() == SKULL_BLACK && attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
+		return false;
+	}
+
+	// Early exit if the target is already dead
+	if (target->getHealth() <= 0) {
+		return false;
+	}
+
+	// Handle lua events immediately
+	if (const auto& events = target->getCreatureEvents(CREATURE_EVENT_HEALTHCHANGE); !events.empty()) {
+		for (const auto creatureEvent : events) {
+			creatureEvent->executeHealthChange(target, attacker, damage);
+		}
+	}
+
 	const Position& targetPos = target->getPosition();
 
 	// If the damage value is positive (indicating healing or positive health change)
 	if (damage.primary.value > 0) {
-		// Early exit if the target is already dead
-		if (target->getHealth() <= 0) {
-			return false;
-		}
-
-		// Determine if the attacker is a player, if not, set to nullptr
-		PlayerPtr attackerPlayer;
-		if (attacker) {
-			attackerPlayer = attacker->getPlayer();
-		} else {
-			attackerPlayer = nullptr;
-		}
-
-		// Check if the target is a player
-		auto targetPlayer = target->getPlayer();
-
-		// If the attacker is a player with a black skull and the target is not marked with a skull,
-		// the attack should not proceed.
-		if (attackerPlayer && targetPlayer && attackerPlayer->getSkull() == SKULL_BLACK && attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
-			return false;
-		}
-
-		// Handle health change events in a single pass
-		const auto& events = target->getCreatureEvents(CREATURE_EVENT_HEALTHCHANGE);
-		if (!events.empty()) {
-			for (const auto creatureEvent : events) {
-				creatureEvent->executeHealthChange(target, attacker, damage);
-			}
-		}
-
-		// Calculate the actual health change and apply it to the target
+		
 		int32_t realHealthChange = target->getHealth();
 		target->gainHealth(attacker, damage.primary.value);
 		realHealthChange = target->getHealth() - realHealthChange;
 		
 		// rewardboss healing contribution
-		if (target && target->getPlayer()) {
+		if (targetPlayer) {
 			for (const auto& monsterId : g_game.rewardBossTracking | std::views::keys) {
 				if (const auto monster = getMonsterByID(monsterId); monster && monster->isRewardBoss()) {
 					const Position& monsterPos = monster->getPosition();
+					// what da fuq is this formula for determining range eligibility?
 					if (double distBetweenTargetAndBoss = std::sqrt(std::pow(targetPos.x - monsterPos.x, 2) + std::pow(targetPos.y - monsterPos.y, 2)); distBetweenTargetAndBoss < 7) {
 						uint32_t playerGuid = target->getPlayer()->getGUID();
 						rewardBossTracking[monsterId].playerScoreTable[playerGuid].damageTaken += realHealthChange * g_config.getFloat(ConfigManager::REWARD_RATE_HEALING_DONE);
@@ -4220,20 +4218,7 @@ bool Game::combatChangeHealth(const CreaturePtr& attacker, const CreaturePtr& ta
 			if (!target->isInGhostMode()) {
 				addMagicEffect(targetPos, CONST_ME_POFF);
 			}
-			return true;
-		}
-
-		// Similar logic for attacker and target player checks as before
-		PlayerPtr attackerPlayer;
-		if (attacker) {
-			attackerPlayer = attacker->getPlayer();
-		} else {
-			attackerPlayer = nullptr;
-		}
-
-		const auto targetPlayer = target->getPlayer();
-		if (attackerPlayer && targetPlayer && attackerPlayer->getSkull() == SKULL_BLACK && attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
-			return false;
+			return true; // should we return true here? We could be wasting attacks... perhaps we make it a config?
 		}
 
 		// Convert the damage values to positive for health reduction
@@ -4252,7 +4237,7 @@ bool Game::combatChangeHealth(const CreaturePtr& attacker, const CreaturePtr& ta
 		SpectatorVec spectators;
 
 		// Check if the target has a mana shield, which can absorb some or all of the damage
-		if (targetPlayer && target->hasCondition(CONDITION_MANASHIELD) && damage.primary.type != COMBAT_UNDEFINEDDAMAGE) {
+		if (targetPlayer && targetPlayer->hasCondition(CONDITION_MANASHIELD) && damage.primary.type != COMBAT_UNDEFINEDDAMAGE) {
 			if (int32_t manaDamage = std::min<int32_t>(targetPlayer->getMana(), healthChange); manaDamage != 0) {
 				if (const auto& events = target->getCreatureEvents(CREATURE_EVENT_MANACHANGE); !events.empty()) {
 					for (const auto creatureEvent : events) {
@@ -4327,13 +4312,6 @@ bool Game::combatChangeHealth(const CreaturePtr& attacker, const CreaturePtr& ta
 		int32_t realDamage = damage.primary.value + damage.secondary.value;
 		if (realDamage == 0) {
 			return true;
-		}
-
-		// Try single pass again here
-		if (const auto& events = target->getCreatureEvents(CREATURE_EVENT_HEALTHCHANGE); !events.empty()) {
-			for (const auto creatureEvent : events) {
-				creatureEvent->executeHealthChange(target, attacker, damage);
-			}
 		}
 
 		// Cap the primary damage at the target's current health
@@ -4415,7 +4393,7 @@ bool Game::combatChangeHealth(const CreaturePtr& attacker, const CreaturePtr& ta
 				tmpPlayer->sendTextMessage(message);
 			}
 		}
-// rewardboss player attacking boss
+		// rewardboss player attacking boss
 		if (target && target->getMonster() && target->getMonster()->isRewardBoss()) {
 			uint32_t monsterId = target->getMonster()->getID();
 
@@ -4423,8 +4401,8 @@ bool Game::combatChangeHealth(const CreaturePtr& attacker, const CreaturePtr& ta
 				rewardBossTracking[monsterId] = RewardBossContributionInfo();
 			}
 
-			if (attacker && attacker->getPlayer()) {
-				uint32_t playerGuid = attacker->getPlayer()->getGUID();
+			if (attackerPlayer) {
+				uint32_t playerGuid = attackerPlayer->getGUID();
 				rewardBossTracking[monsterId].playerScoreTable[playerGuid].damageDone += realDamage * g_config.getFloat(ConfigManager::REWARD_RATE_DAMAGE_DONE);
 			}
 		}

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4121,13 +4121,11 @@ bool Game::combatChangeHealth(const CreaturePtr& attacker, const CreaturePtr& ta
 	const auto attackerPlayer = attacker and attacker->getPlayer() ? attacker->getPlayer() : nullptr;
 	auto targetPlayer = target and target->getPlayer() ? target->getPlayer() : nullptr;
 
-	// If the attacker is a player with a black skull and the target is not marked with a skull,
-	// the attack should not proceed.
 	if (attackerPlayer && targetPlayer && attackerPlayer->getSkull() == SKULL_BLACK && attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
 		return false;
 	}
 
-	// Early exit if the target is already dead
+	// Early exit incase the target is already dead
 	if (target->getHealth() <= 0) {
 		return false;
 	}

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -801,7 +801,10 @@ void Spell::postCastSpell(const PlayerPtr& player, uint32_t manaCost, uint32_t s
 {
 	if (manaCost > 0) {
 		player->addManaSpent(manaCost);
-		player->changeMana(-static_cast<int32_t>(manaCost));
+		CombatDamage manacost;
+		manacost.primary.type = COMBAT_MANADRAIN; // not sure about this, maybe it should be none?
+		manacost.primary.value = -static_cast<int32_t>(manaCost);
+		g_game.combatChangeMana(nullptr, player, manacost);
 	}
 
 	if (!player->hasFlag(PlayerFlag_HasInfiniteSoul)) {


### PR DESCRIPTION
This PR includes the elimination of the recursive calls to the game combat change methods. This PR also includes the missing support for those methods being triggered properly in the event of spell casting (for mana change) and the regeneration condition (such as when eating food) for both mana change and health change events. 