### PR TITLE
Add base stats and starting level to account manager

### DIFF
--- a/config/account_manager.toml
+++ b/config/account_manager.toml
@@ -1,14 +1,22 @@
 [Citizen]
+startingLevel = 10
+baseHealth = 150
+baseMana = 0
+baseCapacity = 400
 premium = false
-vocation = 5
+vocation = 0
 sex = "male"
 towns = [1, 2, 3]
 outfit = {id = 128, head = 1, body = 1, legs = 1, feet = 1, mount = 0}
 skills = {fist = 1, sword = 1, axe = 1, club = 1, shield = 1, fishing = 1}
 
 [Resident]
+startingLevel = 1
+baseHealth = 150
+baseMana = 0
+baseCapacity = 400
 premium = false
-vocation = 5
+vocation = 0
 sex = "female"
 towns = [1, 2, 3]
 outfit = {id = 136, head = 1, body = 1, legs = 1, feet = 1, mount = 0}

--- a/src/accountmanager.cpp
+++ b/src/accountmanager.cpp
@@ -21,8 +21,10 @@ void AccountManager::initialize()
 
 			CharacterOption option;
 			toml::table option_data = *entry.as_table();
-
 			option.vocation = option_data["vocation"].value_or(0);
+			option.baseHealth = option_data["baseHealth"].value_or(150);
+			option.baseMana = option_data["baseMana"].value_or(0);
+			option.baseCapacity = option_data["baseCapacity"].value_or(400);
 			std::string sex = option_data["sex"].value_or("male");
 
 			if (sex == "male") 
@@ -34,7 +36,7 @@ void AccountManager::initialize()
 				option.sex = false;
 			}
 
-
+			option.level = option_data["startingLevel"].value_or(1);
 			option.premium = option_data["premium"].value_or(false);
 
 			if (const auto& towns = option_data["towns"].as_array()) 

--- a/src/accountmanager.h
+++ b/src/accountmanager.h
@@ -15,6 +15,10 @@ struct CharacterOption {
     std::string name = "";
     int32_t vocation = 0;
     bool sex = false;
+    uint32_t level;
+    uint32_t baseHealth;
+    uint32_t baseMana;
+    uint32_t baseCapacity;
     bool premium = false;
     bool allowTowns = true;
     bool needsPosition = true;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4160,11 +4160,17 @@ void Game::onPrivateAccountManagerRecieveText(const uint32_t player_id, uint32_t
 			const auto& config = character_options[player->getTempCharacterChoice()];
 			const auto& vocation = g_vocations.getVocation(config.vocation);
 			const auto& startingPos = player->getTempPosition();
-			auto sex = config.sex ? 1 : 0;
+			const auto sex = config.sex ? 1 : 0;
+			const auto level = config.level;
+			const auto health = config.baseHealth + vocation->getHPGain() * (level - 1);
+			const auto healthmax = health;
+			const auto mana = config.baseMana + vocation->getManaGain() * (level - 1);
+			const auto manamax = mana;
+			const auto cap = config.baseCapacity + (vocation->getCapGain() / 100) * (level - 1);
 
 			std::string query = fmt::format(fmt::runtime(
 				"INSERT INTO `players` ("
-				"`account_id`, `name`, `vocation`, `maglevel`, `sex`, "
+								"`account_id`, `name`, `vocation`, `health`, `healthmax`, `maglevel`, `mana`, `manamax`, `cap`, `sex`, `level`,"
 				"`skill_fist`,`skill_fist_tries`,"
 				"`skill_club`,`skill_club_tries`,"
 				"`skill_sword`,`skill_sword_tries`,"
@@ -4174,7 +4180,7 @@ void Game::onPrivateAccountManagerRecieveText(const uint32_t player_id, uint32_t
 				"`skill_fishing`,`skill_fishing_tries`,"
 				"`town_id`,`posx`,`posy`,`posz`"
 				") VALUES ("
-				"{:d}, {:s}, {:d}, {:d}, {:d},"
+				"{:d}, {:s}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d}, {:d},"
 				"{:d}, {:d}, "
 				"{:d}, {:d}, "
 				"{:d}, {:d}, "
@@ -4187,8 +4193,10 @@ void Game::onPrivateAccountManagerRecieveText(const uint32_t player_id, uint32_t
 				player->getAccount(),
 				db.escapeString(text),
 				config.vocation,
+				health, healthmax,
 				config.magiclevel,
-				sex,
+				mana, manamax,
+				cap, sex, level,
 				config.skills[SKILL_FIST], vocation->getReqSkillTries(SKILL_FIST, config.skills[SKILL_FIST]),
 				config.skills[SKILL_CLUB], vocation->getReqSkillTries(SKILL_CLUB, config.skills[SKILL_CLUB]),
 				config.skills[SKILL_SWORD], vocation->getReqSkillTries(SKILL_SWORD, config.skills[SKILL_SWORD]),


### PR DESCRIPTION
Introduces baseHealth, baseMana, baseCapacity, and startingLevel to account manager config.
Defaults are an example of a proper setup for a level 1 "no vocation".