### PR TITLE
Prevent spellcasting from causing infight and GM poofing effect

### DIFF
--- a/config/stages.toml
+++ b/config/stages.toml
@@ -1,5 +1,5 @@
 [config]
-enabled = 0
+enabled = false
 
 [[stage]]
 minlevel = 1

--- a/src/enums.h
+++ b/src/enums.h
@@ -610,6 +610,7 @@ struct CombatDamage
 	bool critical = false;
 	bool leeched = false;
 	bool augmented = false; // we can use this to help with refactoring combat logic later, by giving more config options to end users for how augmented damage interacts with augments
+	bool isSpellCost = false;
 	CombatDamage(
 		CombatType_t type = COMBAT_NONE,
 		CombatOrigin origin = ORIGIN_NONE,
@@ -617,7 +618,8 @@ struct CombatDamage
 		int32_t value = 0,
 		bool crit = false,
 		bool leech = false,
-		bool augment = false ) :
+		bool augment = false,
+		bool isSpellCost = false ) :
 		origin(origin),
 		primary{ type, value },
 		critical(crit),

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5455,6 +5455,8 @@ bool Game::combatChangeMana(const CreaturePtr& attacker, const CreaturePtr& targ
 		return true;
 	}
 
+	const Position& targetPos = target->getPosition();
+
 	int32_t manaChange = damage.primary.value + damage.secondary.value;
 	if (manaChange > 0) {
 		if (attacker) {
@@ -5484,14 +5486,6 @@ bool Game::combatChangeMana(const CreaturePtr& attacker, const CreaturePtr& targ
 		}
 	}
 	else {
-		const Position& targetPos = target->getPosition();
-		if (!target->isAttackable()) {
-			if (!target->isInGhostMode()) {
-				addMagicEffect(targetPos, CONST_ME_POFF);
-			}
-			return false;
-		}
-
 		PlayerPtr attackerPlayer;
 		if (attacker) {
 			attackerPlayer = attacker->getPlayer();
@@ -5500,19 +5494,33 @@ bool Game::combatChangeMana(const CreaturePtr& attacker, const CreaturePtr& targ
 			attackerPlayer = nullptr;
 		}
 
-		if (attackerPlayer && attackerPlayer->getSkull() == SKULL_BLACK && attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
-			return false;
-		}
-
 		int32_t manaLoss = std::min<int32_t>(targetPlayer->getMana(), -manaChange);
-		BlockType_t blockType = target->blockHit(attacker, COMBAT_MANADRAIN, manaLoss);
-		if (blockType != BLOCK_NONE) {
-			addMagicEffect(targetPos, CONST_ME_POFF);
-			return false;
-		}
 
-		if (manaLoss <= 0) {
-			return true;
+		if (damage.isSpellCost) {
+			if (!target->isAttackable()) {
+				return false;
+			}
+			targetPlayer->changeMana(-manaLoss);
+		}
+		else {
+			if (!target->isAttackable()) {
+				if (!target->isInGhostMode()) {
+					addMagicEffect(targetPos, CONST_ME_POFF);
+				}
+				return false;
+			}
+			if (attackerPlayer && attackerPlayer->getSkull() == SKULL_BLACK && attackerPlayer->getSkullClient(targetPlayer) == SKULL_NONE) {
+				return false;
+			}
+			BlockType_t blockType = target->blockHit(attacker, COMBAT_MANADRAIN, manaLoss);
+			if (blockType != BLOCK_NONE) {
+				addMagicEffect(targetPos, CONST_ME_POFF);
+				return false;
+			}
+			if (manaLoss <= 0) {
+				return true;
+			}
+			targetPlayer->drainMana(attacker, manaLoss);
 		}
 
 		const auto& events = target->getCreatureEvents(CREATURE_EVENT_MANACHANGE);
@@ -5521,8 +5529,6 @@ bool Game::combatChangeMana(const CreaturePtr& attacker, const CreaturePtr& targ
 				creatureEvent->executeManaChange(target, attacker, damage);
 			}
 		}
-
-		targetPlayer->drainMana(attacker, manaLoss);
 
 		const auto& targetNameDesc = target->getNameDescription();
 		const auto& attackerNameDesc = attacker ? attacker->getNameDescription() : "";

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -804,8 +804,9 @@ void Spell::postCastSpell(const PlayerPtr& player, uint32_t manaCost, uint32_t s
 	if (manaCost > 0) {
 		player->addManaSpent(manaCost);
 		CombatDamage manacost;
-		manacost.primary.type = COMBAT_MANADRAIN; // not sure about this, maybe it should be none?
+		manacost.primary.type = COMBAT_NONE;
 		manacost.primary.value = -static_cast<int32_t>(manaCost);
+		manacost.isSpellCost = true;
 		g_game.combatChangeMana(nullptr, player, manacost);
 	}
 


### PR DESCRIPTION
fix: prevent spellcasting from causing infight and GM poofing effects

- Changed manacost combat type to COMBAT_NONE to avoid interaction with manadrain protections and manadrain-specific combat logic.
- Added isSpellCost flag to CombatDamage struct.
- Bypassed combat related logic in combatChangeMana when isSpellCost is true.
- Replaced drainMana with changeMana for spell cost handling to prevent triggering combat related logic and thus infight.