### PR TITLE
remove early return in doCombat. fix #150

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -846,11 +846,6 @@ void Combat::doCombat(const CreaturePtr& caster, const Position& position) const
 {
 	const auto& p = params;
 
-	if (p.combatType == COMBAT_NONE && p.conditionList.empty() && p.dispelType == 0) 
-	{
-		return;
-	}
-
 	if (p.combatType != COMBAT_NONE) 
 	{
 		CombatDamage damage = getCombatDamage(caster, nullptr);


### PR DESCRIPTION
returning early was causing some spells to not execute properly, most notably magic fields without a combat damage type
after some discussion it was decided to remove the check entirely
finally fixes #150  