### PR TITLE
Change COMBAT on lifesteal to fix lose HP using augment lifesteal

### DIFF
--- a/src/combat.cpp
+++ b/src/combat.cpp
@@ -1320,7 +1320,7 @@ void Combat::doTargetCombat(const CreaturePtr& caster, const CreaturePtr& target
 				}
 
 				if (lifeStealGain) {
-					auto lifeStealCombat = CombatDamage(COMBAT_LIFEDRAIN, ORIGIN_AUGMENT, BLOCK_NONE, lifeStealGain, damage.critical, true, true);
+					auto lifeStealCombat = CombatDamage(COMBAT_HEALING, ORIGIN_AUGMENT, BLOCK_NONE, lifeStealGain, damage.critical, true, true);
 					g_game.combatChangeHealth(target, caster, lifeStealCombat);
 				}
 


### PR DESCRIPTION
Actually for lifesteal, system use COMBAT_LIFEDRAIN, but this only discount HP (it's like ignore if you are using +- values compared to COMBAT_MANADRAIN that it's used in manasteal augment)

If you use COMBAT_LIFEDRAIN, you gonna lose HP

But if you use COMBAT_HEALING, you gonna restore HP in each augment event

Probably the only problem it's associated how you take HP from creatures (system show something like creatures are healing you; No make sense, because creatures dont cast heal spells on players).

You are healed by (.+) for (%d+) hitpoints% -> Structure message (.* creature name) (%d+ HP value) hitpoints%

You are healed by orc berserker for 110 hitpoints. -> how look this message

Need like his own message like reform/conversion to show how much HP gain based in how much dmg you deal using lifesteal augment). I bypassed this issue making a change in textmessage (OTClient side) to fix this:

<img width="1177" height="104" alt="imagen" src="https://github.com/user-attachments/assets/5b77a9f8-a4f0-4a14-9969-6171d3485542" />
