### PR TITLE
Update gitignore - ignore filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **.sln
 **.vcxproj
 **.vcxproj.user
+**.vcxproj.filters
 
 # Build Output
 /build


### PR DESCRIPTION
Ignore Black-Tek-Server.vcxproj.filters, that is automatically generated by premake5.