### PR TITLE
feat: set player's id (cid) based on guid

### DIFF
--- a/src/player.h
+++ b/src/player.h
@@ -157,7 +157,8 @@ class Player final : public Creature, public Cylinder
 
 		void setID() override {
 			if (id == 0) {
-				id = playerAutoID++;
+				id = 0x10000000 + guid;
+				playerAutoID = std::max<uint32_t>(playerAutoID, id);
 			}
 		}
 

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -134,9 +134,9 @@ void ProtocolGame::login(uint32_t characterId, uint32_t accountId, OperatingSyst
 	const auto isAccountManager = characterId == AccountManager::ID and managerEnabled;
 	if (not foundPlayer or g_config.getBoolean(ConfigManager::ALLOW_CLONES) or isAccountManager) {
 		player = Player::makePlayer(getThis());
-		
-		player->setID();
+
 		player->setGUID(characterId);
+		player->setID(); // player's id is based on GUID
 
 		if (not IOLoginData::preloadPlayer(player)) {
 			disconnectClient("Your character could not be loaded.");


### PR DESCRIPTION
Makes it so player's id (cid) is predictable, by setting it based on gui.

Expected behaviour after:
- a player re-logging has consistent result returned from ``:getID()``

Test scenario:
- Login player1
- Check id
- Relog
- Check id (should be the same)
You can login player2, and do the same steps, to see that 2 different players won't be sharing the same id, it will be different.


Test talkactions:
talkactions.xml
```xml
<talkaction words="!test" separator=" " script="tests.lua" />
```
tests.lua
```lua
function onSay(player, words, param)
	-- if not player:getGroup():getAccess() then
	-- 	return true
	-- end

	-- Print player's id
	print("Guid: " .. player:getGuid() .. " Id: " .. player:getId())


	local position = player:getPosition()
	position:sendMagicEffect(CONST_ME_HITAREA)
	return false
end
```

credits: was done first by @SaiyansKing