### PR TITLE
Fix rotate (doubled call)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2469,7 +2469,6 @@ void Game::playerRotateItem(const uint32_t playerId, const Position& pos, const 
 	}
 
 	if (const uint16_t newId = Item::items[item->getID()].rotateTo; newId != 0) {
-		transformItem(item, newId);
 		g_events->eventPlayerOnRotateItem(player, item);
 	}
 }


### PR DESCRIPTION
The transform on rotating was called 2 times - once in source, another one in default callback in lua - default_onRotateItem.lua

Fixes #105 