### PR TITLE
fix: sendChannelMessage() incorrect amount of bytes sent

### DIFF
--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -1770,7 +1770,7 @@ void ProtocolGame::sendChannelMessage(const std::string& author, const std::stri
 {
 	NetworkMessage msg;
 	msg.add(ServerCode::CreatureSay);
-	msg.add<SpecialCode>(SpecialCode::Zero);
+	msg.add<uint32_t>(0); // statement guid (unused by clients)
 	msg.addString(author);
 	msg.add<SpecialCode>(SpecialCode::Zero);
 	msg.addByte(type);


### PR DESCRIPTION
In: ProtocolGame::sendChannelMessage(), https://github.com/Black-Tek/BlackTek-Server/commit/34025b150a21877162c3affb62e53e2dc003fc7a#diff-eb01d79b279ebf659ed73216c0b3c490685221c9358e058ce55a1c8ab4e99c35L1579-R1773
sending uint32_t has accidentally been swapped for uint16_t.

Before fix:
<img width="877" height="113" alt="image" src="https://github.com/user-attachments/assets/a12b7e7e-e6b7-44f3-ba9c-5df14224e140" />
After this fix:
<img width="352" height="112" alt="image" src="https://github.com/user-attachments/assets/8af5e523-6224-40e2-a414-399d23517dc0" />
(test code: ``player:sendChannelMessage("ELO", "hehesdzki", 7, 3)`` in any script, with open world chat)

Thanks @diavolo for detecting.