### PR TITLE
Update summon_creature.lua

### DIFF
--- a/data/scripts/spells/support/summon_creature.lua
+++ b/data/scripts/spells/support/summon_creature.lua
@@ -29,7 +29,7 @@ function spell.onCastSpell(creature, variant)
 		end
 	end
 
-	local manaCost = monsterType:getManaCost()
+	local manaCost = monsterType:ManaCost()
 	if creature:getMana() < manaCost and not creature:hasFlag(PlayerFlag_HasInfiniteMana) then
 		creature:sendCancelMessage(RETURNVALUE_NOTENOUGHMANA)
 		creature:getPosition():sendMagicEffect(CONST_ME_POFF)


### PR DESCRIPTION
typo at manaCost function = monsterType:getManaCost()

Checking luascript cpp, show:

int LuaScriptInterface::luaMonsterTypeManaCost(lua_State* L) {
	// get: monsterType:manaCost() set: monsterType:manaCost(mana)
	MonsterType* monsterType = getUserdata<MonsterType>(L, 1);
	if (monsterType) {
		if (lua_gettop(L) == 1) {
			lua_pushinteger(L, monsterType->info.manaCost);
		} else {
			monsterType->info.manaCost = getNumber<uint32_t>(L, 2);
			pushBoolean(L, true);
		}
	} else {
		lua_pushnil(L);
	}
	return 1;
}

creature:getMana let you "get" Mana consume from monsterType, it's why you dont need type monsterType:getManaCost

The correct function it's
monsterType:manaCost()

So, using in spell:
local manaCost = monsterType:manaCost()
if creature:getMana() < manaCost

And manaCost pass to creature:getMana() (like idea behind getManaCost)

Examples tested

<img width="245" height="367" alt="imagen" src="https://github.com/user-attachments/assets/1b1d76e3-c946-4235-bc6a-8c565eddabdd" />

Spell it's working