### PR TITLE
Change default showAttributes: false -> true

### DIFF
--- a/src/items.h
+++ b/src/items.h
@@ -371,7 +371,7 @@ class ItemType
 		bool allowPickupable = false;
 		bool showDuration = false;
 		bool showCharges = false;
-		bool showAttributes = false;
+		bool showAttributes = true;
 		bool replaceable = true;
 		bool pickupable = false;
 		bool rotatable = false;


### PR DESCRIPTION
Change default value of showAttributes from false to true.

User can explicitly set false on items he wants to be mysterious, but otherwise all attributes should be shown in all cases, not just when armor != 0.