### PR TITLE
Missing lines in Spell::postCastSpell to fix mana consume

### DIFF
--- a/src/spells.cpp
+++ b/src/spells.cpp
@@ -591,9 +591,10 @@ void Spell::postCastSpell(const PlayerPtr& player, bool finishedCast /*= true*/,
 
 void Spell::postCastSpell(const PlayerPtr& player, uint32_t manaCost, uint32_t soulCost)
 {
-	if (manaCost > 0) {
-		player->addManaSpent(manaCost);
-	}
+    if (manaCost > 0 && !player->hasFlag(PlayerFlag_HasInfiniteMana)) {
+        player->addManaSpent(manaCost);
+        player->changeMana(-static_cast<int32_t>(manaCost));
+    }
 
 	if (!player->hasFlag(PlayerFlag_HasInfiniteSoul)) {
 		if (soulCost > 0) {


### PR DESCRIPTION
Last commit in mana spent was missing a line to consume mana and trigger changeMana (player cpp event)

added 2 lines

-> 1 line to check mana cost over 0 and HasInfinite flag -> 1 line to consume mana based in spell:mana

Base
<img width="172" height="45" alt="imagen" src="https://github.com/user-attachments/assets/40205150-3a78-4040-9fd9-287c58876b67" />

Test mana spell (100 mana points consume)
<img width="174" height="49" alt="imagen" src="https://github.com/user-attachments/assets/40a22661-d779-4f21-a2df-f5f64a0c89f7" />

So, now consume 100 mana
