### PR TITLE
prevent regeneration condition from setting unwanted inFight

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -883,6 +883,7 @@ bool ConditionRegeneration::executeCondition(const CreaturePtr creature, int32_t
 		CombatDamage regen;
 		regen.primary.value = static_cast<int32_t>(healthGain);
 		regen.primary.type = COMBAT_HEALING;
+		regen.noInFight = isBuff;
 		g_game.combatChangeHealth(nullptr, creature, regen);
 	}
 
@@ -893,6 +894,7 @@ bool ConditionRegeneration::executeCondition(const CreaturePtr creature, int32_t
 			CombatDamage regen;
 			regen.primary.value = static_cast<int32_t>(manaGain);
 			regen.primary.type = COMBAT_HEALING;
+			regen.noInFight = isBuff;
 			g_game.combatChangeMana(nullptr, player, regen);
 		}
 	}

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -878,16 +878,15 @@ bool ConditionRegeneration::executeCondition(const CreaturePtr creature, int32_t
 		return ConditionGeneric::executeCondition(creature, interval);
 	}
 
-	if (internalHealthTicks >= healthTicks) {
+	if (internalHealthTicks >= healthTicks && healthGain != 0) {
 		internalHealthTicks = 0;
 		CombatDamage regen;
 		regen.primary.value = static_cast<int32_t>(healthGain);
 		regen.primary.type = COMBAT_HEALING;
-		regen.noInFight = isBuff;
 		g_game.combatChangeHealth(nullptr, creature, regen);
 	}
 
-	if (internalManaTicks >= manaTicks) {
+	if (internalManaTicks >= manaTicks && manaGain != 0) {
 		internalManaTicks = 0;
 
 		if (auto player = creature->getPlayer()) {

--- a/src/enums.h
+++ b/src/enums.h
@@ -610,7 +610,7 @@ struct CombatDamage
 	bool critical = false;
 	bool leeched = false;
 	bool augmented = false; // we can use this to help with refactoring combat logic later, by giving more config options to end users for how augmented damage interacts with augments
-	bool isSpellCost = false;
+	bool noInFight = false;
 	CombatDamage(
 		CombatType_t type = COMBAT_NONE,
 		CombatOrigin origin = ORIGIN_NONE,
@@ -619,7 +619,7 @@ struct CombatDamage
 		bool crit = false,
 		bool leech = false,
 		bool augment = false,
-		bool isSpellCost = false ) :
+		bool noInFight = false ) :
 		origin(origin),
 		primary{ type, value },
 		critical(crit),

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5500,9 +5500,6 @@ bool Game::combatChangeMana(const CreaturePtr& attacker, const CreaturePtr& targ
 			if (!target->isAttackable()) {
 				return false;
 			}
-			if (manaLoss == 0) {
-				return false;
-			}
 			targetPlayer->changeMana(-manaLoss);
 		}
 		else {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5496,8 +5496,11 @@ bool Game::combatChangeMana(const CreaturePtr& attacker, const CreaturePtr& targ
 
 		int32_t manaLoss = std::min<int32_t>(targetPlayer->getMana(), -manaChange);
 
-		if (damage.isSpellCost) {
+		if (damage.noInFight) {
 			if (!target->isAttackable()) {
+				return false;
+			}
+			if (manaLoss == 0) {
 				return false;
 			}
 			targetPlayer->changeMana(-manaLoss);

--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -806,7 +806,7 @@ void Spell::postCastSpell(const PlayerPtr& player, uint32_t manaCost, uint32_t s
 		CombatDamage manacost;
 		manacost.primary.type = COMBAT_NONE;
 		manacost.primary.value = -static_cast<int32_t>(manaCost);
-		manacost.isSpellCost = true;
+		manacost.noInFight = true;
 		g_game.combatChangeMana(nullptr, player, manacost);
 	}
 


### PR DESCRIPTION
regeneration conditions (e.g. "utura") were incorrectly causing players to remain in combat

rename isSpellCost flag for clarity

check if health/mana change is not 0 to prevent unnecessary calls which in some cases will be incorrectly setting inFight

added noInFight flag to mana change event, set by isBuff
by using isBuff we can safely assert the intent of the condition and not apply inFight when it's true, even for negative regen