### PR TITLE
Fix character name validation for account manager

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4150,7 +4150,7 @@ void Game::onPrivateAccountManagerRecieveText(const uint32_t player_id, uint32_t
 				if (!std::isalnum(static_cast<unsigned char>(ch)) && ch != ' ') {
 					// invalid name, contains symbols
 					player->sendModalWindow(CreatePrivateAccountManagerWindow(AccountManager::PRIVATE_CHARACTER_FAILED));
-					break;
+					return;
 				}
 			}
 


### PR DESCRIPTION
change name validation to use 'return' instead of 'break' to ensure invalid names do not continue to get processed by the account manager

Fix #146 
