### PR TITLE
fix: clean up customAttrMap when empty after erase

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -522,8 +522,6 @@ class ItemAttributes
 					customAttrMap->erase(it);
 
 					if (customAttrMap->empty()) {
-						delete customAttrMap;
-						getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom = nullptr;
 						removeAttribute(ITEM_ATTRIBUTE_CUSTOM);
 					}
 					return true;

--- a/src/item.h
+++ b/src/item.h
@@ -520,6 +520,12 @@ class ItemAttributes
 				auto lowercaseKey = boost::algorithm::to_lower_copy(std::string{ key });
 				if (auto it = customAttrMap->find(lowercaseKey); it != customAttrMap->end()) {
 					customAttrMap->erase(it);
+
+					if (customAttrMap->empty()) {
+						delete customAttrMap;
+						getAttr(ITEM_ATTRIBUTE_CUSTOM).value.custom = nullptr;
+						removeAttribute(ITEM_ATTRIBUTE_CUSTOM);
+					}
 					return true;
 				}
 			}


### PR DESCRIPTION
After removing custom attribute, if the map of custom attributes is empty, we should remove it and not keep it in the memory, as it prevents item::equals method from properly comparing items.


https://github.com/user-attachments/assets/aa70a47a-262f-45f3-adf2-0f757d3b3b1b

**How to test**
Have 23 arrows.
Put custom attribute on 3 arrows
Pick 1 out of 3 arrows and remove the custom attribute from it.
Now that 1 arrow should stack with the 20 arrows, however that is not the case until relog.
