### PR TITLE
Fix lua monster parsing and improve example script readability

### DIFF
--- a/data/monster/lua/#example.lua
+++ b/data/monster/lua/#example.lua
@@ -40,7 +40,7 @@ monster.voices = {
 	interval = 5000,
 	chance = 10,
 	{text = "I'm an example", yell = false},
-	{text = "You shall bow", yell = false}
+	{text = "You shall bow",  yell = false}
 }
 
 monster.loot = {
@@ -48,42 +48,131 @@ monster.loot = {
 	{id = 1987, chance = 60000, -- bag
 		child = {
 			{id = "platinum coin", chance = 60000, maxCount = 100},
-			{id = "crystal coin", chance = 60000, maxCount = 100}
+			{id = "crystal coin",  chance = 60000, maxCount = 100}
 		}
 	}
 }
 
 monster.attacks = {
 	{name = "melee", attack = 130, skill = 70, effect = CONST_ME_DRAWBLOOD, interval = 2*1000},
-	{name = "energy strike", range = 1, chance = 10, interval = 2*1000, minDamage = -210, maxDamage = -300, target = true},
-	{name = "combat", type = COMBAT_MANADRAIN, chance = 10, interval = 2*1000, minDamage = 0, maxDamage = -120, target = true, range = 7, effect = CONST_ME_MAGIC_BLUE},
-	{name = "combat", type = COMBAT_FIREDAMAGE, chance = 20, interval = 2*1000, minDamage = -150, maxDamage = -250, radius = 1, target = true, effect = CONST_ME_FIREAREA, shootEffect = CONST_ANI_FIRE},
-	{name = "speed", chance = 15, interval = 2*1000, speed = -700, radius = 1, target = true, duration = 30*1000, effect = CONST_ME_MAGIC_RED},
-	{name = "firefield", chance = 10, interval = 2*1000, range = 7, radius = 1, target = true, shootEffect = CONST_ANI_FIRE},
-	{name = "combat", type = COMBAT_LIFEDRAIN, chance = 10, interval = 2*1000, length = 8, spread = 0, minDamage = -300, maxDamage = -490, effect = CONST_ME_PURPLEENERGY}
+	{
+		name = "energy strike",
+		range = 1,
+		chance = 10,
+		interval = 2 * 1000,
+		minDamage = -210,
+		maxDamage = -300,
+		target = true
+	},
+	{
+		name = "combat",
+		type = COMBAT_MANADRAIN,
+		chance = 100,
+		interval = 2 * 1000,
+		minDamage = 0,
+		maxDamage = -10,
+		target = true,
+		range = 7,
+		condition = {type = CONDITION_CURSED, minDamage = 10, maxDamage = 20, duration = 5000, interval = 1000}
+	},
+	{
+		name = "combat",
+		type = COMBAT_FIREDAMAGE,
+		chance = 20,
+		interval = 2 * 1000,
+		minDamage = -150,
+		maxDamage = -250,
+		radius = 1,
+		target = true,
+		effect = CONST_ME_FIREAREA,
+		shootEffect = CONST_ANI_FIRE
+	},
+	{
+		name = "combat",
+		type = COMBAT_LIFEDRAIN,
+		chance = 10,
+		interval = 2 * 1000,
+		length = 8,
+		spread = 0,
+		minDamage = -300,
+		maxDamage = -490,
+		effect = CONST_ME_PURPLEENERGY
+	},
+	{
+		name = "speed",
+		chance = 15,
+		interval = 2 * 1000,
+		speed = -700,
+		radius = 1,
+		target = true,
+		duration = 30 * 1000,
+		effect = CONST_ME_MAGIC_RED
+	},
+	{
+		name = "firefield",
+		chance = 10,
+		interval = 2 * 1000,
+		range = 7,
+		radius = 1,
+		target = true,
+		shootEffect = CONST_ANI_FIRE
+	},
+	{
+		name = "condition",
+		chance = 100,
+		range = 1,
+		condition = {type = CONDITION_ENERGY, minDamage = 10, maxDamage = 20, duration = 5000, interval = 1000}
+	},
+	{
+		name = "drunk",
+		chance = 10,
+		interval = 2000,
+		drunkenness = 25,
+		duration = 5000,
+		range = 7,
+		shootEffect = CONST_ANI_ENERGY
+	},
+	{
+		name = "outfit",
+		chance = 10,
+		interval = 2000,
+		item = 7172,
+		duration = 8000,
+		range = 7,
+		effect = CONST_ME_MAGIC_BLUE
+	}
 }
 
 monster.defenses = {
 	defense = 55,
 	armor = 55,
-	{name = "combat", type = COMBAT_HEALING, chance = 15, interval = 2*1000, minDamage = 180, maxDamage = 250, effect = CONST_ME_MAGIC_BLUE},
-	{name = "speed", chance = 15, interval = 2*1000, speed = 320, effect = CONST_ME_MAGIC_RED}
+	{
+		name = "combat",
+		type = COMBAT_HEALING,
+		chance = 15,
+		interval = 2 * 1000,
+		minDamage = 180,
+		maxDamage = 250,
+		effect = CONST_ME_MAGIC_BLUE
+	},
+	{name = "speed",     chance = 15, interval = 2*1000,   speed = 320,     effect = CONST_ME_MAGIC_RED},
+	{name = "invisible", chance = 15, interval = 2000,     duration = 3000, effect = CONST_ME_MAGIC_BLUE}
 }
 
 monster.elements = {
 	{type = COMBAT_PHYSICALDAMAGE, percent = 30},
-	{type = COMBAT_DEATHDAMAGE, percent = 30},
-	{type = COMBAT_ENERGYDAMAGE, percent = 50},
-	{type = COMBAT_EARTHDAMAGE, percent = 40},
-	{type = COMBAT_ICEDAMAGE, percent = -10},
-	{type = COMBAT_HOLYDAMAGE, percent = -10}
+	{type = COMBAT_DEATHDAMAGE,    percent = 30},
+	{type = COMBAT_ENERGYDAMAGE,   percent = 50},
+	{type = COMBAT_EARTHDAMAGE,    percent = 40},
+	{type = COMBAT_ICEDAMAGE,      percent = -10},
+	{type = COMBAT_HOLYDAMAGE,     percent = -10}
 }
 
 monster.immunities = {
-	{type = "fire", combat = true, condition = true},
-	{type = "drown", condition = true},
+	{type = "fire",      combat = true,   condition = true},
+	{type = "drown",     condition = true},
 	{type = "lifedrain", combat = true},
-	{type = "paralyze", condition = true},
+	{type = "paralyze",  condition = true},
 	{type = "invisible", condition = true}
 }
 

--- a/data/scripts/lib/register_monster_type.lua
+++ b/data/scripts/lib/register_monster_type.lua
@@ -1,87 +1,87 @@
 registerMonsterType = {}
 setmetatable(registerMonsterType,
-{
-	__call =
-	function(self, mtype, mask)
-		for _,parse in pairs(self) do
-			parse(mtype, mask)
-		end
-	end
-})
+	{
+		__call =
+			function(self, mtype, mask)
+				for _, parse in pairs(self) do
+					parse(mtype, mask)
+				end
+			end
+	})
 
 MonsterType.register = function(self, mask)
 	return registerMonsterType(self, mask)
 end
 
 registerMonsterType.name = function(mtype, mask)
-	if mask.name ~= nil then
+	if mask.name then
 		mtype:name(mask.name)
 	end
 end
 registerMonsterType.description = function(mtype, mask)
-	if mask.description ~= nil then
+	if mask.description then
 		mtype:nameDescription(mask.description)
 	end
 end
 registerMonsterType.experience = function(mtype, mask)
-	if mask.experience ~= nil then
+	if mask.experience then
 		mtype:experience(mask.experience)
 	end
 end
 registerMonsterType.skull = function(mtype, mask)
-	if mask.skull ~= nil then
+	if mask.skull then
 		mtype:skull(mask.skull)
 	end
 end
 registerMonsterType.outfit = function(mtype, mask)
-	if mask.outfit ~= nil then
+	if mask.outfit then
 		mtype:outfit(mask.outfit)
 	end
 end
 registerMonsterType.maxHealth = function(mtype, mask)
-	if mask.maxHealth ~= nil then
+	if mask.maxHealth then
 		mtype:maxHealth(mask.maxHealth)
 		mtype:health(math.min(mtype:health(), mask.maxHealth))
 	end
 end
 registerMonsterType.health = function(mtype, mask)
-	if mask.health ~= nil then
+	if mask.health then
 		mtype:health(mask.health)
 		mtype:maxHealth(math.max(mask.health, mtype:maxHealth()))
 	end
 end
 registerMonsterType.runHealth = function(mtype, mask)
-	if mask.runHealth ~= nil then
+	if mask.runHealth then
 		mtype:runHealth(mask.runHealth)
 	end
 end
 registerMonsterType.maxSummons = function(mtype, mask)
-	if mask.maxSummons ~= nil then
+	if mask.maxSummons then
 		mtype:maxSummons(mask.maxSummons)
 	end
 end
 registerMonsterType.race = function(mtype, mask)
-	if mask.race ~= nil then
+	if mask.race then
 		mtype:race(mask.race)
 	end
 end
 registerMonsterType.manaCost = function(mtype, mask)
-	if mask.manaCost ~= nil then
+	if mask.manaCost then
 		mtype:manaCost(mask.manaCost)
 	end
 end
 registerMonsterType.speed = function(mtype, mask)
-	if mask.speed ~= nil then
+	if mask.speed then
 		mtype:baseSpeed(mask.speed)
 	end
 end
 registerMonsterType.corpse = function(mtype, mask)
-	if mask.corpse ~= nil then
+	if mask.corpse then
 		mtype:corpseId(mask.corpse)
 	end
 end
 registerMonsterType.flags = function(mtype, mask)
-	if mask.flags ~= nil then
+	if mask.flags then
 		if mask.flags.attackable ~= nil then
 			mtype:isAttackable(mask.flags.attackable)
 		end
@@ -120,13 +120,13 @@ registerMonsterType.flags = function(mtype, mask)
 		end
 		-- if a monster can push creatures,
 		-- it should not be pushable
-		if mask.flags.canPushCreatures ~= nil then
+		if mask.flags.canPushCreatures then
 			mtype:isPushable(false)
 		end
-		if mask.flags.targetDistance ~= nil then
+		if mask.flags.targetDistance then
 			mtype:targetDistance(mask.flags.targetDistance)
 		end
-		if mask.flags.staticAttackChance ~= nil then
+		if mask.flags.staticAttackChance then
 			mtype:staticAttackChance(mask.flags.staticAttackChance)
 		end
 		if mask.flags.canWalkOnEnergy ~= nil then
@@ -141,16 +141,16 @@ registerMonsterType.flags = function(mtype, mask)
 	end
 end
 registerMonsterType.light = function(mtype, mask)
-	if mask.light ~= nil then
+	if mask.light then
 		mtype:light(mask.light.color or 0, mask.light.level or 0)
 	end
 end
 registerMonsterType.changeTarget = function(mtype, mask)
-	if mask.changeTarget ~= nil then
+	if mask.changeTarget then
 		if mask.changeTarget.chance then
 			mtype:changeTargetChance(mask.changeTarget.chance)
 		end
-		if mask.changeTarget.interval ~= nil then
+		if mask.changeTarget.interval then
 			mtype:changeTargetSpeed(mask.changeTarget.interval)
 		end
 	end
@@ -158,10 +158,10 @@ end
 registerMonsterType.voices = function(mtype, mask)
 	if type(mask.voices) == "table" then
 		local interval, chance
-		if mask.voices.interval ~= nil then
+		if mask.voices.interval then
 			interval = mask.voices.interval
 		end
-		if mask.voices.chance ~= nil then
+		if mask.voices.chance then
 			chance = mask.voices.chance
 		end
 		for k, v in pairs(mask.voices) do
@@ -174,7 +174,8 @@ end
 registerMonsterType.summons = function(mtype, mask)
 	if type(mask.summons) == "table" then
 		for k, v in pairs(mask.summons) do
-			mtype:addSummon(v.name, v.interval, v.chance, v.max or -1, v.effect or CONST_ME_TELEPORT, v.masterEffect or CONST_ME_NONE)
+			mtype:addSummon(v.name, v.interval, v.chance, v.max or 0, v.effect or CONST_ME_TELEPORT,
+				v.masterEffect or CONST_ME_NONE)
 		end
 	end
 end
@@ -202,8 +203,11 @@ registerMonsterType.loot = function(mtype, mask)
 			if loot.aid or loot.actionId then
 				parent:setActionId(loot.aid or loot.actionId)
 			end
+			local charges = loot.charges or ItemType(loot.id):getCharges()
 			if loot.subType or loot.charges then
-				parent:setSubType(loot.subType or loot.charges)
+				parent:setSubType(loot.subType or charges)
+			else
+				parent:setSubType(charges)
 			end
 			if loot.text or loot.description then
 				parent:setDescription(loot.text or loot.description)
@@ -223,8 +227,11 @@ registerMonsterType.loot = function(mtype, mask)
 					if children.aid or children.actionId then
 						child:setActionId(children.aid or children.actionId)
 					end
+					local charges = children.charges or ItemType(children.id):getCharges()
 					if children.subType or children.charges then
-						child:setSubType(children.subType or children.charges)
+						child:setSubType(children.subType or charges)
+					else
+						child:setSubType(charges)
 					end
 					if children.text or children.description then
 						child:setDescription(children.text or children.description)
@@ -235,7 +242,7 @@ registerMonsterType.loot = function(mtype, mask)
 			mtype:addLoot(parent)
 		end
 		if lootError then
-			print("[Warning - end] Monster: \"".. mtype:name() .. "\" loot could not correctly be load.")
+			print("[Warning - end] Monster: \"" .. mtype:name() .. "\" loot could not correctly be load.")
 		end
 	end
 end
@@ -260,257 +267,138 @@ registerMonsterType.immunities = function(mtype, mask)
 		end
 	end
 end
+local function AbilityTableToSpell(ability)
+	local spell = MonsterSpell()
+	if ability.name then
+		if ability.name == "melee" then
+			spell:setType("melee")
+			if ability.attack and ability.skill then
+				spell:setAttackValue(ability.attack, ability.skill)
+			end
+			if ability.minDamage and ability.maxDamage then
+				spell:setCombatValue(ability.minDamage, ability.maxDamage)
+			end
+			if ability.interval then
+				spell:setInterval(ability.interval)
+			end
+			if ability.effect then
+				spell:setCombatEffect(ability.effect)
+			end
+		else
+			spell:setType(ability.name)
+			if ability.type then
+				spell:setCombatType(ability.type)
+			end
+			if ability.interval then
+				spell:setInterval(ability.interval)
+			end
+			if ability.chance then
+				spell:setChance(ability.chance)
+			end
+			if ability.range then
+				spell:setRange(ability.range)
+			end
+			if ability.duration then
+				spell:setConditionDuration(ability.duration)
+			end
+			if ability.speed then
+				if type(ability.speed) ~= "table" then
+					spell:setConditionSpeedChange(ability.speed)
+				elseif type(ability.speed) == "table" then
+					if ability.speed.min and ability.speed.max then
+						spell:setConditionSpeedChange(ability.speed.min, ability.speed.max)
+					end
+				end
+			end
+			if ability.target then
+				spell:setNeedTarget(ability.target)
+			end
+			if ability.length then
+				spell:setCombatLength(ability.length)
+			end
+			if ability.spread then
+				spell:setCombatSpread(ability.spread)
+			end
+			if ability.radius then
+				spell:setCombatRadius(ability.radius)
+			end
+			if ability.ring then
+				spell:setCombatRing(ability.ring)
+			end
+			if ability.minDamage and ability.maxDamage then
+				spell:setCombatValue(ability.minDamage, ability.maxDamage)
+			end
+			if ability.effect then
+				spell:setCombatEffect(ability.effect)
+			end
+			if ability.shootEffect then
+				spell:setCombatShootEffect(ability.shootEffect)
+			end
+			local outfit = ability.outfit or ability.monster or ability.item
+			if outfit then
+				spell:setOutfit(outfit)
+			end
+			if ability.drunkenness then
+				spell:setConditionDrunkenness(ability.drunkenness)
+			end
+		end
+		if ability.condition then
+			if ability.condition.type then
+				spell:setConditionType(ability.condition.type)
+			end
+			local startDamage = 0
+			if ability.condition.startDamage then
+				startDamage = ability.condition.startDamage
+			end
+			if ability.condition.minDamage and ability.condition.maxDamage then
+				spell:setConditionDamage(ability.condition.minDamage, ability.condition.maxDamage, startDamage)
+			end
+			if ability.condition.duration then
+				spell:setConditionDuration(ability.condition.duration)
+			end
+			if ability.condition.interval then
+				spell:setConditionTickInterval(ability.condition.interval)
+			end
+		end
+	elseif ability.script then
+		spell:setScriptName(ability.script)
+		if ability.interval then
+			spell:setInterval(ability.interval)
+		end
+		if ability.chance then
+			spell:setChance(ability.chance)
+		end
+		if ability.minDamage and ability.maxDamage then
+			spell:setCombatValue(ability.minDamage, ability.maxDamage)
+		end
+		if ability.target then
+			spell:setNeedTarget(ability.target)
+		end
+		if ability.direction then
+			spell:setNeedDirection(ability.direction)
+		end
+	end
+	return spell
+end
 registerMonsterType.attacks = function(mtype, mask)
 	if type(mask.attacks) == "table" then
 		for _, attack in pairs(mask.attacks) do
-			local spell = MonsterSpell()
-			if attack.name then
-				if attack.name == "melee" then
-					spell:setType("melee")
-					if attack.attack and attack.skill then
-						spell:setAttackValue(attack.attack, attack.skill)
-					end
-					if attack.minDamage and attack.maxDamage then
-						spell:setCombatValue(attack.minDamage, attack.maxDamage)
-					end
-					if attack.interval then
-						spell:setInterval(attack.interval)
-					end
-					if attack.effect then
-						spell:setCombatEffect(attack.effect)
-					end
-					if attack.condition then
-						if attack.condition.type then
-							spell:setConditionType(attack.condition.type)
-						end
-						local startDamage = 0
-						if attack.condition.startDamage then
-							startDamage = attack.condition.startDamage
-						end
-						if attack.condition.minDamage and attack.condition.maxDamage then
-							spell:setConditionDamage(attack.condition.minDamage, attack.condition.maxDamage, startDamage)
-						end
-						if attack.condition.duration then
-							spell:setConditionDuration(attack.condition.duration)
-						end
-						if attack.condition.interval then
-							spell:setConditionTickInterval(attack.condition.interval)
-						end
-					end
-				else
-					spell:setType(attack.name)
-					if attack.type then
-						if attack.name == "combat" then
-							spell:setCombatType(attack.type)
-						else
-							spell:setConditionType(attack.type)
-						end
-					end
-					if attack.interval then
-						spell:setInterval(attack.interval)
-					end
-					if attack.chance then
-						spell:setChance(attack.chance)
-					end
-					if attack.range then
-						spell:setRange(attack.range)
-					end
-					if attack.duration then
-						spell:setConditionDuration(attack.duration)
-					end
-					if attack.speed then
-						if type(attack.speed) ~= "table" then
-							spell:setConditionSpeedChange(attack.speed)
-						elseif type(attack.speed) == "table" then
-							if attack.speed.min and attack.speed.max then
-								spell:setConditionSpeedChange(attack.speed.min, attack.speed.max)
-							end
-						end
-					end
-					if attack.target then
-						spell:setNeedTarget(attack.target)
-					end
-					if attack.length then
-						spell:setCombatLength(attack.length)
-					end
-					if attack.spread then
-						spell:setCombatSpread(attack.spread)
-					end
-					if attack.radius then
-						spell:setCombatRadius(attack.radius)
-					end
-					if attack.minDamage and attack.maxDamage then
-						if attack.name == "combat" then
-							spell:setCombatValue(attack.minDamage, attack.maxDamage)
-						else
-							local startDamage = 0
-							if attack.startDamage then
-								startDamage = attack.startDamage
-							end
-							spell:setConditionDamage(attack.minDamage, attack.maxDamage, startDamage)
-						end
-					end
-					if attack.effect then
-						spell:setCombatEffect(attack.effect)
-					end
-					if attack.shootEffect then
-						spell:setCombatShootEffect(attack.shootEffect)
-					end
-					local outfit = ability.outfit or ability.monster or ability.item
-					if outfit then
-						spell:setOutfit(outfit)
-					end
-					if attack.name == "drunk" then
-						spell:setConditionType(CONDITION_DRUNK)
-						if attack.drunkenness then
-							spell:setConditionDrunkenness(attack.drunkenness)
-						end
-					end
-				end
-			elseif attack.script then
-				spell:setScriptName(attack.script)
-				if attack.interval then
-					spell:setInterval(attack.interval)
-				end
-				if attack.chance then
-					spell:setChance(attack.chance)
-				end
-				if attack.minDamage and attack.maxDamage then
-					spell:setCombatValue(attack.minDamage, attack.maxDamage)
-				end
-				if attack.target then
-					spell:setNeedTarget(attack.target)
-				end
-				if attack.direction then
-					spell:setNeedDirection(attack.direction)
-				end
-			end
+			local spell = AbilityTableToSpell(attack)
 			mtype:addAttack(spell)
 		end
 	end
 end
 registerMonsterType.defenses = function(mtype, mask)
 	if type(mask.defenses) == "table" then
-		if mask.defenses.defense ~= nil then
+		if mask.defenses.defense then
 			mtype:defense(mask.defenses.defense)
 		end
-		if mask.defenses.armor ~= nil then
+		if mask.defenses.armor then
 			mtype:armor(mask.defenses.armor)
 		end
 		for _, defense in pairs(mask.defenses) do
 			if type(defense) == "table" then
-				local spell = MonsterSpell()
-				if defense.name then
-					if defense.name == "melee" then
-						spell:setType("melee")
-						if defense.attack and defense.skill then
-							spell:setAttackValue(defense.attack, defense.skill)
-						end
-						if defense.minDamage and defense.maxDamage then
-							spell:setCombatValue(defense.minDamage, defense.maxDamage)
-						end
-						if defense.interval then
-							spell:setInterval(defense.interval)
-						end
-						if defense.effect then
-							spell:setCombatEffect(defense.effect)
-						end
-						if defense.condition then
-							if defense.condition.type then
-								spell:setConditionType(defense.condition.type)
-							end
-							local startDamage = 0
-							if defense.condition.startDamage then
-								startDamage = defense.condition.startDamage
-							end
-							if defense.condition.minDamage and defense.condition.maxDamage then
-								spell:setConditionDamage(defense.condition.minDamage, defense.condition.maxDamage, startDamage)
-							end
-							if defense.condition.duration then
-								spell:setConditionDuration(defense.condition.duration)
-							end
-							if defense.condition.interval then
-								spell:setConditionTickInterval(defense.condition.interval)
-							end
-						end
-					else
-						spell:setType(defense.name)
-						if defense.type then
-							if defense.name == "combat" then
-								spell:setCombatType(defense.type)
-							else
-								spell:setConditionType(defense.type)
-							end
-						end
-						if defense.interval then
-							spell:setInterval(defense.interval)
-						end
-						if defense.chance then
-							spell:setChance(defense.chance)
-						end
-						if defense.range then
-							spell:setRange(defense.range)
-						end
-						if defense.duration then
-							spell:setConditionDuration(defense.duration)
-						end
-						if defense.speed then
-							if type(defense.speed) ~= "table" then
-								spell:setConditionSpeedChange(defense.speed)
-							elseif type(defense.speed) == "table" then
-								if defense.speed.min and defense.speed.max then
-									spell:setConditionSpeedChange(defense.speed.min, defense.speed.max)
-								end
-							end
-						end
-						if defense.target then
-							spell:setNeedTarget(defense.target)
-						end
-						if defense.length then
-							spell:setCombatLength(defense.length)
-						end
-						if defense.spread then
-							spell:setCombatSpread(defense.spread)
-						end
-						if defense.radius then
-							spell:setCombatRadius(defense.radius)
-						end
-						if defense.minDamage and defense.maxDamage then
-							if defense.name == "combat" then
-								spell:setCombatValue(defense.minDamage, defense.maxDamage)
-							else
-								local startDamage = 0
-								if defense.startDamage then
-									startDamage = defense.startDamage
-								end
-								spell:setConditionDamage(defense.minDamage, defense.maxDamage, startDamage)
-							end
-						end
-						if defense.effect then
-							spell:setCombatEffect(defense.effect)
-						end
-						if defense.shootEffect then
-							spell:setCombatShootEffect(defense.shootEffect)
-						end
-					end
-				elseif defense.script then
-					spell:setScriptName(defense.script)
-					if defense.interval then
-						spell:setInterval(defense.interval)
-					end
-					if defense.chance then
-						spell:setChance(defense.chance)
-					end
-					if defense.minDamage and defense.maxDamage then
-						spell:setCombatValue(defense.minDamage, defense.maxDamage)
-					end
-					if defense.target then
-						spell:setNeedTarget(defense.target)
-					end
-					if defense.direction then
-						spell:setNeedDirection(defense.direction)
-					end
-				end
+				local spell = AbilityTableToSpell(defense)
 				mtype:addDefense(spell)
 			end
 		end


### PR DESCRIPTION
Updated from TFS and adapted for BlackTek
[#example.lua](https://github.com/otland/forgottenserver/blob/d498855e773b6d9e77d310ae36f75c4c95ca3155/data/monster/lua/%23example.lua)
[register_monster_type.lua](https://github.com/otland/forgottenserver/blob/d498855e773b6d9e77d310ae36f75c4c95ca3155/data/scripts/lib/register_monster_type.lua)

Fixes:
Loot handling for charges/subtype
Ability parsing

Changes made for BlackTek:
Fix invalid chance in example script
Improved readability of example script
Removed bestiary code